### PR TITLE
Minor bug fix: bad pixel correction at frame edges

### DIFF
--- a/vip/preproc/badpixremoval.py
+++ b/vip/preproc/badpixremoval.py
@@ -179,7 +179,7 @@ def cube_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
     bar = pyprind.ProgBar(n_frames, stream=1, title='Looping through frames')
     for i in range(n_frames):
         frame = cube_out[i]
-        smoothed = median_filter(frame, size, mode='nearest')
+        smoothed = median_filter(frame, size, mode='mirror')
         frame[np.where(bpm_mask)] = smoothed[np.where(bpm_mask)]
         bar.update()
     array_out = cube_out

--- a/vip/preproc/badpixremoval.py
+++ b/vip/preproc/badpixremoval.py
@@ -94,7 +94,7 @@ def frame_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
         bpm_mask = bpm_mask.astype('bool')
         if debug:  pp_subplots(frame, bpm_mask, title='Frame / Bad pixel mask')
 
-    smoothed = median_filter(frame, size, mode='nearest')
+    smoothed = median_filter(frame, size, mode='mirror')
     frame[np.where(bpm_mask)] = smoothed[np.where(bpm_mask)]
     array_out = frame
 


### PR DESCRIPTION
The bad pixel correction algorithm was not handling lines of bad pixels at a frame's edge. This is now the case.