### PR TITLE
Update cube_collapse to incorporate 4D data

### DIFF
--- a/vip_hci/preproc/derotation.py
+++ b/vip_hci/preproc/derotation.py
@@ -126,7 +126,7 @@ def frame_rotate(array, angle, imlib='opencv', interpolation='lanczos4',
     
 def cube_derotate(array, angle_list, imlib='opencv', interpolation='lanczos4',
                   cxy=None, nproc=1):
-    """ Rotates an cube (3d array or image sequence) providing a vector or
+    """ Rotates a cube (3d, 4d array or image sequence) providing a vector or
     corrsponding angles. Serves for rotating an ADI sequence to a common north
     given a vector with the corresponding parallactic angles for each frame. By
     default bicubic interpolation is used (opencv).
@@ -134,7 +134,7 @@ def cube_derotate(array, angle_list, imlib='opencv', interpolation='lanczos4',
     Parameters
     ----------
     array : array_like 
-        Input 3d array, cube.
+        Input 3d, 4d array, cube.
     angle_list : list
         Vector containing the parallactic angles.
     imlib : str, optional
@@ -155,28 +155,61 @@ def cube_derotate(array, angle_list, imlib='opencv', interpolation='lanczos4',
         Resulting cube with de-rotated frames.
         
     """
-    if array.ndim != 3:
-        raise TypeError('Input array is not a cube or 3d array.')
-    n_frames = array.shape[0]
+    if not (array.ndim==3 or array.ndim==4):
+        raise TypeError('Input array is not a cube, 3d or 4d array.')
 
     if nproc is None:
         nproc = cpu_count() // 2        # Hyper-threading doubles the # of cores
+        
+    if array.ndim==3:
+        
+        n_frames = array.shape[0]
+        
+        if not cxy:
+            cy, cx = frame_center(array[0])
+            cxy = (cx, cy)
+        
+        if nproc == 1:
+            array_der = np.zeros_like(array)
+            for i in range(n_frames):
+                array_der[i] = frame_rotate(array[i], -angle_list[i], imlib=imlib,
+                                            interpolation=interpolation, cxy=cxy)
+        elif nproc > 1:
+            global data_array
+            data_array = array
 
-    if nproc == 1:
-        array_der = np.zeros_like(array)
+            pool = Pool(processes=nproc)
+            res = pool.map(EFT, zip(itt.repeat(_cube_rotate_mp), range(n_frames),
+                                    itt.repeat(angle_list), itt.repeat(imlib),
+                                    itt.repeat(interpolation), itt.repeat(cxy)))
+            pool.close()
+            array_der = np.array(res)
+            
+    if array.ndim==4:
+
+        n_frames = array.shape[1]
+
+        if not cxy:
+            cy, cx = frame_center(array[0,0])
+            cxy = (cx, cy)
+
         for i in range(n_frames):
-            array_der[i] = frame_rotate(array[i], -angle_list[i], imlib=imlib,
-                                        interpolation=interpolation, cxy=cxy)
-    elif nproc > 1:
-        global data_array
-        data_array = array
+            vec_ang = np.ones((array.shape[0]))*-angle_list[i]
+            if nproc==1:
+                array_der[:,i] = cube_derotate(array[:,i,:,:], vec_ang, imlib=imlib,
+                                               interpolation=interpolation, cxy=cxy)
+            elif nproc>1:
+                global data_array
+                data_array = array
 
-        pool = Pool(processes=nproc)
-        res = pool.map(EFT, zip(itt.repeat(_cube_rotate_mp), range(n_frames),
-                                itt.repeat(angle_list), itt.repeat(imlib),
-                                itt.repeat(interpolation), itt.repeat(cxy)))
-        pool.close()
-        array_der = np.array(res)
+                pool = Pool(processes=int(nproc))
+                res = pool.map(futup, itt.izip(itt.repeat(_cube_rotate_mp),
+                                               range(n_frames), itt.repeat(vec_ang),
+                                               itt.repeat(imlib),
+                                               itt.repeat(interpolation),
+                                               itt.repeat(cxy)))
+                pool.close()
+                array_der = np.array(res)
 
     return array_der
 

--- a/vip_hci/preproc/derotation.py
+++ b/vip_hci/preproc/derotation.py
@@ -124,9 +124,9 @@ def frame_rotate(array, angle, imlib='opencv', interpolation='lanczos4',
     return array_out
     
     
-def cube_derotate(array, angle_list, imlib='opencv', interpolation='lanczos4',
+def cube_derotate(array, angle_list, imlib='opencv', interpolation='bicubic',
                   cxy=None, nproc=1):
-    """ Rotates a cube (3d, 4d array or image sequence) providing a vector or
+    """ Rotates an cube (3d array or image sequence) providing a vector or
     corrsponding angles. Serves for rotating an ADI sequence to a common north
     given a vector with the corresponding parallactic angles for each frame. By
     default bicubic interpolation is used (opencv).
@@ -134,18 +134,23 @@ def cube_derotate(array, angle_list, imlib='opencv', interpolation='lanczos4',
     Parameters
     ----------
     array : array_like 
-        Input 3d, 4d array, cube.
+        Input 3d array, cube.
     angle_list : list
         Vector containing the parallactic angles.
-    imlib : str, optional
-        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
-    interpolation : str, optional
-        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    imlib : {'opencv', 'skimage'}, str optional
+        Library used for image transformations. Opencv is usually faster than
+        ndimage or skimage.
+    interpolation : {'bicubic', 'bilinear', 'nearneig'}, optional
+        'nneighbor' stands for nearest-neighbor interpolation,
+        'bilinear' stands for bilinear interpolation,
+        'bicubic' for interpolation over 4x4 pixel neighborhood.
+        The 'bicubic' is the default. The 'nearneig' is the fastest method and
+        the 'bicubic' the slowest of the three. The 'nearneig' is the poorer
+        option for interpolation of noisy astronomical images.
     cxy : tuple of int, optional
         Coordinates X,Y  of the point with respect to which the rotation will be 
         performed. By default the rotation is done with respect to the center 
-        of the frames, as it is returned by the function
-        vip_hci.var.frame_center. 
+        of the frames, as it is returned by the function vip_hci.var.frame_center. 
     collapse : {'median','mean'}
         Way of collapsing the derotated cube.
         
@@ -155,61 +160,33 @@ def cube_derotate(array, angle_list, imlib='opencv', interpolation='lanczos4',
         Resulting cube with de-rotated frames.
         
     """
-    if not (array.ndim == 3 or array.ndim == 4):
-        raise TypeError('Input array is not a cube, 3d or 4d array.')
+    if not array.ndim == 3:
+        raise TypeError('Input array is not a cube or 3d array.')
+    array_der = np.empty_like(array)
+    n_frames = array.shape[0]
+    
+    if not cxy:
+        cy, cx = frame_center(array[0])
+        cxy = (cx, cy)
 
-    if nproc is None:
-        nproc = cpu_count() // 2        # Hyper-threading doubles the # of cores
-        
-    if array.ndim == 3:
-        
-        n_frames = array.shape[0]
-        
-        if not cxy:
-            cy, cx = frame_center(array[0])
-            cxy = (cx, cy)
-        
-        if nproc == 1:
-            array_der = np.zeros_like(array)
-            for i in range(n_frames):
-                array_der[i] = frame_rotate(array[i], -angle_list[i], imlib=imlib,
-                                            interpolation=interpolation, cxy=cxy)
-        elif nproc > 1:
-            global data_array
-            data_array = array
+    if not nproc: nproc = int((cpu_count() / 2))
 
-            pool = Pool(processes=nproc)
-            res = pool.map(EFT, zip(itt.repeat(_cube_rotate_mp), range(n_frames),
-                                    itt.repeat(angle_list), itt.repeat(imlib),
-                                    itt.repeat(interpolation), itt.repeat(cxy)))
-            pool.close()
-            array_der = np.array(res)
-            
-    if array.ndim == 4:
-
-        n_frames = array.shape[1]
-
-        if not cxy:
-            cy, cx = frame_center(array[0,0])
-            cxy = (cx, cy)
-
+    if nproc==1:
         for i in range(n_frames):
-            vec_ang = np.ones((array.shape[0]))*-angle_list[i]
-            if nproc == 1:
-                array_der[:,i] = cube_derotate(array[:,i,:,:], vec_ang, imlib=imlib,
-                                               interpolation=interpolation, cxy=cxy)
-            elif nproc > 1:
-                global data_array
-                data_array = array
+            array_der[i] = frame_rotate(array[i], -angle_list[i], imlib=imlib,
+                                        interpolation=interpolation, cxy=cxy)
+    elif nproc>1:
+        global data_array
+        data_array = array
 
-                pool = Pool(processes=int(nproc))
-                res = pool.map(futup, itt.izip(itt.repeat(_cube_rotate_mp),
-                                               range(n_frames), itt.repeat(vec_ang),
-                                               itt.repeat(imlib),
-                                               itt.repeat(interpolation),
-                                               itt.repeat(cxy)))
-                pool.close()
-                array_der = np.array(res)
+        pool = Pool(processes=int(nproc))
+        res = pool.map(futup, itt.izip(itt.repeat(_cube_rotate_mp),
+                                       range(n_frames), itt.repeat(angle_list),
+                                       itt.repeat(imlib),
+                                       itt.repeat(interpolation),
+                                       itt.repeat(cxy)))
+        pool.close()
+        array_der = np.array(res)
 
     return array_der
 

--- a/vip_hci/preproc/derotation.py
+++ b/vip_hci/preproc/derotation.py
@@ -155,13 +155,13 @@ def cube_derotate(array, angle_list, imlib='opencv', interpolation='lanczos4',
         Resulting cube with de-rotated frames.
         
     """
-    if not (array.ndim==3 or array.ndim==4):
+    if not (array.ndim == 3 or array.ndim == 4):
         raise TypeError('Input array is not a cube, 3d or 4d array.')
 
     if nproc is None:
         nproc = cpu_count() // 2        # Hyper-threading doubles the # of cores
         
-    if array.ndim==3:
+    if array.ndim == 3:
         
         n_frames = array.shape[0]
         
@@ -185,7 +185,7 @@ def cube_derotate(array, angle_list, imlib='opencv', interpolation='lanczos4',
             pool.close()
             array_der = np.array(res)
             
-    if array.ndim==4:
+    if array.ndim == 4:
 
         n_frames = array.shape[1]
 
@@ -195,10 +195,10 @@ def cube_derotate(array, angle_list, imlib='opencv', interpolation='lanczos4',
 
         for i in range(n_frames):
             vec_ang = np.ones((array.shape[0]))*-angle_list[i]
-            if nproc==1:
+            if nproc == 1:
                 array_der[:,i] = cube_derotate(array[:,i,:,:], vec_ang, imlib=imlib,
                                                interpolation=interpolation, cxy=cxy)
-            elif nproc>1:
+            elif nproc > 1:
                 global data_array
                 data_array = array
 

--- a/vip_hci/preproc/subsampling.py
+++ b/vip_hci/preproc/subsampling.py
@@ -69,7 +69,7 @@ def cube_collapse(cube, mode='median', n=50, wl_cube=False):
         elif mode=='sum':
             cube_wl = np.sum(arr, axis=1)
         elif mode=='trimmean':
-            print 'Sorry: no trimmed mean for 4d cubes'
+            print('Sorry: no trimmed mean for 4d cubes')
             return 0
         if wl_cube:
             return cube_wl

--- a/vip_hci/preproc/subsampling.py
+++ b/vip_hci/preproc/subsampling.py
@@ -14,8 +14,8 @@ __all__ = ['cube_collapse',
 import numpy as np
 
 
-def cube_collapse(cube, mode='median', n=50):
-    """ Collapses a cube into a frame (3D array -> 2D array) depending on the
+def cube_collapse(cube, mode='median', n=50, wl_cube=False):
+    """ Collapses a cube into a frame (4d or 3d array to 2d array) depending on the
     parameter ``mode``. It's possible to perform a trimmed mean combination of
     the frames based on description in Brandt+ 2012.
     
@@ -28,6 +28,8 @@ def cube_collapse(cube, mode='median', n=50):
     n : int, optional
         Sets the discarded values at high and low ends. When n = N is the same
         as taking the mean, when n = 1 is like taking the median.
+    wl_cube : True or False
+        Enable if you only want to collapse the rotations. Set to False to collapse wavelengths
         
     Returns
     -------
@@ -35,29 +37,49 @@ def cube_collapse(cube, mode='median', n=50):
         Output array, cube combined. 
     """
     arr = cube
-    if arr.ndim != 3:
-        raise TypeError('The input array is not a cube or 3d array.')
-    
-    if mode == 'mean':
-        frame = np.mean(arr, axis=0)
-    elif mode == 'median':
-        frame = np.median(arr, axis=0)
-    elif mode == 'sum':
-        frame = np.sum(arr, axis=0)
-    elif mode == 'max':
-        frame = np.max(arr, axis=0)
-    elif mode == 'trimmean':
-        N = arr.shape[0]
-        if N % 2 == 0:
-            k = (N - n)//2
-        else:
-            k = (N - n)/2                                                               
-        
-        frame = np.empty_like(arr[0])                                    
-        for index, _ in np.ndenumerate(arr[0]):
-            sort = np.sort(arr[:, index[0], index[1]])
-            frame[index] = np.mean(sort[k:N-k])
+    if not (arr.ndim == 3 or arr.ndim==4):
+        raise TypeError('The input array is not a cube, 3d or 4d array.')
+
+    if arr.ndim==3:
+        if mode == 'mean':
+            frame = np.mean(arr, axis=0)
+        elif mode == 'median':
+            frame = np.median(arr, axis=0)
+        elif mode == 'sum':
+            frame = np.sum(arr, axis=0)
+        elif mode == 'max':
+            frame = np.max(arr, axis=0)
+        elif mode == 'trimmean':
+            N = arr.shape[0]
+            if N % 2 == 0:
+                k = (N - n)//2
+            else:
+                k = (N - n)/2                                                               
+
+            frame = np.empty_like(arr[0])                                    
+            for index, _ in np.ndenumerate(arr[0]):
+                sort = np.sort(arr[:, index[0], index[1]])
+                frame[index] = np.mean(sort[k:N-k])
             
+    elif arr.ndim==4:
+        if mode=='mean':
+            cube_wl = np.mean(arr, axis=1)
+        elif mode=='median':
+            cube_wl = np.median(arr, axis=1)
+        elif mode=='sum':
+            cube_wl = np.sum(arr, axis=1)
+        elif mode=='trimmean':
+            print 'Sorry: no trimmed mean for 4d cubes'
+            return 0
+        if wl_cube:
+            return cube_wl
+        else:
+            if mode=='mean':
+                frame = np.mean(cube_wl, axis=0)
+            elif mode=='median':
+                frame = np.median(cube_wl, axis=0)
+            elif mode=='sum':
+                frame = np.sum(cube_wl, axis=0)
     return frame
 
 

--- a/vip_hci/preproc/subsampling.py
+++ b/vip_hci/preproc/subsampling.py
@@ -40,7 +40,7 @@ def cube_collapse(cube, mode='median', n=50, wl_cube=False):
     if not (arr.ndim == 3 or arr.ndim==4):
         raise TypeError('The input array is not a cube, 3d or 4d array.')
 
-    if arr.ndim==3:
+    if arr.ndim == 3:
         if mode == 'mean':
             frame = np.mean(arr, axis=0)
         elif mode == 'median':
@@ -61,24 +61,24 @@ def cube_collapse(cube, mode='median', n=50, wl_cube=False):
                 sort = np.sort(arr[:, index[0], index[1]])
                 frame[index] = np.mean(sort[k:N-k])
             
-    elif arr.ndim==4:
-        if mode=='mean':
+    elif arr.ndim == 4:
+        if mode == 'mean':
             cube_wl = np.mean(arr, axis=1)
-        elif mode=='median':
+        elif mode == 'median':
             cube_wl = np.median(arr, axis=1)
-        elif mode=='sum':
+        elif mode == 'sum':
             cube_wl = np.sum(arr, axis=1)
-        elif mode=='trimmean':
+        elif mode == 'trimmean':
             print('Sorry: no trimmed mean for 4d cubes')
             return 0
         if wl_cube:
             return cube_wl
         else:
-            if mode=='mean':
+            if mode == 'mean':
                 frame = np.mean(cube_wl, axis=0)
-            elif mode=='median':
+            elif mode == 'median':
                 frame = np.median(cube_wl, axis=0)
-            elif mode=='sum':
+            elif mode == 'sum':
                 frame = np.sum(cube_wl, axis=0)
     return frame
 


### PR DESCRIPTION
Added ability to collapse 4D data by choosing whether the wavelength or angle gets collapsed. Required for SNR map calculations. 

cube_derotate also required but will do a separate pull request for it.