### PR TITLE
fix for pip >= 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,10 @@
 import os
 import re
 from setuptools import setup
-from pip.req import parse_requirements
+try: # pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # pip <= 9.0.3
+    from pip.req import parse_requirements
 from setuptools.command.install import install
 
 


### PR DESCRIPTION
`pip.req` moved to `pip._internal.req` in pip 10.