### PR TITLE
v0.8.3: Fixed the companion injection for ADI+IFS case

### DIFF
--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -60,7 +60,7 @@ If you are new to the Jupyter notebook application check out the `beginner guide
 <https://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/what_is_jupyter.html>`_.
 
 
-TL;DR Guide
+TL;DR setup guide
 -----------------
 .. code-block:: bash
 

--- a/readme.rst
+++ b/readme.rst
@@ -60,7 +60,7 @@ If you are new to the Jupyter notebook application check out the `beginner guide
 <https://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/what_is_jupyter.html>`_.
 
 
-TL;DR Guide
+TL;DR setup guide
 -----------------
 .. code-block:: bash
 

--- a/vip_hci/__init__.py
+++ b/vip_hci/__init__.py
@@ -12,7 +12,7 @@ from . import phot
 from . import stats
 from . import var
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 
 print("---------------------------------------------------")

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -26,7 +26,7 @@ from matplotlib.ticker import MaxNLocator
 from matplotlib.mlab import normpdf
 from scipy.stats import norm
 from ..fits import open_adicube, open_fits
-from ..phot import inject_fcs_cube
+from ..phot import cube_inject_companions
 from ..conf import time_ini, timing, sep
 from .simplex_fmerit import get_values_optimize
 import warnings
