### PR TITLE
More outputs from contrast_curve

### DIFF
--- a/vip/negfc/simplex_optim.py
+++ b/vip/negfc/simplex_optim.py
@@ -291,6 +291,7 @@ def firstguess(cube, angs, psfn, ncomp, plsc, planets_xy_coord, fwhm=4,
     -------
     out : The radial coordinates and the flux of the companion.
 
+    WARNING: POLAR ANGLE IS NOT THE CONVENTIONAL NORTH-TO-EAST P.A.
     """
     if verbose:  start_time = time_ini()
 


### PR DESCRIPTION
Added an full_output option to the contrast_curve function that also returns the processed images with and without the injected companions. This should not interfere with current usage. full_output=False by default. Setting full_output=True returns a list of additional arrays. 