### PR TITLE
Correction of minor bugs.

### DIFF
--- a/vip/negfc/mcmc_sampling.py
+++ b/vip/negfc/mcmc_sampling.py
@@ -506,8 +506,7 @@ def mcmc_negfc_sampling(cubes, angs, psfn, ncomp, plsc, initial_state,
                                             cube_ref, svd_mode, scaling, fmerit,
                                             collapse]),
                                     threads=nproc)
-    
-    duration_start = datetime.datetime.now()
+                                    
     start = datetime.datetime.now()
 
     # #########################################################################

--- a/vip/preproc/cosmetics_ifs.py
+++ b/vip/preproc/cosmetics_ifs.py
@@ -153,7 +153,7 @@ def approx_stellar_position(cube, fwhm, return_test=False, verbose=False):
     #1/ Write a 2-columns array with indices of all max pixel values in the cube
     star_tmp_idx = np.zeros([n_z,2])
     star_approx_idx = np.zeros([n_z,2])
-    test_result = np.zeros(n_z)
+    test_result = np.ones(n_z)
     for zz in range(n_z):
         star_tmp_idx[zz] = peak_coordinates(obj_tmp[zz], fwhm[zz])
         
@@ -174,22 +174,22 @@ def approx_stellar_position(cube, fwhm, return_test=False, verbose=False):
     for zz in range(n_z):
         if ((star_tmp_idx[zz,0]<lim_inf_y) or (star_tmp_idx[zz,0]>lim_sup_y) or
             (star_tmp_idx[zz,1]<lim_inf_x) or (star_tmp_idx[zz,1]>lim_sup_x)):
-            test_result[zz] = 1
+            test_result[zz] = 0
 
     #3/ Replace by the median of neighbouring good coordinates if need be
     for zz in range(n_z):             
-        if test_result[zz] == 1:
+        if test_result[zz] == 0:
             ii= 1
             inf_neigh = max(0,zz-ii)
             sup_neigh = min(n_z-1,zz+ii)
-            while test_result[inf_neigh] == 1 and test_result[sup_neigh] == 1:
+            while test_result[inf_neigh] == 0 and test_result[sup_neigh] == 0:
                 ii=ii+1
                 inf_neigh = max(0,zz-ii)
                 sup_neigh = min(n_z-1,zz+ii)
-            if test_result[inf_neigh] == 0 and test_result[sup_neigh] == 0:
+            if test_result[inf_neigh] == 1 and test_result[sup_neigh] == 1:
                 star_approx_idx[zz] = np.floor((star_tmp_idx[sup_neigh]+ \
                                                 star_tmp_idx[inf_neigh])/2.)
-            elif test_result[inf_neigh] == 0: 
+            elif test_result[inf_neigh] == 1: 
                 star_approx_idx[zz] = star_tmp_idx[inf_neigh]
             else: star_approx_idx[zz] = star_tmp_idx[sup_neigh]
         else: star_approx_idx[zz] = star_tmp_idx[zz]

--- a/vip/preproc/rescaling.py
+++ b/vip/preproc/rescaling.py
@@ -334,7 +334,7 @@ def check_scal_vector(scal_vec):
     correct = False
 
     if isinstance(scal_vec, list):
-        scal_list = scal_vec.copy()
+        scal_list = scal_vec[:]
         nz = len(scal_list)
         scal_vec = np.zeros(nz)
         for ii in range(nz):

