### PR TITLE
Small bug fix in cube_px_resampling()

### DIFF
--- a/vip/pca/pca_local.py
+++ b/vip/pca/pca_local.py
@@ -8,7 +8,6 @@ from __future__ import division, print_function
 
 __author__ = 'C. Gomez @ ULg'
 __all__ = ['pca_adi_annular',
-           'pca_adi_annular2',
            'pca_rdi_annular']
 
 import numpy as np
@@ -186,7 +185,6 @@ def pca_rdi_annular(cube, angle_list, cube_ref, radius_int=0, asize=1,
         return cube_out, cube_der, frame 
     else:
         return frame           
-
 
 
 def pca_adi_annular(cube, angle_list, radius_int=0, fwhm=4, asize=3, 

--- a/vip/pca/pca_local.py
+++ b/vip/pca/pca_local.py
@@ -8,6 +8,7 @@ from __future__ import division, print_function
 
 __author__ = 'C. Gomez @ ULg'
 __all__ = ['pca_adi_annular',
+           'pca_adi_annular2',
            'pca_rdi_annular']
 
 import numpy as np
@@ -185,6 +186,7 @@ def pca_rdi_annular(cube, angle_list, cube_ref, radius_int=0, asize=1,
         return cube_out, cube_der, frame 
     else:
         return frame           
+
 
 
 def pca_adi_annular(cube, angle_list, radius_int=0, fwhm=4, asize=3, 

--- a/vip/phot/contrcurve.py
+++ b/vip/phot/contrcurve.py
@@ -174,7 +174,7 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
 
     if smooth:
         # smoothing the noise vector using a Savitzky-Golay filter
-        win = int(noise_samp.shape[0]*0.1)
+        win = min(noise_samp.shape[0]-2,int(2*fwhm))
         if win%2==0.:  win += 1
         noise_samp_sm = savgol_filter(noise_samp, polyorder=2, mode='nearest',
                                       window_length=win)

--- a/vip/preproc/recentering.py
+++ b/vip/preproc/recentering.py
@@ -966,10 +966,15 @@ def cube_recenter_moffat2d_fit(array, pos_y, pos_x, fwhm=4, subi_size=5,
     elif nproc>1:
         pool = Pool(processes=int(nproc))  
         res = pool.map(EFT,itt.izip(itt.repeat(_centroid_2dm_frame),
-                                    itt.repeat(array), range(n_frames),
-                                    size.tolist(), pos_y.tolist(), 
-                                    pos_x.tolist(), star_approx_coords,
-                                    star_not_present, negative, fwhm))
+                                    itt.repeat(array), 
+                                    range(n_frames),
+                                    size.tolist(), 
+                                    pos_y.tolist(), 
+                                    pos_x.tolist(), 
+                                    star_approx_coords,
+                                    star_not_present, 
+                                    itt.repeat(negative), 
+                                    fwhm))
         res = np.array(res)
         pool.close()
     y = cy - res[:,0]

--- a/vip/preproc/recentering.py
+++ b/vip/preproc/recentering.py
@@ -724,7 +724,8 @@ def cube_recenter_dft_upsampling(array, cy_1, cx_1, negative=False, fwhm=4,
 
 def cube_recenter_gauss2d_fit(array, xy, fwhm=4, subi_size=5, nproc=1, 
                               full_output=False, verbose=True, save_shifts=False, 
-                              offset=None, negative=False, debug=False):
+                              offset=None, negative=False, debug=False,
+                              threshold=False):
     """ Recenters the frames of a cube. The shifts are found by fitting a 2d 
     gaussian to a subimage centered at (pos_x, pos_y). This assumes the frames 
     don't have too large shifts (>5px). The frames are shifted using the 
@@ -812,7 +813,8 @@ def cube_recenter_gauss2d_fit(array, xy, fwhm=4, subi_size=5, nproc=1,
                               title='2d Gauss-fitting, looping through frames')
         for i in range(n_frames):
             res.append(_centroid_2dg_frame(array, i, subfr_sz[i], 
-                                           pos_y, pos_x, negative, debug, fwhm[i]))
+                                           pos_y, pos_x, negative, debug, fwhm[i], 
+                                           threshold))
             bar.update()
         res = np.array(res)
     elif nproc>1:
@@ -825,7 +827,8 @@ def cube_recenter_gauss2d_fit(array, xy, fwhm=4, subi_size=5, nproc=1,
                                      itt.repeat(pos_x),
                                      itt.repeat(negative),
                                      itt.repeat(debug),
-                                     fwhm)) 
+                                     fwhm,
+                                     itt.repeat(threshold))) 
         res = np.array(res)
         pool.close()
     y = cy - res[:,0]
@@ -999,7 +1002,7 @@ def cube_recenter_moffat2d_fit(array, pos_y, pos_x, fwhm=4, subi_size=5,
 
 
 def _centroid_2dg_frame(cube, frnum, size, pos_y, pos_x, negative, debug=False, 
-                        fwhm=4):
+                        fwhm=4,threshold=False):
     """ Finds the centroid by using a 2d gaussian fitting in one frame from a 
     cube. To be called from within cube_recenter_gauss2d_fit().
     """
@@ -1010,7 +1013,7 @@ def _centroid_2dg_frame(cube, frnum, size, pos_y, pos_x, negative, debug=False,
     if negative:  sub_image = -sub_image + np.abs(np.min(-sub_image))
             
     y_i, x_i = fit_2dgaussian(sub_image, crop=False, fwhmx=fwhm, fwhmy=fwhm, 
-                              threshold=False, sigfactor=1, debug=debug)
+                              threshold=threshold, sigfactor=1, debug=debug)
     y_i = y1 + y_i
     x_i = x1 + x_i
     return y_i, x_i

--- a/vip/preproc/recentering2.py
+++ b/vip/preproc/recentering2.py
@@ -110,7 +110,7 @@ min_spat_freq = 0.5, max_spat_freq = 3, fwhm = 8., debug = False , NegFit = True
         alignment_cube[0,:,:]=np.median(alignment_cube[1:(cube_sci.shape[0]+1),:,:],axis=0) 
         if(recenter_median):
             ## Recenter the median frame using a neg. gaussian fit
-            sub_image, y1, x1 = get_square_robust(alignment_cube[0,:,:], size=10, y=ceny,x=cenx, position=True)
+            sub_image, y1, x1 = get_square_robust(alignment_cube[0,:,:], size=int(fwhm)+1, y=ceny,x=cenx, position=True)
             if(NegFit):
                 sub_image = -sub_image + np.abs(np.min(-sub_image))       
             y_i, x_i = fit_2dgaussian(sub_image, crop=False, threshold=False,sigfactor=1, debug=debug)
@@ -121,7 +121,7 @@ min_spat_freq = 0.5, max_spat_freq = 3, fwhm = 8., debug = False , NegFit = True
             alignment_cube[0,:,:] = frame_shift(alignment_cube[0,:,:], yshift, xshift, imlib=imlib, interpolation=interpolation)
         
         # center the cube with stretched values
-        _,y_shift,x_shift = cube_recenter_dft_upsampling(np.log10((abs(alignment_cube)+1)**(gammaval)), ceny, cenx, fwhm=10, 
+        _,y_shift,x_shift = cube_recenter_dft_upsampling(np.log10((abs(alignment_cube)+1)**(gammaval)), ceny, cenx, fwhm=fwhm, 
                                          subi_size=None, full_output=True, verbose=False, save_shifts=False, debug=False)   
         
         print '\nSquare sum of shift vecs: '+str(np.sum(np.sqrt(y_shift**2+x_shift**2)))

--- a/vip/preproc/skysubtraction.py
+++ b/vip/preproc/skysubtraction.py
@@ -74,7 +74,7 @@ def cube_subtract_sky_pca(sci_cube, sky_cube, mask, ref_cube=None, ncomp=2):
         transf_sci[:, i] = np.inner(sky_pcs, Msci_masked[i].T)
 
     Msky_pcs_masked = prepare_matrix(sky_pcs_cube_masked, scaling=None,
-                                             verbose=False)
+                                     verbose=False)
     mat_inv = np.linalg.inv(np.dot(Msky_pcs_masked, Msky_pcs_masked.T))
     transf_sci_scaled = np.dot(mat_inv, transf_sci)
 

--- a/vip/var/fit_2d.py
+++ b/vip/var/fit_2d.py
@@ -98,7 +98,7 @@ def fit_2dgaussian(array, crop=False, cent=None, cropsize=15, fwhmx=4, fwhmy=4,
     if threshold:
         _, clipmed, clipstd = sigma_clipped_stats(psf_subimage, sigma=2)
         indi = np.where(psf_subimage<=clipmed+sigfactor*clipstd)
-        subimnoise = np.random.randn(psf_subimage.shape[0], psf_subimage.shape[1])*50
+        subimnoise = np.random.randn(psf_subimage.shape[0], psf_subimage.shape[1])*clipstd#*50
         psf_subimage[indi] = subimnoise[indi]
     
     yme, xme = np.where(psf_subimage==psf_subimage.max())


### PR DESCRIPTION
- I corrected the bug that occurs when running vip.preproc.cube_px_resampling(): "frame_px_resampling() got an unexpected keyword argument 'imlib'". This is due to the latest update of frame_px_resampling (keyword 'imlib' was removed); the call to frame_px_resampling in cube_px_resampling was not modified accordingly.

- I added the optional keyword "threshold" in cube_recenter_gauss2d_fit(), this argument is passed to _centroid_2dg_frame(), and hence to vip.var.fit2d_gaussian().