### PR TITLE
fix a problem with ds9 set function

### DIFF
--- a/vip_hci/fits/vipds9.py
+++ b/vip_hci/fits/vipds9.py
@@ -220,7 +220,7 @@ class ds9(object):
         else:
             self.window.set('scale open')
 
-    def set(self, paramlist, data=None, data_func=None):
+    def set(self, paramlist, data=None, data_func=-1):
         """ XPA set command. Sends data or commands to ds9. See:
         http://ds9.si.edu/doc/ref/xpa.html
         """


### PR DESCRIPTION
The set function of pyds9.DS9() does not accept None as third argument (currently the default value), it expects an integer.  
I therefore suggest to use -1 as default:
ds9.set(paramlist, buf=None, blen=-1)

This problem comes from the migration from python 2.7 to python 3.6. I checked and the proposed change is compatible with python 2.7