### PR TITLE
Implemented SSIM metric to calculate distances between frames/cubes

### DIFF
--- a/vip/stats/distances.py
+++ b/vip/stats/distances.py
@@ -14,27 +14,32 @@ import numpy as np
 import scipy.stats
 from matplotlib import pyplot as plt
 from ..var import get_annulus
+from skimage.measure import compare_ssim as ssim
 
 
-def cube_distance(array, frame, mode='full', dist='sad', inradius=None, 
+def cube_distance(array, frame, mode='full', dist='sad', inradius=None,
                   width=None, plot=True):
     """ Computes the distance (or similarity) between frames in a cube, using
     one as the reference. Depending on the mode, the whole image can be used,
-    or just the pixels in a given annulus. The criteria used are: 
+    or just the pixels in a given annulus. The criteria used are:
     - the Manhattan distance (SAD or sum of absolute differences),
     - the Euclidean distance (square root of the sum of the squared differences),
     - the Mean Squared Error,
     - the Spearman correlation coefficient,
     - the Pearson correlation coefficient,
     - the Structural Similarity Index (SSIM).
-    
+
     The SAD, MSE and Ecuclidean criteria are dissimilarity criteria, which
     means that 0 is perfect similarity.
-    The Spearman and Pearson correlation coefficients, vary between -1 and +1 
-    with 0 implying no correlation. Correlations of -1 or +1 imply an exact 
-    linear relationship. 
+    The Spearman and Pearson correlation coefficients, vary between -1 and +1
+    with 0 implying no correlation. Correlations of -1 or +1 imply an exact
+    linear relationship.
+    The Structural Similarity Index was proposed by Wang et al. 2004.
+    (http://www.cns.nyu.edu/pub/eero/wang03-reprint.pdf)
+    SSIM varies between -1 and 1, where 1 means perfect similarity. SSIM
+    attempts to model the perceived change in the structural information of the
+    image. The mean SSIM is reported.
 
-    
     Parameters
     ----------
     array : array_like
@@ -43,7 +48,7 @@ def cube_distance(array, frame, mode='full', dist='sad', inradius=None,
         Reference frame in the cube.
     mode : {'full','annulus'}, string optional
         Whether to use the full frames or a centered annulus.
-    dist : {'sad','euclidean','mse','pearson','spearman'}, str optional
+    dist : {'sad','euclidean','mse','pearson','spearman', 'ssim'}, str optional
         Which criterion to use.
     inradius : None or int, optional
         The inner radius when mode is 'annulus'.
@@ -51,7 +56,7 @@ def cube_distance(array, frame, mode='full', dist='sad', inradius=None,
         The width when mode is 'annulus'.
     plot : {True, False}, bool optional
         Whether to plot the distances or not.
-        
+
     Returns
     -------
     lista : array_like
@@ -68,13 +73,13 @@ def cube_distance(array, frame, mode='full', dist='sad', inradius=None,
         frame_ref = get_annulus(array[frame], inradius, width, True)
     else:
         raise TypeError('Mode not recognized or missing parameters')
-    
+
     for i in range(n):
         if mode=='full':
             framei = array[i]
         elif mode=='annulus':
             framei = get_annulus(array[i], inradius, width, True)
-            
+
         if dist=='sad':
             lista.append(np.sum(abs(frame_ref - framei)))
         elif dist=='euclidean':
@@ -83,14 +88,22 @@ def cube_distance(array, frame, mode='full', dist='sad', inradius=None,
             lista.append((np.sum((frame_ref - framei)**2))/len(frame_ref))
         elif dist=='pearson':
             pears, _ = scipy.stats.pearsonr(frame_ref.ravel(), framei.ravel())
-            lista.append(pears)    
+            lista.append(pears)
         elif dist=='spearman':
             spear, _ = scipy.stats.spearmanr(frame_ref.ravel(), framei.ravel())
             lista.append(spear)
+        elif dist=='ssim':
+            mean_ssim = ssim(frame_ref, framei,
+                  win_size=7,
+                  dynamic_range=frame_ref.max() - frame_ref.min(),
+                  gaussian_weights=True,
+                  sigma=1.5,
+                  use_sample_covariance=True)
+            lista.append(mean_ssim)
         else:
             raise ValueError('Distance not recognized')
     lista = np.array(lista)
-    
+
     median_cor = np.median(lista)
     mean_cor = np.mean(lista)
     if plot:
@@ -98,12 +111,12 @@ def cube_distance(array, frame, mode='full', dist='sad', inradius=None,
         x = range(len(lista))
         ax.plot(x, lista, '-', color='blue', alpha=0.3)
         ax.plot(x, lista, '.', color='blue', alpha=0.5)
-        ax.vlines(frame, ymin=np.nanmin(lista), ymax=np.nanmax(lista), 
+        ax.vlines(frame, ymin=np.nanmin(lista), ymax=np.nanmax(lista),
                    colors='green', linestyles='dashed', lw=2, alpha=0.8,
                    label='Frame '+str(frame))
-        ax.hlines(median_cor, xmin=-1, xmax=n+1, colors='purple', 
+        ax.hlines(median_cor, xmin=-1, xmax=n+1, colors='purple',
                    linestyles='solid', label='Median value : '+str(median_cor))
-        ax.hlines(mean_cor, xmin=-1, xmax=n+1, colors='red', 
+        ax.hlines(mean_cor, xmin=-1, xmax=n+1, colors='red',
                    linestyles='solid', label='Mean value : '+str(mean_cor))
         plt.xlabel('Frame number')
         if dist=='sad':
@@ -118,38 +131,38 @@ def cube_distance(array, frame, mode='full', dist='sad', inradius=None,
             plt.ylabel('Mean squared error')
         elif dist=='ssim':
             plt.ylabel('Structural Similarity Index')
-        
+
         plt.xlim(xmin=-1, xmax=n+1)
         plt.minorticks_on()
         plt.legend(fancybox=True, framealpha=0.5, fontsize=12, loc='best')
         plt.grid(which='both')
-        
+
     return lista
 
 
-def cube_distance_to_frame(array, frame_ref, mode='full', dist='sad', 
+def cube_distance_to_frame(array, frame_ref, mode='full', dist='sad',
                            inradius=None, width=None, plot=True):
     """ Computes the distance (or similarity) between frames in a cube and a
     reference image. Depending on the mode, the whole image can be used,
-    or just the pixels in a given annulus. The criteria used are: 
+    or just the pixels in a given annulus. The criteria used are:
     - the Manhattan distance (SAD or sum of absolute differences),
     - the Euclidean distance (square root of the sum of the squared differences),
     - the Mean Squared Error,
     - the Spearman correlation coefficient,
     - the Pearson correlation coefficient,
     - the Structural Similarity Index (SSIM).
-    
+
     The SAD, MSE and Ecuclidean criteria are dissimilarity criteria, which
     means that 0 is perfect similarity.
-    The Spearman and Pearson correlation coefficients, vary between -1 and +1 
-    with 0 implying no correlation. Correlations of -1 or +1 imply an exact 
-    linear relationship. 
-    The Structural Similarity Index was proposed by Wang et al. 2004. 
+    The Spearman and Pearson correlation coefficients, vary between -1 and +1
+    with 0 implying no correlation. Correlations of -1 or +1 imply an exact
+    linear relationship.
+    The Structural Similarity Index was proposed by Wang et al. 2004.
     (http://www.cns.nyu.edu/pub/eero/wang03-reprint.pdf)
-    SSIM varies between -1 and 1, where 1 means perfect similarity. SSIM 
-    attempts to model the perceived change in the structural information of the 
-    image. 
-    
+    SSIM varies between -1 and 1, where 1 means perfect similarity. SSIM
+    attempts to model the perceived change in the structural information of the
+    image. The mean SSIM is reported.
+
     Parameters
     ----------
     array : array_like
@@ -166,7 +179,7 @@ def cube_distance_to_frame(array, frame_ref, mode='full', dist='sad',
         The width when mode is 'annulus'.
     plot : {True, False}, bool optional
         Whether to plot the distances or not.
-        
+
     Returns
     -------
     lista : array_like
@@ -183,13 +196,13 @@ def cube_distance_to_frame(array, frame_ref, mode='full', dist='sad',
         frame_ref = get_annulus(frame_ref, inradius, width, True)
     else:
         raise TypeError('Mode not recognized or missing parameters')
-    
+
     for i in range(n):
         if mode=='full':
             framei = array[i]
         elif mode=='annulus':
             framei = get_annulus(array[i], inradius, width, True)
-            
+
         if dist=='sad':
             lista.append(np.sum(abs(frame_ref - framei)))
         elif dist=='euclidean':
@@ -198,17 +211,22 @@ def cube_distance_to_frame(array, frame_ref, mode='full', dist='sad',
             lista.append((np.sum((frame_ref - framei)**2))/len(frame_ref))
         elif dist=='pearson':
             pears, _ = scipy.stats.pearsonr(frame_ref.ravel(), framei.ravel())
-            lista.append(pears)    
+            lista.append(pears)
         elif dist=='spearman':
             spear, _ = scipy.stats.spearmanr(frame_ref.ravel(), framei.ravel())
             lista.append(spear)
         elif dist=='ssim':
-            lista.append(ssim(frame_ref, framei, win_size=7, 
-                              dynamic_range=frame_ref.max() - frame_ref.min()))
+            mean_ssim = ssim(frame_ref, framei,
+                              win_size=7,
+                              dynamic_range=frame_ref.max() - frame_ref.min(),
+                              gaussian_weights=True,
+                              sigma=1.5,
+                              use_sample_covariance=True)
+            lista.append(mean_ssim)
         else:
             raise ValueError('Distance not recognized')
     lista = np.array(lista)
-    
+
     median_cor = np.median(lista)
     mean_cor = np.mean(lista)
     if plot:
@@ -216,9 +234,9 @@ def cube_distance_to_frame(array, frame_ref, mode='full', dist='sad',
         x = range(len(lista))
         ax.plot(x, lista, '-', color='blue', alpha=0.3)
         ax.plot(x, lista, '.', color='blue', alpha=0.5)
-        ax.hlines(median_cor, xmin=-1, xmax=n+1, colors='purple', 
+        ax.hlines(median_cor, xmin=-1, xmax=n+1, colors='purple',
                    linestyles='solid', label='Median value : '+str(median_cor))
-        ax.hlines(mean_cor, xmin=-1, xmax=n+1, colors='red', 
+        ax.hlines(mean_cor, xmin=-1, xmax=n+1, colors='red',
                    linestyles='solid', label='Mean value : '+str(mean_cor))
         plt.xlabel('Frame number')
         if dist=='sad':
@@ -233,11 +251,10 @@ def cube_distance_to_frame(array, frame_ref, mode='full', dist='sad',
             plt.ylabel('Mean squared error')
         elif dist=='ssim':
             plt.ylabel('Structural Similarity Index')
-        
+
         plt.xlim(xmin=-1, xmax=n+1)
         plt.minorticks_on()
         plt.legend(fancybox=True, framealpha=0.5, fontsize=12, loc='best')
         plt.grid(which='both')
-        
-    return lista
 
+    return lista


### PR DESCRIPTION
The implementation of the SSIM metric appeared to be incomplete (i.e. the code allows the user to select SSIM but it doesn't do anything). I've added the import command to use scikit-image's implementation of the SSIM calculation (it returns the *mean* SSIM between two frames). I've set the default parameters to match the Wang et al. 2004 paper cited in the current description of the SSIM. I also added a clarification in the comments to say that the *mean* SSIM is returned (unlike the other metrics, the SSIM is a matrix, not just a single value).

This calculation is done via scikit-image rather than OpenCV because there's no builtin function in OpenCV to calculate the SSIM. scikit-image is still *very* fast since no rotations are necessary (just a few convolutions). However, if an OpenCV approach is desired in the future, here is how to create an OpenCV version out of OpenCV functions: http://docs.opencv.org/2.4/doc/tutorials/gpu/gpu-basics-similarity/gpu-basics-similarity.html