### PR TITLE
VIP v0.8.5

### DIFF
--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -34,15 +34,15 @@ the interested scientific community. The main repository of ``VIP`` resides on
 `Github <https://github.com/vortex-exoplanet/VIP>`_, the standard for scientific
 open source code distribution, using Git as a version control system.
 
-``VIP`` started as the effort of a `PhD student <https://github.com/carlgogo/>`_
-within the `VORTEX team <http://www.vortex.ulg.ac.be/>`_ (Liege, Belgium). It is
-currently developed by collaborators from several institutes/teams. The tab
-contributors on ``VIP``'s Github repo shows the direct contributions to the code.
-Most of ``VIP``'s functionalities are mature but it doesn't mean it's free from
-bugs. The code is continuously evolving and therefore feedback/contributions are
-greatly appreciated. If you want to report a bug, suggest or add a functionality
-please create an issue or send a pull request on
-`the repository <https://github.com/vortex-exoplanet/VIP>`_.
+``VIP`` started as the effort of `Carlos Alberto Gomez Gonzalez <https://carlgogo.github.io/>`_,
+a former PhD student within the `VORTEX team <http://www.vortex.ulg.ac.be/>`_
+(Liege, Belgium). ``VIP``'s development is led by C. Gomez with contributions
+made by collaborator from several teams (take a look at the tab contributors on
+``VIP``'s Github repository). Most of ``VIP``'s functionalities are mature but
+it doesn't mean it's free from bugs. The code is continuously evolving and
+therefore feedback/contributions are greatly appreciated. If you want to report
+a bug, suggest or add a functionality please create an issue or send a pull
+request on `this repository <https://github.com/vortex-exoplanet/VIP>`_.
 
 
 Documentation

--- a/readme.rst
+++ b/readme.rst
@@ -34,15 +34,15 @@ the interested scientific community. The main repository of ``VIP`` resides on
 `Github <https://github.com/vortex-exoplanet/VIP>`_, the standard for scientific
 open source code distribution, using Git as a version control system.
 
-``VIP`` started as the effort of a `PhD student <https://github.com/carlgogo/>`_
-within the `VORTEX team <http://www.vortex.ulg.ac.be/>`_ (Liege, Belgium). It is
-currently developed by collaborators from several institutes/teams. The tab
-contributors on ``VIP``'s Github repo shows the direct contributions to the code.
-Most of ``VIP``'s functionalities are mature but it doesn't mean it's free from
-bugs. The code is continuously evolving and therefore feedback/contributions are
-greatly appreciated. If you want to report a bug, suggest or add a functionality
-please create an issue or send a pull request on
-`the repository <https://github.com/vortex-exoplanet/VIP>`_.
+``VIP`` started as the effort of `Carlos Alberto Gomez Gonzalez <https://carlgogo.github.io/>`_,
+a former PhD student within the `VORTEX team <http://www.vortex.ulg.ac.be/>`_
+(Liege, Belgium). ``VIP``'s development is led by C. Gomez with contributions
+made by collaborator from several teams (take a look at the tab contributors on
+``VIP``'s Github repository). Most of ``VIP``'s functionalities are mature but
+it doesn't mean it's free from bugs. The code is continuously evolving and
+therefore feedback/contributions are greatly appreciated. If you want to report
+a bug, suggest or add a functionality please create an issue or send a pull
+request on `this repository <https://github.com/vortex-exoplanet/VIP>`_.
 
 
 Documentation

--- a/vip_hci/__init__.py
+++ b/vip_hci/__init__.py
@@ -12,7 +12,7 @@ from . import phot
 from . import stats
 from . import var
 
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 
 
 print("---------------------------------------------------")

--- a/vip_hci/conf/mem.py
+++ b/vip_hci/conf/mem.py
@@ -5,7 +5,7 @@ Module for functions that check available memory, and input sizes.
 """
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['check_enough_memory',
            'get_available_memory']
 

--- a/vip_hci/conf/timing.py
+++ b/vip_hci/conf/timing.py
@@ -4,7 +4,7 @@
 Functions for timing other functions/procedures.
 """
 from __future__ import print_function
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['time_ini', 'timing', 'time_fin']
 
 from datetime import datetime

--- a/vip_hci/conf/utils_conf.py
+++ b/vip_hci/conf/utils_conf.py
@@ -7,7 +7,7 @@ Module with utilities.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['eval_func_tuple', 'redirect_output', 'sep']
 
 import sys

--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -5,7 +5,7 @@ Module with various fits handling functions.
 """
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['open_fits',
            'open_adicube',
            'info_fits',

--- a/vip_hci/llsg/llsg.py
+++ b/vip_hci/llsg/llsg.py
@@ -6,7 +6,7 @@ LLSG (Gomez Gonzalez et al. 2016)
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['llsg']
 
 import numpy as np
@@ -26,8 +26,9 @@ from ..conf import eval_func_tuple as EFT
 
 def llsg(cube, angle_list, fwhm, rank=10, thresh=1, max_iter=10, 
          low_rank_mode='svd', thresh_mode='soft', nproc=1, radius_int=None, 
-         random_seed=None, collapse='median', low_pass=False, full_output=False, 
-         verbose=True, debug=False):
+         random_seed=None, imlib='opencv', interpolation='lanczos4',
+         collapse='median', low_pass=False, full_output=False, verbose=True,
+         debug=False):
     """ 
     Local Low-rank plus Sparse plus Gaussian-noise decomposition (LLSG) as 
     described in Gomez Gonzalez et al. 2016. This first version of our algorithm 
@@ -67,7 +68,11 @@ def llsg(cube, angle_list, fwhm, rank=10, thresh=1, max_iter=10,
         The radius of the innermost annulus. By default is 0, if >0 then the 
         central circular area is discarded.
     random_seed : int or None, optional
-        Controls the seed for the Pseudo Random Number generator. 
+        Controls the seed for the Pseudo Random Number generator.
+    imlib : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    interpolation : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
     collapse : {'median', 'mean', 'sum', 'trimmean'}, str optional
         Sets the way of collapsing the frames for producing a final image.  
     low_pass : {False, True}, bool optional
@@ -163,11 +168,14 @@ def llsg(cube, angle_list, fwhm, rank=10, thresh=1, max_iter=10,
                     matrix_final_s[:, yy[q], xx[q]] = patch[q]
         
     if full_output:       
-        S_array_der = cube_derotate(matrix_final_s, angle_list)
+        S_array_der = cube_derotate(matrix_final_s, angle_list, imlib=imlib,
+                                    interpolation=interpolation)
         frame_s = cube_collapse(S_array_der, mode=collapse)
-        L_array_der = cube_derotate(matrix_final_l, angle_list)
+        L_array_der = cube_derotate(matrix_final_l, angle_list, imlib=imlib,
+                                    interpolation=interpolation)
         frame_l = cube_collapse(L_array_der, mode=collapse)
-        G_array_der = cube_derotate(matrix_final_g, angle_list)
+        G_array_der = cube_derotate(matrix_final_g, angle_list, imlib=imlib,
+                                    interpolation=interpolation)
         frame_g = cube_collapse(G_array_der, mode=collapse)
     else:
         S_array_der = cube_derotate(matrix_final_s, angle_list)              
@@ -183,7 +191,6 @@ def llsg(cube, angle_list, fwhm, rank=10, thresh=1, max_iter=10,
         else:
             return frame_s
     
-
 
 def patch_rlrps(array, rank, low_rank_mode, thresh, thresh_mode, max_iter, 
                 random_seed, debug=False, full_output=False):

--- a/vip_hci/llsg/thresholding.py
+++ b/vip_hci/llsg/thresholding.py
@@ -5,7 +5,7 @@
 
 from __future__ import division
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['thresholding']
 
 import numpy as np

--- a/vip_hci/madi/adi_source.py
+++ b/vip_hci/madi/adi_source.py
@@ -8,7 +8,7 @@ Carlos A. Gomez / ULg
 from __future__ import division 
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['adi']
 
 import numpy as np
@@ -19,8 +19,8 @@ from ..pca.pca_local import define_annuli
 
 
 def adi(cube, angle_list, fwhm=4, radius_int=0, asize=2, delta_rot=1, 
-        mode='fullfr', nframes=4, collapse='median', full_output=False, 
-        verbose=True):
+        mode='fullfr', nframes=4, imlib='opencv', interpolation='lanczos4',
+        collapse='median', full_output=False, verbose=True):
     """ Algorithm based on Marois et al. 2006 on Angular Differential Imaging.   
     First the median frame is subtracted, then the median of the four closest 
     frames taking into account the pa_threshold (field rotation).
@@ -47,7 +47,11 @@ def adi(cube, angle_list, fwhm=4, radius_int=0, asize=2, delta_rot=1,
         subtracted.
     nframes : even int optional
         Number of frames to be used for building the optimized reference PSF 
-        when working in annular mode. 
+        when working in annular mode.
+    imlib : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    interpolation : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
     collapse : {'median', 'mean', 'sum', 'trimmean'}, str optional
         Sets the way of collapsing the frames for producing a final image.
     full_output: boolean, optional
@@ -172,7 +176,8 @@ def adi(cube, angle_list, fwhm=4, radius_int=0, asize=2, delta_rot=1,
     else:
         raise RuntimeError('Mode not recognized')
     
-    cube_der = cube_derotate(cube_out, angle_list)
+    cube_der = cube_derotate(cube_out, angle_list, imlib=imlib,
+                             interpolation=interpolation)
     frame = cube_collapse(cube_der, mode=collapse)
     if verbose:
         print('Done derotating and combining')

--- a/vip_hci/negfc/nested_sampling.py
+++ b/vip_hci/negfc/nested_sampling.py
@@ -7,7 +7,7 @@ nested sampling (``nestle``).
 
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg',
+__author__ = 'Carlos Alberto Gomez Gonzalez',
 __all__ = ['nested_negfc_sampling',
            'nested_sampling_results']
 

--- a/vip_hci/negfc/utils_negfc.py
+++ b/vip_hci/negfc/utils_negfc.py
@@ -13,7 +13,8 @@ import math
 from matplotlib.pyplot import plot, xlim, ylim, hold, axes, gca, show
 
 
-def cube_planet_free(planet_parameter, cube, angs, psfn, plsc):
+def cube_planet_free(planet_parameter, cube, angs, psfn, plsc, imlib='opencv',
+                     interpolation='lanczos4'):
     """
     Return a cube in which we have injected negative fake companion at the
     position/flux given by planet_parameter.
@@ -30,6 +31,10 @@ def cube_planet_free(planet_parameter, cube, angs, psfn, plsc):
         The scaled psf expressed as a numpy.array.
     plsc: float
         The platescale, in arcsec per pixel.
+    imlib : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    interpolation : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
 
     Returns
     -------
@@ -52,6 +57,7 @@ def cube_planet_free(planet_parameter, cube, angs, psfn, plsc):
                                      flevel=-planet_parameter[i, 2],
                                      plsc=plsc, rad_dists=[planet_parameter[i, 0]],
                                      n_branches=1, theta=planet_parameter[i, 1],
+                                     imlib=imlib, interpolation=interpolation,
                                      verbose=False)
     return cpf
 

--- a/vip_hci/nmf/nmf_fullfr.py
+++ b/vip_hci/nmf/nmf_fullfr.py
@@ -7,7 +7,7 @@ Module with NMF algorithm for ADI.
 from __future__ import division 
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['nmf']
 
 import numpy as np
@@ -18,8 +18,9 @@ from ..conf import timing, time_ini
 
 
 def nmf(cube, angle_list, cube_ref=None, ncomp=1, scaling=None, max_iter=100,
-        random_state=None, mask_center_px=None, full_output=False, verbose=True, 
-        **kwargs):
+        random_state=None, mask_center_px=None, imlib='opencv',
+        interpolation='lanczos4', collapse='median', full_output=False,
+        verbose=True, **kwargs):
     """ Non Negative Matrix Factorization for ADI sequences. Alternative to the
     full-frame ADI-PCA processing that does not rely on SVD or ED for obtaining
     a low-rank approximation of the datacube. This function embeds the 
@@ -49,7 +50,13 @@ def nmf(cube, angle_list, cube_ref=None, ncomp=1, scaling=None, max_iter=100,
         Controls the seed for the Pseudo Random Number generator.
     mask_center_px : None or int
         If None, no masking is done. If an integer > 1 then this value is the
-        radius of the circular mask. 
+        radius of the circular mask.
+    imlib : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    interpolation : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    collapse : {'median', 'mean', 'sum', 'trimmean'}, str optional
+        Sets the way of collapsing the frames for producing a final image.
     full_output: boolean, optional
         Whether to return the final median combined image only or with other 
         intermediate arrays.  
@@ -99,8 +106,9 @@ def nmf(cube, angle_list, cube_ref=None, ncomp=1, scaling=None, max_iter=100,
     for i in range(n):
         array_out[i] = residuals[i].reshape(y,x)
             
-    array_der = cube_derotate(array_out, angle_list) 
-    frame = cube_collapse(array_der, 'median') 
+    array_der = cube_derotate(array_out, angle_list, imlib=imlib,
+                              interpolation=interpolation)
+    frame = cube_collapse(array_der, mode=collapse)
     
     if verbose:  
         print('Done derotating and combining.')

--- a/vip_hci/pca/pca_local.py
+++ b/vip_hci/pca/pca_local.py
@@ -6,7 +6,7 @@ Module with local smart pca (annulus-wise) serial and parallel implementations.
 
 from __future__ import division, print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['pca_adi_annular',
            'pca_rdi_annular']
 
@@ -26,7 +26,8 @@ from ..stats import descriptive_stats
 
 def pca_rdi_annular(cube, angle_list, cube_ref, radius_int=0, asize=1, 
                     ncomp=1, svd_mode='randsvd', min_corr=0.9, fwhm=4, 
-                    scaling='temp-standard', collapse='median', 
+                    scaling='temp-standard', imlib='opencv',
+                    interpolation='lanczos4', collapse='median',
                     full_output=False, verbose=True, debug=False):
     """ Annular PCA with Reference Library + Correlation + standardization
     
@@ -76,7 +77,11 @@ def pca_rdi_annular(cube, angle_list, cube_ref, radius_int=0, asize=1,
         "spat-mean" then the spatial mean is subtracted, with "temp-standard" 
         temporal mean centering plus scaling to unit variance is done and with
         "spat-standard" spatial mean centering plus scaling to unit variance is
-        performed.  
+        performed.
+    imlib : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    interpolation : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
     collapse : {'median', 'mean', 'sum', 'trimmean'}, str optional
         Sets the way of collapsing the frames for producing a final image.
     full_output: boolean, optional
@@ -188,7 +193,8 @@ def pca_rdi_annular(cube, angle_list, cube_ref, radius_int=0, asize=1,
             print('Done PCA with {:} for current annulus'.format(svd_mode))
             timing(start_time)      
          
-    cube_der = cube_derotate(cube_out, angle_list)
+    cube_der = cube_derotate(cube_out, angle_list, imlib=imlib,
+                             interpolation=interpolation)
     frame = cube_collapse(cube_der, mode=collapse)
     if verbose:
         print('Done derotating and combining.')
@@ -202,8 +208,8 @@ def pca_rdi_annular(cube, angle_list, cube_ref, radius_int=0, asize=1,
 def pca_adi_annular(cube, angle_list, radius_int=0, fwhm=4, asize=3, 
                     delta_rot=1, ncomp=1, svd_mode='randsvd', nproc=1,
                     min_frames_pca=10, tol=1e-1, scaling=None, quad=False,
-                    collapse='median', full_output=False, verbose=True, 
-                    debug=False):
+                    imlib='opencv', interpolation='lanczos4', collapse='median',
+                    full_output=False, verbose=True, debug=False):
     """ Annular (smart) ADI PCA. The PCA model is computed locally in each
     annulus (optionally quadrants of each annulus). For each annulus we discard
     reference images taking into account a parallactic angle threshold
@@ -276,6 +282,10 @@ def pca_adi_annular(cube, angle_list, radius_int=0, fwhm=4, asize=3,
     quad : {False, True}, bool optional
         If False the images are processed in annular fashion. If True, quadrants
         of annulus are used instead.
+    imlib : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    interpolation : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
     collapse : {'median', 'mean', 'sum', 'trimmean'}, str optional
         Sets the way of collapsing the frames for producing a final image.
     full_output: boolean, optional
@@ -409,7 +419,8 @@ def pca_adi_annular(cube, angle_list, radius_int=0, fwhm=4, asize=3,
     #***************************************************************************
     # Cube is derotated according to the parallactic angle and median combined.
     #***************************************************************************
-    cube_der = cube_derotate(cube_out, angle_list)
+    cube_der = cube_derotate(cube_out, angle_list, imlib=imlib,
+                             interpolation=interpolation)
     frame = cube_collapse(cube_der, mode=collapse)
     if verbose:
         print('Done derotating and combining.')

--- a/vip_hci/pca/svd.py
+++ b/vip_hci/pca/svd.py
@@ -7,7 +7,7 @@ Module with functions for computing SVDs.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['svd_wrapper',
            'randomized_svd_gpu']
 

--- a/vip_hci/phot/detection.py
+++ b/vip_hci/phot/detection.py
@@ -7,7 +7,7 @@ Module with detection algorithms.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['detection',
            'mask_source_centers',
            'peak_coordinates']

--- a/vip_hci/phot/frame_analysis.py
+++ b/vip_hci/phot/frame_analysis.py
@@ -7,7 +7,7 @@
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['frame_quick_report']
 
 import numpy as np

--- a/vip_hci/phot/snr.py
+++ b/vip_hci/phot/snr.py
@@ -7,7 +7,7 @@ Module with SNR calculation functions.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg, O. Absil @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez, O. Absil @ ULg'
 __all__ = ['snr_ss',
            'snr_peakstddev',
            'snrmap',

--- a/vip_hci/preproc/badframes.py
+++ b/vip_hci/preproc/badframes.py
@@ -7,7 +7,7 @@ Module with functions for outlier frame detection.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['cube_detect_badfr_pxstats',
            'cube_detect_badfr_ellipticipy',
            'cube_detect_badfr_correlation']

--- a/vip_hci/preproc/badpixremoval.py
+++ b/vip_hci/preproc/badpixremoval.py
@@ -7,7 +7,7 @@ Module with functions for correcting bad pixels in cubes.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg', 'V. Christiaens'
+__author__ = 'Carlos Alberto Gomez Gonzalez, V. Christiaens'
 __all__ = ['frame_fix_badpix_isolated',
            'cube_fix_badpix_isolated',
            'cube_fix_badpix_annuli',

--- a/vip_hci/preproc/cosmetics.py
+++ b/vip_hci/preproc/cosmetics.py
@@ -8,7 +8,7 @@ Also functions for cropping cubes.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['cube_crop_frames',
            'cube_drop_frames',
            'frame_crop']

--- a/vip_hci/preproc/cosmetics_ifs.py
+++ b/vip_hci/preproc/cosmetics_ifs.py
@@ -7,7 +7,7 @@ Module with cube cosmetic functions for SDI datasets.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'V. Christiaens @ UChile/ULg, C. Gomez @ ULg'
+__author__ = 'V. Christiaens @ UChile/ULg, Carlos Alberto Gomez Gonzalez'
 __all__ = ['cube_correct_nan',
            'approx_stellar_position']
 

--- a/vip_hci/preproc/parangles.py
+++ b/vip_hci/preproc/parangles.py
@@ -4,7 +4,7 @@
 Module with frame de-rotation routine for ADI.
 """
 from __future__ import print_function
-__author__ = 'V. Christiaens @ UChile/ULg, C. Gomez @ ULg'
+__author__ = 'V. Christiaens @ UChile/ULg, Carlos Alberto Gomez Gonzalez'
 __all__ = ['compute_paral_angles',
            'compute_derot_angles_PA',
            'compute_derot_angles_CD',

--- a/vip_hci/preproc/skysubtraction.py
+++ b/vip_hci/preproc/skysubtraction.py
@@ -6,7 +6,7 @@ Module with sky subtraction function.
 
 from __future__ import division
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['cube_subtract_sky_pca']
 
 import numpy as np

--- a/vip_hci/preproc/subsampling.py
+++ b/vip_hci/preproc/subsampling.py
@@ -7,7 +7,7 @@ Module with pixel and frame subsampling functions.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['cube_collapse',
            'cube_subsample',
            'cube_subsample_trimmean']

--- a/vip_hci/stats/clip_sigma.py
+++ b/vip_hci/stats/clip_sigma.py
@@ -6,7 +6,7 @@ Module with sigma clipping functions.
 
 from __future__ import division, print_function
 
-__author__ = 'C. Gomez @ ULg', 'V. Christiaens'
+__author__ = 'Carlos Alberto Gomez Gonzalez', 'V. Christiaens'
 __all__ = ['clip_array',
            'sigma_filter']
 

--- a/vip_hci/stats/cube_stats.py
+++ b/vip_hci/stats/cube_stats.py
@@ -6,7 +6,7 @@ Module for stats of a fits-cube.
 
 from __future__ import division 
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['cube_stats_aperture',
            'cube_stats_annulus']
 

--- a/vip_hci/stats/distances.py
+++ b/vip_hci/stats/distances.py
@@ -6,7 +6,7 @@ Distance between images.
 
 from __future__ import division
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['cube_distance',
            'cube_distance_to_frame']
 

--- a/vip_hci/stats/im_stats.py
+++ b/vip_hci/stats/im_stats.py
@@ -6,7 +6,7 @@ Module for image statistics.
 
 from __future__ import division
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['frame_histo_stats']
 
 import numpy as np

--- a/vip_hci/stats/utils_stats.py
+++ b/vip_hci/stats/utils_stats.py
@@ -6,7 +6,7 @@ Various stat functions.
 
 from __future__ import division, print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['descriptive_stats']
 
 import numpy as np

--- a/vip_hci/var/filters.py
+++ b/vip_hci/var/filters.py
@@ -6,7 +6,7 @@ Module with frame/cube filtering functionalities
 
 from __future__ import division
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['frame_filter_highpass',
            'frame_filter_lowpass',
            'cube_filter_highpass',

--- a/vip_hci/var/fit_2d.py
+++ b/vip_hci/var/fit_2d.py
@@ -5,7 +5,7 @@
 """
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['fit_2dgaussian',
            'fit_2dmoffat']
 

--- a/vip_hci/var/shapes.py
+++ b/vip_hci/var/shapes.py
@@ -7,7 +7,7 @@ Module with various functions.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['dist',
            'frame_center',
            'get_square',

--- a/vip_hci/var/utils_var.py
+++ b/vip_hci/var/utils_var.py
@@ -7,7 +7,7 @@ Module with various functions.
 from __future__ import division
 from __future__ import print_function
 
-__author__ = 'C. Gomez @ ULg', 'O. Wertz'
+__author__ = 'Carlos Alberto Gomez Gonzalez, O. Wertz'
 __all__ = ['pp_subplots',
            'plot_surface',
            'get_fwhm',


### PR DESCRIPTION
- Lanczos4 interpolation was set as default for every image transformation operation (shift, rescale, rotate)
- Image library (opencv, skimage/ndimage) and interpolation type has been included as a parameter for every function (when needed)
- When skimage/ndimage is used the order of the spline can be set up to 5 (bi-quintic interpolation)