### PR TITLE
Fix of a bug in the SDI+ADI mode

### DIFF
--- a/vip/pca/pca_fullfr.py
+++ b/vip/pca/pca_fullfr.py
@@ -210,10 +210,10 @@ def pca(cube, angle_list=None, cube_ref=None, scale_list=None, ncomp=1, ncomp2=1
     if not cube.ndim>2:
         raise TypeError('Input array is not a 3d or 4d array')
     if angle_list is not None:
-        if not cube.shape[0] == angle_list.shape[0]:
-            msg = "Angle list vector has wrong length. It must equal the number"
-            msg += " frames in the cube."
-            raise TypeError(msg)
+    	if (cube.ndim==3 and not (cube.shape[0] == angle_list.shape[0])) or  (cube.ndim==4 and not (cube.shape[1] == angle_list.shape[0])):
+    		msg = "Angle list vector has wrong length. It must equal the number"
+        	msg += " frames in the cube."
+        	raise TypeError(msg)
     if source_xy is not None and delta_rot is None or fwhm is None:
         msg = 'Delta_rot or fwhm parameters missing. They are needed for the ' 
         msg += 'PA-based rejection of frames from the library'  


### PR DESCRIPTION
In SDI+ADI mode, the cube has 4 dimensions and one of the tests to validate the input parameters fails because it assumes that the first dimension of the cube is the temporal range whereas it is the spectral range (see code below). 
I proposed a fix.

Cheers
Julien