### PR TITLE
Check for None using "is" instead of equality and one other small change

### DIFF
--- a/vip/exlib/ds9.py
+++ b/vip/exlib/ds9.py
@@ -263,7 +263,7 @@ def _findDS9AndXPA():
             "SAOImage DS9.app/Contents/MacOS",
             "SAOImageDS9.app/Contents/MacOS",
         ], doRaise=False)
-        foundDS9 = (ds9Dir != None)
+        foundDS9 = (ds9Dir is not None)
         if foundDS9:
             _DS9Path = os.path.join(ds9Dir, "ds9")
         foundXPA = False

--- a/vip/exlib/ds9.py
+++ b/vip/exlib/ds9.py
@@ -179,7 +179,7 @@ def _findApp(appName, subDirs = None, doRaise = True):
     Return None or raise RuntimeError if not found.
     """
     appDirs = getAppDirs()
-    if subDirs == None:
+    if subDirs is None:
         subDirs = [None]
     dirTrials = []
     for appDir in appDirs:

--- a/vip/exlib/ds9_getDirs.py
+++ b/vip/exlib/ds9_getDirs.py
@@ -113,7 +113,7 @@ except ImportError:
                 return [getHomeDir(), None]
             else:
                 homeDir = getHomeDir()
-                if homeDir != None:
+                if homeDir is not None:
                     return [homeDir]
             return []
 

--- a/vip/exlib/ds9_getMacDirs.py
+++ b/vip/exlib/ds9_getMacDirs.py
@@ -56,7 +56,7 @@ def getMacUserSharedDirs(dirType, inclNone = False):
             dirType = dirType,
             doCreate = False,
         )
-        if (path != None) or inclNone:
+        if (path is not None) or inclNone:
             retDirs.append(path)
     return retDirs
 

--- a/vip/exlib/ds9_getMacDirs.py
+++ b/vip/exlib/ds9_getMacDirs.py
@@ -33,7 +33,7 @@ def getStandardDir(domain, dirType, doCreate=False):
         If dirType is None, then returns None.
     - doCreate: try to create the directory if it does not exist?
     """
-    if dirType == None:
+    if dirType is None:
         return None
     try:
         fsref = Carbon.Folder.FSFindFolder(domain, dirType, doCreate)

--- a/vip/exlib/ds9_getWinDirs.py
+++ b/vip/exlib/ds9_getWinDirs.py
@@ -67,7 +67,7 @@ def getStandardDir(dirType):
     not change).
     """
 
-    if dirType == None:
+    if dirType is None:
         return None
     try:
         return shell.SHGetFolderPath(

--- a/vip/exlib/ds9_getWinDirs.py
+++ b/vip/exlib/ds9_getWinDirs.py
@@ -94,7 +94,7 @@ def getAppDirs(inclNone = False):
     retDirs = []
     for dirType in (None, shellcon.CSIDL_PROGRAM_FILES):
         path = getStandardDir(dirType)
-        if (path != None) or inclNone:
+        if (path is not None) or inclNone:
             retDirs.append(path)
     return retDirs
 
@@ -112,7 +112,7 @@ def getAppSuppDirs(inclNone = False):
     retDirs = []
     for dirType in (shellcon.CSIDL_APPDATA, shellcon.CSIDL_COMMON_APPDATA):
         path = getStandardDir(dirType)
-        if (path != None) or inclNone:
+        if (path is not None) or inclNone:
             retDirs.append(path)
     return retDirs
 

--- a/vip/pca/pca_fullfr.py
+++ b/vip/pca/pca_fullfr.py
@@ -821,7 +821,7 @@ def pca_optimize_snr(cube, angle_list, (source_xy), fwhm, cube_ref=None,
             ax1.set_ylabel('S/N')
             ax1.minorticks_on()
             ax1.grid('on', 'major', linestyle='solid', alpha=0.2)
-            if plot_title != None:
+            if plot_title is not None:
                 ax1.set_title('Optimal pc: ' + str(opt_npc) + ' for ' + plot_title)
             
             ax2 = plt.subplot(212)

--- a/vip/pca/pca_fullfr.py
+++ b/vip/pca/pca_fullfr.py
@@ -839,7 +839,7 @@ def pca_optimize_snr(cube, angle_list, (source_xy), fwhm, cube_ref=None,
             #plt.savefig('figure.pdf', dpi=300, bbox_inches='tight')
             print()
             # Optionally, save the contrast curve
-            if save_plot != None:
+            if save_plot is not None:
                 plt.savefig(save_plot, dpi=100, bbox_inches='tight')
 
     if mode == 'fullfr':

--- a/vip/pca/utils_pca.py
+++ b/vip/pca/utils_pca.py
@@ -192,7 +192,7 @@ def matrix_scaling(matrix, scaling):
     "spat-standard" spatial mean centering plus scaling to unit variance is
     performed.
     """