@@ -126,9 +126,9 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
         
     """    
     # Create the cube with the negative fake companion injected
-    cube_negfc = inject_fcs_cube(cube, psf_norm, angs, flevel=-param[2],
-                                 plsc=plsc, rad_dists=[param[0]], n_branches=1,
-                                 theta=param[1], verbose=False, imlib='opencv')
+    cube_negfc = cube_inject_companions(cube, psf_norm, angs, flevel=-param[2],
+                                        plsc=plsc, rad_dists=[param[0]], n_branches=1,
+                                        theta=param[1], verbose=False, imlib='opencv')
                                   
     # Perform PCA and extract the zone of interest
     values = get_values_optimize(cube_negfc,angs,ncomp,annulus_width*fwhm,

--- a/vip_hci/negfc/simplex_fmerit.py
+++ b/vip_hci/negfc/simplex_fmerit.py
@@ -7,7 +7,7 @@ from __future__ import print_function
 
 import numpy as np
 from skimage.draw import circle
-from ..phot import inject_fcs_cube
+from ..phot import cube_inject_companions
 from ..var import frame_center
 from ..pca import pca_annulus
 
@@ -72,9 +72,9 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
         print('paraVector must be a tuple, {} was given'.format(type(modelParameters)))
 
     # Create the cube with the negative fake companion injected
-    cube_negfc = inject_fcs_cube(cube, psfs_norm, angs, flevel=-flux, 
-                                 plsc=plsc, rad_dists=[r], n_branches=1, 
-                                 theta=theta, verbose=False)       
+    cube_negfc = cube_inject_companions(cube, psfs_norm, angs, flevel=-flux,
+                                        plsc=plsc, rad_dists=[r], n_branches=1,
+                                        theta=theta, verbose=False)       
                                       
     # Perform PCA and extract the zone of interest
     values = get_values_optimize(cube_negfc, angs, ncomp, annulus_width*fwhm,

--- a/vip_hci/negfc/utils_negfc.py
+++ b/vip_hci/negfc/utils_negfc.py
@@ -8,7 +8,7 @@ algorithm.
 __all__ = ['cube_planet_free']
 
 import numpy as np
-from ..phot import inject_fcs_cube
+from ..phot import cube_inject_companions
 import math
 from matplotlib.pyplot import plot, xlim, ylim, hold, axes, gca, show
 
@@ -48,11 +48,11 @@ def cube_planet_free(planet_parameter, cube, angs, psfn, plsc):
         else:
             cube_temp = cpf
 
-        cpf = inject_fcs_cube(cube_temp, psfn, angs,
-                              flevel=-planet_parameter[i, 2],
-                              plsc=plsc, rad_dists=[planet_parameter[i, 0]],
-                              n_branches=1, theta=planet_parameter[i, 1],
-                              verbose=False)
+        cpf = cube_inject_companions(cube_temp, psfn, angs,
+                                     flevel=-planet_parameter[i, 2],
+                                     plsc=plsc, rad_dists=[planet_parameter[i, 0]],
+                                     n_branches=1, theta=planet_parameter[i, 1],
+                                     verbose=False)
     return cpf
 
 

--- a/vip_hci/pca/pca_fullfr.py
+++ b/vip_hci/pca/pca_fullfr.py
@@ -278,7 +278,7 @@ def pca(cube, angle_list=None, cube_ref=None, scale_list=None, ncomp=1, ncomp2=1
     #***************************************************************************
     if scale_list is not None:
         if ncomp > z:
-            ncomp = min(10, z)
+            ncomp = min(ncomp, z)
             msg = 'Number of PCs too high (max PCs={}), using instead {:} PCs.'
             print(msg.format(z, ncomp))
         scale_list = check_scal_vector(scale_list)
@@ -350,8 +350,8 @@ def pca(cube, angle_list=None, cube_ref=None, scale_list=None, ncomp=1, ncomp2=1
                 bar.update()
             
             # de-rotation of the PCA processed channels
-            if ncomp2 > n:
-                ncomp2 = min(10, n)
+            if ncomp2 > z:
+                ncomp2 = min(ncomp2, z)
                 msg = 'Number of PCs too high (max PCs={}), using instead {:} PCs.'
                 print(msg.format(n, ncomp2))
 

--- a/vip_hci/phot/contrcurve.py
+++ b/vip_hci/phot/contrcurve.py
@@ -21,7 +21,7 @@ from scipy import stats
 from scipy.signal import savgol_filter
 from skimage.draw import circle
 from matplotlib import pyplot as plt
-from .fakecomp import inject_fcs_cube, inject_fc_frame, psf_norm
+from .fakecomp import cube_inject_companions, frame_inject_companion, psf_norm
 from ..conf import time_ini, timing, sep
 from ..var import frame_center, dist
 
@@ -297,8 +297,8 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
                 pca_type = 'ADI'
             else:
                 pca_type = 'RDI'
-            plt.title(pca_type+' '+object_name+' '+str(ncomp)+'pc '+str(frame_size)+'+'+str(inner_rad),
-                      fontsize = 14)
+            title = pca_type + ' ' + object_name + ' ' + str(ncomp) + 'pc ' + str(frame_size) + '+' + str(inner_rad)
+            plt.title(title, fontsize = 14)
 
         # Option to fix the y-limit
         if len(fix_y_lim) == 2:
@@ -510,13 +510,13 @@ def throughput(cube, angle_list, psf_template, fwhm, pxscale, algo, nbranch=1,
             fcy = []; fcx = []
             for i in range(radvec.shape[0]):
                 flux = snr_level[irad+i*fc_rad_sep] * noise[irad+i*fc_rad_sep]
-                cube_fc = inject_fcs_cube(cube_fc, psf_template, parangles, flux,
-                                          pxscale, rad_dists=[radvec[i]],
-                                          theta=br*angle_branch + theta, imlib=imlib,
-                                          verbose=False)
+                cube_fc = cube_inject_companions(cube_fc, psf_template, parangles, flux,
+                                                 pxscale, rad_dists=[radvec[i]],
+                                                 theta=br*angle_branch + theta, imlib=imlib,
+                                                 verbose=False)
                 y = cy + radvec[i] * np.sin(np.deg2rad(br*angle_branch + theta))
                 x = cx + radvec[i] * np.cos(np.deg2rad(br*angle_branch + theta))
-                fc_map = inject_fc_frame(fc_map, psf_template, y, x, flux)
+                fc_map = frame_inject_companion(fc_map, psf_template, y, x, flux)
                 fcy.append(y); fcx.append(x)
 
             if verbose:


### PR DESCRIPTION
Renamed functions ``inject_fcs_cube`` to ``cube_inject_companions`` and ``inject_fc_frame`` to ``frame_inject_companion`` (to be consistent with the naming conventions in VIP). Aliases were created not to brake old code that relies on VIP (the aliases will be removed in a later version of VIP).