### PR TITLE
Small fixes

### DIFF
--- a/vip/pca/pca_fullfr.py
+++ b/vip/pca/pca_fullfr.py
@@ -838,9 +838,9 @@ def pca_optimize_snr(cube, angle_list, (source_xy), fwhm, cube_ref=None,
             ax2.grid('on', 'major', linestyle='solid', alpha=0.2)
             #plt.savefig('figure.pdf', dpi=300, bbox_inches='tight')
             print()
-            # Optionally, save the contrast curve
-            if save_plot != None:
-                plt.savefig(save_plot, dpi=100, bbox_inches='tight')
+    # Optionally, save the contrast curve
+    if save_plot != None:
+        plt.savefig(save_plot, dpi=100, bbox_inches='tight')
 
     if mode == 'fullfr':
         finalfr = pca(cube, angle_list, cube_ref=cube_ref, ncomp=opt_npc,

--- a/vip/pca/pca_fullfr.py
+++ b/vip/pca/pca_fullfr.py
@@ -770,12 +770,12 @@ def pca_optimize_snr(cube, angle_list, (source_xy), fwhm, cube_ref=None,
     # automatic "clever" grid
     else:
         grid1 = grid(matrix, angle_list, y, x, mode, V, fwhm, fmerit, 
-                     int(pcmax*0.1), pcmin, pcmax, debug, full_output)
+                     max(int(pcmax*0.1),1), pcmin, pcmax, debug, full_output)
         if full_output:  argm, pclist, snrlist, fluxlist, frlist1 = grid1
         else:  argm, pclist, snrlist, fluxlist = grid1
         
         grid2 = grid(matrix, angle_list, y, x, mode, V, fwhm, fmerit, 
-                     int(pcmax*0.05), pclist[argm-1], pclist[argm+1], debug, 
+                     max(int(pcmax*0.05),1), pclist[argm-1], pclist[argm+1], debug, 
                      full_output)
         if full_output:  argm2, pclist2, snrlist2, fluxlist2, frlist2 = grid2
         else:  argm2, pclist2, snrlist2, fluxlist2  = grid2
@@ -791,7 +791,7 @@ def pca_optimize_snr(cube, angle_list, (source_xy), fwhm, cube_ref=None,
         dfr = pd.DataFrame(np.array((pclist+pclist2+pclist3, 
                                      snrlist+snrlist2+snrlist3,
                                      fluxlist+fluxlist2+fluxlist3)).T)  
-        dfrs = dfr.sort(columns=0)
+        dfrs = dfr.sort_values(0)
         dfrsrd = dfrs.drop_duplicates()
         ind = np.array(dfrsrd.index)    
         

--- a/vip/phot/detection.py
+++ b/vip/phot/detection.py
@@ -193,10 +193,11 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
     if not psf.ndim == 2 and psf.shape[0] < array.shape[0]:
         raise TypeError('Input psf is not a 2d array or has wrong size')
     
-    # Getting the FWHM from the PSF array
-    _,_,fwhm_y, fwhm_x,_,_ = fit_2dgaussian(psf, cent=(frame_center(psf)[1],
-                                                       frame_center(psf)[0]), 
-                                            debug=debug, full_output=True)    
+    # Getting the FWHM from the PSF array    
+    outdf = fit_2dgaussian(psf, cent=(frame_center(psf)[1],
+                                                       frame_center(psf)[0]),
+                                            debug=debug, full_output=True)
+    fwhm_x, fwhm_y = outdf.at[0,'fwhm_x'],outdf.at[0,'fwhm_y']
     fwhm = np.mean([fwhm_x, fwhm_y])
     if verbose:  
         print 'FWHM =', fwhm

--- a/vip/phot/snr.py
+++ b/vip/phot/snr.py
@@ -159,7 +159,7 @@ def snrmap(array, fwhm, plot=False, mode='sss', source_mask=None, nproc=None,
     # In this case, set plot = False
     elif save_plot!=None:
         pp_subplots(snrmap, colorb=True, title=plot_title, save=save_plot,
-                    vmin=-1, vmax=5, angscale=True)
+                    vmin=-1, vmax=5, angscale=True, getfig = True)
         
     print "S/N map created using {:} processes.".format(nproc)
     timing(start_time)


### PR DESCRIPTION
1) Updated the old pandas sort() function to sort_values() in pca_fullfr.py. This function was changed back in pandas version 0.17.0: http://pandas.pydata.org/pandas-docs/version/0.19.2/generated/pandas.DataFrame.sort_values.html#pandas.DataFrame.sort_values
2) In snr.py added paramater getfig = True in the snrmap function to suppress show() in pp_subplots(). This is to expedite reduction process for the pipeline.
3) Added precaution to avoid the step param in grid() from being zero in pca_fullfr.py
4) The fit_2dgaussian function was changed to output a pandas dataframe, when full_output = True. Must use 1 variable to catch the dataframe, instead of 6 variables.
5) Unindented lines in vip/pca/pca_fullfr, where the opt_pc plot is saved. Those lines were wrongly indented so it only saves for the clever grid, not the manual grid.