-    if scaling==None:
+    if scaling is None:
         pass
     elif scaling=='temp-mean':
         matrix = scale(matrix, with_mean=True, with_std=False)

--- a/vip/phot/contrcurve.py
+++ b/vip/phot/contrcurve.py
@@ -287,7 +287,7 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
             ax1.set_ylim(min_y_lim, max_y_lim)
 
         # Optionally, save the figure to a path
-        if save_plot != None:
+        if save_plot is not None:
             fig.savefig(save_plot, dpi=100)
             
         if debug:

--- a/vip/phot/contrcurve.py
+++ b/vip/phot/contrcurve.py
@@ -273,7 +273,7 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
         if object_name != None and frame_size != None:
             # Retrieve ncomp and pca_type info to use in title
             ncomp = algo_dict['ncomp']
-            if algo_dict['cube_ref'] == None:
+            if algo_dict['cube_ref'] is None:
                 pca_type = 'ADI'
             else:
                 pca_type = 'RDI'

--- a/vip/phot/contrcurve.py
+++ b/vip/phot/contrcurve.py
@@ -270,7 +270,7 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
         ax1.set_xlim(0, np.max(rad_samp*pxscale))
 
         # Give a title to the contrast curve plot
-        if object_name != None and frame_size != None:
+        if object_name is not None and frame_size is not None:
             # Retrieve ncomp and pca_type info to use in title
             ncomp = algo_dict['ncomp']
             if algo_dict['cube_ref'] is None:

--- a/vip/phot/detection.py
+++ b/vip/phot/detection.py
@@ -331,7 +331,7 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
                        cmap='gray', alpha=0.8)
 
         # Option to plot axes in angular scale
-        if NIRC2angscale and frame_size != None:
+        if NIRC2angscale and frame_size is not None:
             from scipy.ndimage import gaussian_filter
             # Converting axes from pixels to arcseconds
             # Find the middle value in the odd frame sizes
@@ -364,7 +364,7 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
             plt.tick_params(axis='both', which='major', labelsize=10)
 
             # Set the title of the plot
-            if object_name != None and inner_rad != None:
+            if object_name is not None and inner_rad is not None:
                 ax.set_title(pca_type + ' ' + object_name+' '+ str(ncomp) + 'pc ' + str(frame_size)+'+'+str(inner_rad),
                              fontsize=14)
             array_smoothed = gaussian_filter(array, sigma=(2.3, 2.3), order=0)
@@ -394,7 +394,7 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
             ax.add_patch(circ)
         # Save the plot if output path is provided
         # Don't show the plot when running pipeline (i.e. when saving figures)
-        if save_plot !=None:
+        if save_plot is not None:
             plt.savefig(save_plot, dpi= 100, bbox_inches='tight')
         else:
             plt.show()

--- a/vip/phot/detection.py
+++ b/vip/phot/detection.py
@@ -7,7 +7,7 @@ Module with detection algorithms.
 from __future__ import division
 
 __author__ = 'C. Gomez @ ULg'
