### PR TITLE
improve performance: repeated item instead of list comprehension

### DIFF
--- a/vip_hci/leastsq/leastsq.py
+++ b/vip_hci/leastsq/leastsq.py
@@ -111,7 +111,7 @@ def xloci(cube, angle_list, fwhm=4, metric='manhattan', dist_threshold=50,
 
     annulus_width = asize
     if isinstance(n_segments, int):
-        n_segments = [n_segments for _ in range(n_annuli)]
+        n_segments = [n_segments]*n_annuli
     elif n_segments == 'auto':
         n_segments = []
         n_segments.append(2)    # for first annulus

--- a/vip_hci/llsg/llsg.py
+++ b/vip_hci/llsg/llsg.py
@@ -170,7 +170,7 @@ def llsg(cube, angle_list, fwhm, rank=10, thresh=1, max_iter=10,
     if n_segments is None:
         n_segments = [4 for _ in range(n_annuli)]   # as in the paper
     elif isinstance(n_segments, int):
-        n_segments = [n_segments for _ in range(n_annuli)]
+        n_segments = [n_segments]*n_annuli
     elif n_segments == 'auto':
         n_segments = []
         n_segments.append(2)    # for first annulus

--- a/vip_hci/phot/contrcurve.py
+++ b/vip_hci/phot/contrcurve.py
@@ -622,7 +622,7 @@ def throughput(cube, angle_list, psf_template, fwhm, pxscale, algo, nbranch=1,
 
     elif cube.ndim == 4:
         if isinstance(fwhm, (int, float)):
-            fwhm = [fwhm for _ in range(array.shape[0])]
+            fwhm = [fwhm]*array.shape[0]
 
         psf_template = psf_norm(psf_template, fwhm=fwhm,
                                 size=min(new_psf_size, psf_template.shape[1]))

--- a/vip_hci/phot/fakecomp.py
+++ b/vip_hci/phot/fakecomp.py
@@ -396,7 +396,7 @@ def psf_norm(array, fwhm=4, size=None, threshold=None, mask_core=None,
                 print(msg.format(size))
 
         if isinstance(fwhm, (int, float)):
-            fwhm = [fwhm for _ in range(array.shape[0])]
+            fwhm = [fwhm]*array.shape[0]
         elif fwhm == 'fit':
             fits_vect = [fit_2dgaussian(array[i], full_output=True) for i
                          in range(n)]

--- a/vip_hci/var/utils_var.py
+++ b/vip_hci/var/utils_var.py
@@ -206,13 +206,13 @@ def pp_subplots(*args, **kwargs):
                                                            list):
             if len(kwargs['vmax']) != num_plots:
                 print("Vmax list does not have enough items, setting all to None")
-                vmax = [None for i in range(num_plots)]
+                vmax = [None]*num_plots
             else:
                 vmax = kwargs['vmax']
         else:
             vmax = [kwargs['vmax'] for i in range(num_plots)]
     else:
-        vmax = [None for i in range(num_plots)]
+        vmax = [None]*num_plots
 
     if 'vmin' in kwargs:
         if isinstance(kwargs['vmin'], tuple) or isinstance(kwargs['vmin'],
@@ -220,13 +220,13 @@ def pp_subplots(*args, **kwargs):
             if len(kwargs['vmin']) != num_plots:
                 print(
                 "Vmax list does not have enough items, setting all to None")
-                vmin = [None for i in range(num_plots)]
+                vmin = [None]*num_plots
             else:
                 vmin = kwargs['vmin']
         else:
-            vmin = [kwargs['vmin'] for i in range(num_plots)]
+            vmin = [kwargs['vmin']]*num_plots
     else:
-        vmin = [None for i in range(num_plots)]
+        vmin = [None]*num_plots
 
     # CROSS --------------------------------------------------------------------
     if 'cross' in kwargs:


### PR DESCRIPTION
Multiplication of a list by an integer is faster than using list comprehension and `range`.

benchmark:
``` python
def test_old(n_segments):
    n_annuli = 30
    n_segments = [n_segments for _ in range(n_annuli)]

def test_new(n_segments):
    n_annuli = 30
    n_segments = [n_segments]*n_annuli

if __name__ == '__main__':
    import timeit
    print(timeit.timeit("test_old(4)", setup="from __main__ import test_old"))
    # → 2.264435631004744 (for 1.000.000 rounds)
    print(timeit.timeit("test_new(4)", setup="from __main__ import test_new"))
    # → 0.3929279360017972 (for 1.000.000 rounds)
```