--- a/vip/var/fit_2d.py
+++ b/vip/var/fit_2d.py
@@ -145,7 +145,7 @@ def fit_2dgaussian(array, crop=False, cent=None, cropsize=15, fwhmx=4, fwhmy=4,
 
 
     
-def fit_2dmoffat(array, yy, xx, full_output=False):
+def fit_2dmoffat(array, yy, xx, full_output=False,fwhm=4):
     """Fits a star/planet with a 2D circular Moffat PSF.
     
     Parameters
@@ -158,6 +158,11 @@ def fit_2dmoffat(array, yy, xx, full_output=False):
     xx : int
         X integer position of the first pixel (0,0) of the subimage in the 
         whole image.
+    full_output: bool, opt
+        Whether to return floor, height, mean_y, mean_x, fwhm, beta, or just 
+        mean_y, mean_x
+    fwhm: float, opt
+        First estimate of the fwhm
     
     Returns
     -------

--- a/vip/var/shapes.py
+++ b/vip/var/shapes.py
@@ -137,7 +137,7 @@ def get_square(array, size, y, x, position=False):
         raise TypeError('Input array is not a frame or 2d array.')
     
     if size%2!=0:  size -= 1 # making it odd to get the wing
-    wing = size/2
+    wing = int(size/2)
     # wing is added to the sides of the subframe center. Note the +1 when 
     # closing the interval (python doesn't include the endpoint)
     array_view = array[int(y-wing):int(y+wing+1),


### PR DESCRIPTION
Hola Carlos,
I've spotted a couple of bugs here and there, and have corrected the obvious ones in this pull request. For the others, that I also list below, I let you choose how to best deal with them. I also include a  suggestion that might be worth considering:

- Corrected Bugs:
1) mcmc_sampling.py
	* l.510: duration_start is assigned to but never used (probably a duplication of the next line) => deleted
2) rescaling.py: 
	* l.338 in check_scal_vector: list object has no attribute copy() => I replaced scal_list = scal_vec.copy() by scal_list = scal_vec[:]
3) recentering.py:
	* l.776 in cube_recenter_gauss2d_fit(): fwhm should not be converted to int, as a change from 3.5px (e.g. NACO) to 3 or 4px would change both the subarray size (subi_size*fwhm) and possibly the gaussian fit result. 
	=> Instead, now fwhm is kept as float, but subi_size*fwhm is converted to int.
	* l.818 in cube_recenter_gauss2d_fit(): the arguments should support iteration
	=> itt.repeat(posy) and itt.repeat(posx)
	=> also, I added upstream some lines to convert fwhm to a 1d array (is fwhm is not given as a 1d array), this is to allow the function to be readily used on an ifs cube (different fwhm value in each frame of the cube)
	* l.988 in _centroid_2dg_frame(): I added an extra argument fwhm to the function, which will be used to feed arguments fwhmx and fwhmy of function fit_2dgaussian(); otherwise it is probably dangerous to assume 4px as first estimate of fwhmx and fwhmy in all cases.
	=> I also modified the calls to _centroid_2dg_frame() accordingly
	* l.1005 in centroid_2dm_frame(): I also added an extra argument fwhm
	=> I also modified the calls to _centroid_2dm_frame() accordingly
4) fit_2d.py:
	* l.187 in fit2d_moffat(): This line does not seem to give a proper estimate of the fwhm. Instead, I added an optional argument "fwhm" to the function, to provide a first estimate.
5) cosmetics_ifs.py
	* approx_stellar_position(): For consistency with the description, now the returning vector contains True where the star is detected and False otherwise (instead of the opposite as it was implemented)
6) var/shapes.py
	* l.140 in get_square: due to __future__ import division, 2 integers division gives a float even if the result could be an integer 
	=> problem with size in get_square 
	=> modified to int(size/2)

- Bugs still to be corrected:
1) mcmc_sampling.py
	* l.559: showWalk is not defined => either include the showWalk function somewhere, or delete the argument "display" of function mcmc_negfc_sampling() all together (it's only use is to activate showWalk when True)
2) recentering.py:
	* frame_center_radon() lacks a description of what is returned in the case full_output = True; in particular what is the returned variable "cost_bound"?


- Suggestion regarding pca_adi_annular() in pca_local.py:
	l.307-380: It might be good to consider a delta_rot value that can vary for each annulus. Currently, when the delta_rot value is such that not enough frames are left in the pca library (typically for the innermost annuli), one has to manually play with this threshold until the error "Too few frames left in the PCA library. 'Try decreasing either delta_rot or min_frames_pca." is not raised any more. Instead, delta_rot could be decreased automatically for those particular annuli. This would make sense according to Absil+13, as a slightly better contrast can be reached for the innermost annuli if we consider a delta_rot condition as small as 0.1 lambda/D. This is because at very small separation, the effect of speckle correlation is more significant than self-subtraction. Therefore, the value of delta_rot that would be given as argument of pca_adi_annular would only apply in annuli where enough frames are left in the pca library. If you deem it useful, I can adapt the current version of the code to implement this.