-__all__ = ['detection', 
+__all__ = ['detection',
            'mask_source_centers',
            'peak_coordinates']
 
@@ -21,7 +21,7 @@ from astropy.table import Table
 from astropy.modeling.models import Gaussian2D
 from astropy.modeling.fitting import LevMarLSQFitter
 from skimage.feature import peak_local_max
-from ..var import (mask_circle, pp_subplots, get_square, frame_center, 
+from ..var import (mask_circle, pp_subplots, get_square, frame_center,
                    frame_filter_gaussian2d, fit_2dgaussian)
 from ..conf import sep
 from .snr import snr_ss
@@ -30,17 +30,17 @@ from .frame_analysis import frame_quick_report
 
 # TODO: Add the option of computing and thresholding an S/N map
 
-def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False, 
-              mask=True, snr_thresh=5, plot=True, debug=False, 
+def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
+              mask=True, snr_thresh=5, plot=True, debug=False,
               full_output=False, verbose=True, save_plot=None,
-              object_name = None, frame_size=None, inner_rad=None, 
-              pca_type = None, ncomp = None, NIRC2angscale = False):                 
-    """ Finds blobs in a 2d array. The algorithm is designed for automatically 
-    finding planets in post-processed high contrast final frames. Blob can be 
-    defined as a region of an image in which some properties are constant or 
+              object_name = None, frame_size=None, inner_rad=None,
+              pca_type = None, ncomp = None, NIRC2angscale = False):
+    """ Finds blobs in a 2d array. The algorithm is designed for automatically
+    finding planets in post-processed high contrast final frames. Blob can be
+    defined as a region of an image in which some properties are constant or
     vary within a prescribed range of values. See <Notes> below to read about
     the algorithm details.
-    
+
     Parameters
     ----------
     array : array_like, 2d
@@ -49,7 +49,7 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
         Input psf.
     bkg_sigma : float, optional
         The number standard deviations above the clipped median for setting the
-        background level. 
+        background level.
     mode : {'lpeaks','log','dog'}, optional
         Sets with algorithm to use. Each algorithm yields different results.
     matched_filter : {True, False}, bool optional
@@ -57,7 +57,7 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
     mask : {True, False}, optional
         Whether to mask the central region (circular aperture of 2*fwhm radius).
     snr_thresh : float, optional
-        SNR threshold for deciding whether the blob is a detection or not.         
+        SNR threshold for deciding whether the blob is a detection or not.
     plot {True, False}, bool optional
         If True plots the frame showing the detected blobs on top.
     debug : {False, True}, bool optional
@@ -82,142 +82,141 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
     NIRC2angscale: {False, True}
         If True the plot axes are converted to angular scale (arcseconds,
         assuming NIRC2's ~ 0.01 pixel scale)
-    
+
     Returns
     -------
     yy, xx : array_like
-        Two vectors with the y and x coordinates of the centers of the sources 
-        (potential planets). 
+        Two vectors with the y and x coordinates of the centers of the sources
+        (potential planets).
     If full_output is True then a table with all the candidates that passed the
-    2d Gaussian fit constrains and their SNR is returned. Also the count of 
-    companions with SNR>5 (those with highest probability of being true 
+    2d Gaussian fit constrains and their SNR is returned. Also the count of
+    companions with SNR>5 (those with highest probability of being true
     detections).
-                
+
     Notes
     -----
     The FWHM of the PSF is measured directly on the provided array. If the
-    parameter matched_filter==True then the PSF is used to run a matched filter 
-    (correlation) which is equivalent to a convolution filter. Filtering the 
-    image will smooth the noise and maximize detectability of objects with a 
-    shape similar to the kernel. 
-    The background level or threshold is found with sigma clipped statistics 
-    (5 sigma over the median) on the image/correlated image. Then 5 different 
+    parameter matched_filter==True then the PSF is used to run a matched filter
+    (correlation) which is equivalent to a convolution filter. Filtering the
+    image will smooth the noise and maximize detectability of objects with a
+    shape similar to the kernel.
+    The background level or threshold is found with sigma clipped statistics
+    (5 sigma over the median) on the image/correlated image. Then 5 different
     strategies can be used to detect the blobs (potential planets):
-    
-    Local maxima + 2d Gaussian fit. The local peaks above the background on the 
-    (correlated) frame are detected. A maximum filter is used for finding local 
-    maxima. This operation dilates the original image and merges neighboring 
-    local maxima closer than the size of the dilation. Locations where the 
+
+    Local maxima + 2d Gaussian fit. The local peaks above the background on the
+    (correlated) frame are detected. A maximum filter is used for finding local
+    maxima. This operation dilates the original image and merges neighboring
+    local maxima closer than the size of the dilation. Locations where the
     original image is equal to the dilated image are returned as local maxima.
-    The minimum separation between the peaks is 1*FWHM. A 2d Gaussian fit is 
+    The minimum separation between the peaks is 1*FWHM. A 2d Gaussian fit is
     done on each of the maxima constraining the position on the subimage and the
-    sigma of the fit. Finally the blobs are filtered based on its SNR. 
-    
-    Laplacian of Gaussian + 2d Gaussian fit. It computes the Laplacian of 
-    Gaussian images with successively increasing standard deviation and stacks 
-    them up in a cube. Blobs are local maximas in this cube. LOG assumes that 
-    the blobs are again assumed to be bright on dark. A 2d Gaussian fit is done 
-    on each of the candidates constraining the position on the subimage and the 
-    sigma of the fit. Finally the blobs are filtered based on its SNR. 
-    
-    Difference of Gaussians. This is a faster approximation of LoG approach. In 
-    this case the image is blurred with increasing standard deviations and the 
-    difference between two successively blurred images are stacked up in a cube. 
-    DOG assumes that the blobs are again assumed to be bright on dark. A 2d 
-    Gaussian fit is done on each of the candidates constraining the position on 
-    the subimage and the sigma of the fit. Finally the blobs are filtered based 
-    on its SNR. 
-                
+    sigma of the fit. Finally the blobs are filtered based on its SNR.
+
+    Laplacian of Gaussian + 2d Gaussian fit. It computes the Laplacian of
+    Gaussian images with successively increasing standard deviation and stacks
+    them up in a cube. Blobs are local maximas in this cube. LOG assumes that
+    the blobs are again assumed to be bright on dark. A 2d Gaussian fit is done
+    on each of the candidates constraining the position on the subimage and the
+    sigma of the fit. Finally the blobs are filtered based on its SNR.
+
+    Difference of Gaussians. This is a faster approximation of LoG approach. In
+    this case the image is blurred with increasing standard deviations and the
+    difference between two successively blurred images are stacked up in a cube.
+    DOG assumes that the blobs are again assumed to be bright on dark. A 2d
+    Gaussian fit is done on each of the candidates constraining the position on
+    the subimage and the sigma of the fit. Finally the blobs are filtered based
+    on its SNR.
+
     """
     def check_blobs(array_padded, coords_temp, fwhm, debug):
         y_temp = coords_temp[:,0]
-        x_temp = coords_temp[:,1]   
+        x_temp = coords_temp[:,1]
         coords = []
         # Fitting a 2d gaussian to each local maxima position
         for y,x in zip(y_temp,x_temp):
-            subim, suby, subx = get_square(array_padded, 
-                                           2*int(np.ceil(fwhm)), 
-                                           y+pad, x+pad, position=True) 
+            subim, suby, subx = get_square(array_padded,
+                                           2*int(np.ceil(fwhm)),
+                                           y+pad, x+pad, position=True)
             cy, cx = frame_center(subim)
-            
-            gauss = Gaussian2D(amplitude=subim.max(), 
-                               x_mean=cx, y_mean=cy, 
-                               x_stddev=fwhm*gaussian_fwhm_to_sigma, 
+
+            gauss = Gaussian2D(amplitude=subim.max(),
+                               x_mean=cx, y_mean=cy,
+                               x_stddev=fwhm*gaussian_fwhm_to_sigma,
                                y_stddev=fwhm*gaussian_fwhm_to_sigma, theta=0)
-            
+
             sy, sx = np.indices(subim.shape)
-            fitter = LevMarLSQFitter() 
+            fitter = LevMarLSQFitter()
             fit = fitter(gauss, sx, sy, subim)
-            
+
             # checking that the amplitude is positive > 0
-            # checking whether the x and y centroids of the 2d gaussian fit 
+            # checking whether the x and y centroids of the 2d gaussian fit
             # coincide with the center of the subimage (within 2px error)
-            # checking whether the mean of the fwhm in y and x of the fit 
+            # checking whether the mean of the fwhm in y and x of the fit
             # are close to the FWHM_PSF with a margin of 3px
             fwhm_y = fit.y_stddev.value*gaussian_sigma_to_fwhm
             fwhm_x = fit.x_stddev.value*gaussian_sigma_to_fwhm
-            mean_fwhm_fit = np.mean([np.abs(fwhm_x), np.abs(fwhm_y)]) 
+            mean_fwhm_fit = np.mean([np.abs(fwhm_x), np.abs(fwhm_y)])
             if fit.amplitude.value>0 \
             and np.allclose(fit.y_mean.value, cy, atol=2) \
             and np.allclose(fit.x_mean.value, cx, atol=2) \
-            and np.allclose(mean_fwhm_fit, fwhm, atol=3):                     
+            and np.allclose(mean_fwhm_fit, fwhm, atol=3):
                 coords.append((suby+fit.y_mean.value,subx+fit.x_mean.value))
-        
-            if debug:  
+
+            if debug:
                 print 'Coordinates (Y,X): {:.3f},{:.3f}'.format(y, x)
                 print 'fit peak = {:.3f}'.format(fit.amplitude.value)
                 #print fit
                 msg = 'fwhm_y in px = {:.3f}, fwhm_x in px = {:.3f}'
-                print msg.format(fwhm_y, fwhm_x) 
+                print msg.format(fwhm_y, fwhm_x)
                 print 'mean fit fwhm = {:.3f}'.format(mean_fwhm_fit)
                 pp_subplots(subim, colorb=True)
         return coords
-    
+
     def print_coords(coords):
         print 'Blobs found:', len(coords)
         print ' ycen   xcen'
         print '------ ------'
         for i in range(len(coords[:,0])):
             print '{:.3f} \t {:.3f}'.format(coords[i,0], coords[i,1])
-    
+
     def print_abort():
-        if verbose:  
+        if verbose:
             print sep
             print 'No potential sources found'
             print sep
-    
+
     # --------------------------------------------------------------------------
-    
+
     if not array.ndim == 2:
         raise TypeError('Input array is not a frame or 2d array')
     if not psf.ndim == 2 and psf.shape[0] < array.shape[0]:
         raise TypeError('Input psf is not a 2d array or has wrong size')
-    
+
     # Getting the FWHM from the PSF array
-    _,_,fwhm_y, fwhm_x,_,_ = fit_2dgaussian(psf, cent=(frame_center(psf)[1],
-                                                       frame_center(psf)[0]), 
-                                            debug=debug, full_output=True)    
+    outdf = fit_2dgaussian(psf, cent=(frame_center(psf)[1],frame_center(psf)[0]),debug=debug, full_output=True)
+    fwhm_x, fwhm_y = outdf.at[0,'fwhm_x'],outdf.at[0,'fwhm_y']
     fwhm = np.mean([fwhm_x, fwhm_y])
-    if verbose:  
+    if verbose:
         print 'FWHM =', fwhm
         print
-    if debug:   
+    if debug:
         print 'FWHM_y', fwhm_y
         print 'FWHM_x', fwhm_x
-    
+
     # Masking the center, 2*lambda/D is the expected IWA
     if mask:  array = mask_circle(array, radius=fwhm)
-    
+
     # Matched filter
-    if matched_filter:  
+    if matched_filter:
         frame_det = correlate(array, psf)
     else:
         frame_det = array
-    
+
     # Estimation of background level
     _, median, stddev = sigma_clipped_stats(frame_det, sigma=5, iters=None)
     bkg_level = median + (stddev * bkg_sigma)
-    if debug:  
+    if debug:
         print 'Sigma clipped median = {:.3f}'.format(median)
         print 'Sigma clipped stddev = {:.3f}'.format(stddev)
         print 'Background threshold = {:.3f}'.format(bkg_level)
@@ -227,24 +226,24 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
         # Padding the image with zeros to avoid errors at the edges
         pad = 10
         array_padded = np.lib.pad(array, pad, 'constant', constant_values=0)
-        
-    if debug and plot and matched_filter:  
+
+    if debug and plot and matched_filter:
         print 'Input frame after matched filtering:'
         pp_subplots(frame_det, rows=2, colorb=True)
-        
+
     if mode=='lpeaks':
-        # Finding local peaks (can be done in the correlated frame)                                           
-        coords_temp = peak_local_max(frame_det, threshold_abs=bkg_level, 
+        # Finding local peaks (can be done in the correlated frame)
+        coords_temp = peak_local_max(frame_det, threshold_abs=bkg_level,
                                      min_distance=int(np.ceil(fwhm)),
                                      num_peaks=20)
-        coords = check_blobs(array_padded, coords_temp, fwhm, debug)          
+        coords = check_blobs(array_padded, coords_temp, fwhm, debug)
         coords = np.array(coords)
         if verbose and coords.shape[0]>0:  print_coords(coords)
 
     elif mode=='log':
         sigma = fwhm*gaussian_fwhm_to_sigma
-        coords = feature.blob_log(frame_det.astype('float'), 
-                                  threshold=bkg_level, 
+        coords = feature.blob_log(frame_det.astype('float'),
+                                  threshold=bkg_level,
                                   min_sigma=sigma-.5, max_sigma=sigma+.5)
         if len(coords)==0:
             print_abort()
@@ -253,11 +252,11 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
         coords = check_blobs(array_padded, coords, fwhm, debug)
         coords = np.array(coords)
         if coords.shape[0]>0 and verbose:  print_coords(coords)
-     
+
     elif mode=='dog':
         sigma = fwhm*gaussian_fwhm_to_sigma
-        coords = feature.blob_dog(frame_det.astype('float'), 
-                                  threshold=bkg_level, 
+        coords = feature.blob_dog(frame_det.astype('float'),
+                                  threshold=bkg_level,
                                   min_sigma=sigma-.5, max_sigma=sigma+.5)
         if len(coords)==0:
             print_abort()
@@ -266,7 +265,7 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
         coords = check_blobs(array_padded, coords, fwhm, debug)
         coords = np.array(coords)
         if coords.shape[0]>0 and verbose:  print_coords(coords)
-        
+
     else:
         msg = 'Wrong mode. Available modes: lpeaks, log, dog.'
         raise TypeError(msg)
@@ -274,22 +273,22 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
     if coords.shape[0]==0:
         print_abort()
         return 0, 0
-    
+
     yy = coords[:,0]
     xx = coords[:,1]
-    yy_final = [] 
+    yy_final = []
     xx_final = []
     yy_out = []
     xx_out = []
     snr_list = []
     xx -= pad
     yy -= pad
-    
+
     # Checking SNR for potential sources
     for i in range(yy.shape[0]):
         y = yy[i]
         x = xx[i]
-        if verbose: 
+        if verbose:
             print sep
             print 'X,Y = ({:.1f},{:.1f})'.format(x,y)
         subim = get_square(array, size=15, y=y, x=x)
@@ -298,7 +297,7 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
         if snr >= snr_thresh:
             #if plot:
                 #pp_subplots(subim)
-            if verbose:  
+            if verbose:
                 _ = frame_quick_report(array, fwhm, (x,y), verbose=verbose)
             yy_final.append(y)
             xx_final.append(x)
@@ -315,19 +314,19 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
         table = Table([yy.tolist(), xx.tolist(), snr_list],
                       names=('y','x','px_snr'))
         table.sort('px_snr')
-    yy_final = np.array(yy_final) 
-    xx_final = np.array(xx_final) 
-    yy_out = np.array(yy_out) 
-    xx_out = np.array(xx_out) 
-    
-    if plot: 
+    yy_final = np.array(yy_final)
+    xx_final = np.array(xx_final)
+    yy_out = np.array(yy_out)
+    xx_out = np.array(xx_out)
+
+    if plot:
         #print
         #print sep
         #print 'Input frame showing all the detected blobs / potential sources:'
         #print 'In RED circles those that did not pass the SNR and 2dGaussian '
         #print 'fit constraints while in CYAN circles those that passed them.'
         fig, ax = plt.subplots(figsize=(6,6))
-        im = ax.imshow(array, origin='lower', interpolation='nearest', 
+        im = ax.imshow(array, origin='lower', interpolation='nearest',
                        cmap='gray', alpha=0.8)
 
         # Option to plot axes in angular scale
@@ -337,8 +336,8 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
             # Find the middle value in the odd frame sizes
             center_val = int((frame_size / 2.0) + 0.5)
             # Place a tick every 0.5 arcseconds
-            half_num_ticks = center_val // 50       
-            
+            half_num_ticks = center_val // 50
+
             # Calculate the pixel locations at which to put ticks
             ticks = []
             for i in range(half_num_ticks, -half_num_ticks-1, -1):
@@ -374,22 +373,22 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
             colorbar_ax = fig.add_axes([0.92, 0.12, 0.03, 0.78])
             fig.colorbar(im, cax=colorbar_ax)
             ax.grid('off')
-        
+
         for i in range(yy_out.shape[0]):
             y = yy_out[i]
             x = xx_out[i]
             circ = plt.Circle((x, y), radius=fwhm, color='red', fill=False,
                               linewidth=1.5, alpha=0.6)
-            ax.text(x, y+1.5*fwhm, (int(x), int(y)), fontsize=10, color='red', 
-                    family='monospace', ha='center', va='top', weight='bold', 
+            ax.text(x, y+1.5*fwhm, (int(x), int(y)), fontsize=10, color='red',
+                    family='monospace', ha='center', va='top', weight='bold',
                     alpha=0.6)
             ax.add_patch(circ)
         for i in range(yy_final.shape[0]):
             y = yy_final[i]
             x = xx_final[i]
-            circ = plt.Circle((x, y), radius=fwhm, color='cyan', fill=False, 
+            circ = plt.Circle((x, y), radius=fwhm, color='cyan', fill=False,
                               linewidth=2)
-            ax.text(x, y+1.5*fwhm, (int(x), int(y)), fontsize=10, color='cyan', 
+            ax.text(x, y+1.5*fwhm, (int(x), int(y)), fontsize=10, color='cyan',
                     weight='heavy', family='monospace', ha='center', va='top')
             ax.add_patch(circ)
         # Save the plot if output path is provided
@@ -398,40 +397,40 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
             plt.savefig(save_plot, dpi= 100, bbox_inches='tight')
         else:
             plt.show()
-    
+
     if debug:  print table
-    
+
     if full_output:
         return table, yy_final.shape[0]
     else:
         return yy_final, xx_final
 
-    
-def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None, 
+
+def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
                      channels_peak=False):
-    """Find the pixel coordinates of maximum in either a frame or a cube, 
-    after convolution with gaussian. It first applies a gaussian filter, to 
-    lower the probability of returning a hot pixel (although it may still 
-    happen with clumps of hot pixels, hence the need for function 
+    """Find the pixel coordinates of maximum in either a frame or a cube,
+    after convolution with gaussian. It first applies a gaussian filter, to
+    lower the probability of returning a hot pixel (although it may still
+    happen with clumps of hot pixels, hence the need for function
     "approx_stellar_position").
-    
+
     Parameters
     ----------
     obj_tmp : cube_like or frame_like
         Input 3d cube or image.
     fwhm : float_like
-        Input full width half maximum value of the PSF in pixels. This will be 
-        used as the standard deviation for Gaussian kernel of the Gaussian 
+        Input full width half maximum value of the PSF in pixels. This will be
+        used as the standard deviation for Gaussian kernel of the Gaussian
         filtering.
     approx_peak: 2 components list or array, opt
         Gives the approximate coordinates of the peak.
     search_box: float or 2 components list or array, opt
-        Gives the half-size in pixels of a box in which the peak is searched, 
-        around approx_peak. If float, it is assumed the same box size is wanted 
-        in both y and x. Note that this parameter should be provided if 
+        Gives the half-size in pixels of a box in which the peak is searched,
+        around approx_peak. If float, it is assumed the same box size is wanted
+        in both y and x. Note that this parameter should be provided if
         approx_peak is provided.
     channels_peak: bool, {False, True}, opt
-        Whether returns the indices of the peak in each channel in addition to 
+        Whether returns the indices of the peak in each channel in addition to
         the global indices of the peak in the cube. If True, it would hence also
         return two 1d-arrays. (note: only available if the input is a 3d cube)
 
@@ -439,12 +438,12 @@ def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
     -------
     zz_max, yy_max, xx_max : integers
         Indices of highest throughput channel
-    
+
     """
 
     ndims = len(obj_tmp.shape)
     assert ndims == 2 or ndims == 3, "Array is not two or three dimensional"
-    
+
     if approx_peak is not None:
         assert len(approx_peak) == 2, "Approx peak is not two dimensional"
         if isinstance(search_box,float) or isinstance(search_box,int):
@@ -461,10 +460,10 @@ def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
             sbox = np.zeros([n_z,2*sbox_y+1,2*sbox_x+1])
 
     if ndims == 2:
-        gauss_filt_tmp = frame_filter_gaussian2d(obj_tmp, 
+        gauss_filt_tmp = frame_filter_gaussian2d(obj_tmp,
                                             fwhm/gaussian_sigma_to_fwhm)
         if approx_peak is None:
-            ind_max = np.unravel_index(gauss_filt_tmp.argmax(), 
+            ind_max = np.unravel_index(gauss_filt_tmp.argmax(),
                                        gauss_filt_tmp.shape)
         else:
             sbox = gauss_filt_tmp[approx_peak[0]-sbox_y:approx_peak[0]+sbox_y+1,
@@ -481,26 +480,26 @@ def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
         ind_ch_max = np.zeros([n_z,2])
 
         for zz in range(n_z):
-            gauss_filt_tmp[zz] = frame_filter_gaussian2d(obj_tmp[zz], 
+            gauss_filt_tmp[zz] = frame_filter_gaussian2d(obj_tmp[zz],
                                                     fwhm[zz]/gaussian_sigma_to_fwhm)
             if approx_peak is None:
-                ind_ch_max[zz] = np.unravel_index(gauss_filt_tmp[zz].argmax(), 
+                ind_ch_max[zz] = np.unravel_index(gauss_filt_tmp[zz].argmax(),
                                                   gauss_filt_tmp[zz].shape)
             else:
                 sbox[zz] = gauss_filt_tmp[zz, approx_peak[0]-sbox_y:\
                                           approx_peak[0]+sbox_y+1,
                                           approx_peak[1]-sbox_x:\
                                           approx_peak[1]+sbox_x+1]
-                ind_max_sbox = np.unravel_index(sbox[zz].argmax(), 
+                ind_max_sbox = np.unravel_index(sbox[zz].argmax(),
                                                 sbox[zz].shape)
                 ind_ch_max[zz] = (approx_peak[0]-sbox_y+ind_max_sbox[0],
                                   approx_peak[1]-sbox_x+ind_max_sbox[1])
 
         if approx_peak is None:
-            ind_max = np.unravel_index(gauss_filt_tmp.argmax(), 
+            ind_max = np.unravel_index(gauss_filt_tmp.argmax(),
                                        gauss_filt_tmp.shape)
         else:
-            ind_max_tmp = np.unravel_index(sbox.argmax(), 
+            ind_max_tmp = np.unravel_index(sbox.argmax(),
                                            sbox.shape)
             ind_max = (ind_max_tmp[0]+approx_peak[0]-sbox_y,
                        ind_max_tmp[1]+approx_peak[1]-sbox_x)
@@ -511,10 +510,10 @@ def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
             return ind_max
 
 
-def mask_source_centers(array, fwhm, y, x):                                                  
+def mask_source_centers(array, fwhm, y, x):
     """ Creates a mask of ones with the size of the input frame and zeros at
     the center of the sources (planets) with coordinates x, y.
-    
+
     Parameters
     ----------
     array : array_like
@@ -523,16 +522,16 @@ def mask_source_centers(array, fwhm, y, x):
         Size in pixels of the FWHM.
     y, x : tuples of int
         Coordinates of the center of the sources.
-        
+
     Returns
     -------
     mask : array_like
         Mask frame.
-    
+
     """
     if not array.ndim==2:
         raise TypeError('Wrong input array shape.')
-    
+
     frame = array.copy()
     if not y and x:
         frame = mask_circle(frame, radius=2*fwhm)
@@ -541,7 +540,7 @@ def mask_source_centers(array, fwhm, y, x):
         yy = np.array(y); xx = np.array(x)
     mask = np.ones_like(array)
     # center sources become zeros
-    mask[yy.astype('int'), xx.astype('int')] = 0                                 
+    mask[yy.astype('int'), xx.astype('int')] = 0
     return mask
 
 

--- a/vip/phot/snr.py
+++ b/vip/phot/snr.py
@@ -157,7 +157,7 @@ def snrmap(array, fwhm, plot=False, mode='sss', source_mask=None, nproc=None,
 
     # Option to save snrmap in angular scale, using Keck NIRC2's ~0.01 pixel scale
     # In this case, set plot = False
-    elif save_plot!=None:
+    elif save_plot is not None:
         pp_subplots(snrmap, colorb=True, title=plot_title, save=save_plot,
                     vmin=-1, vmax=5, angscale=True)
         

--- a/vip/preproc/badpixremoval.py
+++ b/vip/preproc/badpixremoval.py
@@ -683,7 +683,7 @@ def find_outliers(frame, sig_dist, in_bpix=None, stddev=None,neighbor_box=3,
     nx = frame.shape[1]
     ny = frame.shape[0]
     bpix_map = np.zeros_like(frame)
-    if stddev == None: stddev = np.std(frame)
+    if stddev is None: stddev = np.std(frame)
     half_box = int(np.floor(neighbor_box/2.))
     
     if in_bpix is None:
@@ -827,7 +827,7 @@ def reject_outliers(data, test_value, m=5., stddev=None, DEBUG=False,
         0 if test_value is not an outlier. 1 otherwise. 
     """
 
-    if stddev == None: stddev = np.std(data)
+    if stddev is None: stddev = np.std(data)
     if min_thr is None:
         min_thr = min(np.amin(data),test_value)-1
     if mid_thr is None:

--- a/vip/preproc/parangles.py
+++ b/vip/preproc/parangles.py
@@ -189,7 +189,7 @@ def compute_derot_angles_PA(objname_tmp_A,digit_format=3,objname_tmp_B='',
             print ii, ' -> ', rot[ii]
 
     if writing:
-        if outpath == '' or outpath == None: outpath=inpath
+        if outpath == '' or outpath is None: outpath=inpath
         f=open(outpath+'Parallactic_angles.txt','w')
         for ii in range(len(list_obj)):
             print >>f, rot[ii]
@@ -334,7 +334,7 @@ def compute_derot_angles_CD(objname_tmp_A, digit_format=3,objname_tmp_B='',
             if skew: print 'rot2: ', ii, ' -> ', rot2[ii]
 
     if writing:
-        if outpath == '' or outpath == None: outpath=inpath
+        if outpath == '' or outpath is None: outpath=inpath
         f=open(outpath+'Parallactic_angles.txt','w')
         if skew:
             for ii in range(len(cd1_1)):


### PR DESCRIPTION
My machine returns an error when e.g. an array is checked for None type using equality instead of "is". i.e. array==None returns an array of True/False values, which doesn't work in "if" statements (asks for "any" or "all"). It seems like the PEP recommendation for NoneType checking is to use "is" rather than equality. So, I changed the few cases of this. https://www.python.org/dev/peps/pep-0008/#programming-recommendations

Other small change: handle output from the changed fit_2dgaussian in VIP 0.7.5 correctly.