### PR TITLE
FEAT: Progressbar class

### DIFF
--- a/vip_hci/madi/adi_source.py
+++ b/vip_hci/madi/adi_source.py
@@ -22,10 +22,9 @@ __all__ = ['adi']
 
 import numpy as np
 import itertools as itt
-import pyprind
 from multiprocessing import Pool, cpu_count
 from ..conf import time_ini, timing
-from ..var import get_annulus, mask_circle
+from ..var import get_annulus, mask_circle, Progressbar
 from ..preproc import (cube_derotate, cube_collapse, check_pa_vector,
                        check_scal_vector)
 from ..preproc import cube_rescaling_wavelengths as scwave
@@ -211,9 +210,9 @@ def adi(cube, angle_list, scale_list=None, fwhm=4, radius_int=0, asize=2,
 
         if mode == 'fullfr':
             if verbose:
-                tit = 'First median subtraction exploiting spectral variability'
-                bar = pyprind.ProgBar(n, stream=1, title=tit)
-            for i in range(n):
+                print('First median subtraction exploiting spectral '
+                      'variability')
+            for i in ProgressBar(range(n), verbose=verbose):
                 cube_resc, _, _, _, _, _ = scwave(array[:, i, :, :], scale_list)
                 median_frame = np.median(cube_resc, axis=0)
                 residuals_cube = cube_resc - median_frame
@@ -221,8 +220,6 @@ def adi(cube, angle_list, scale_list=None, fwhm=4, radius_int=0, asize=2,
                                  full_output=full_output, inverse=True,
                                  y_in=y_in, x_in=x_in)
                 residuals_cube_channels[i] = frame_i
-                if verbose:
-                    bar.update()
 
             if verbose:
                 timing(start_time)
@@ -240,9 +237,9 @@ def adi(cube, angle_list, scale_list=None, fwhm=4, radius_int=0, asize=2,
         elif mode == 'annular':
             # TODO : implement the radial movement exclusion
             if verbose:
-                tit = 'First median subtraction exploiting spectral variability'
-                bar = pyprind.ProgBar(n, stream=1, title=tit)
-            for i in range(n):
+                print('First median subtraction exploiting spectral '
+                      'variability')
+            for i in Progressbar(range(n), verbose=verbose):
                 cube_resc, _, _, _, _, _ = scwave(array[:, i, :, :], scale_list)
                 median_frame = np.median(cube_resc, axis=0)
                 residuals_cube = cube_resc - median_frame
@@ -250,8 +247,6 @@ def adi(cube, angle_list, scale_list=None, fwhm=4, radius_int=0, asize=2,
                                  full_output=full_output, inverse=True,
                                  y_in=y_in, x_in=x_in)
                 residuals_cube_channels[i] = frame_i
-                if verbose:
-                    bar.update()
 
             if nframes % 2 != 0:
                 raise TypeError('nframes argument must be even value')

--- a/vip_hci/preproc/badpixremoval.py
+++ b/vip_hci/preproc/badpixremoval.py
@@ -13,12 +13,11 @@ __all__ = ['frame_fix_badpix_isolated',
            'cube_fix_badpix_clump']
 
 import numpy as np
-import pyprind
 from skimage.draw import circle, ellipse
 from scipy.ndimage import median_filter
 from astropy.stats import sigma_clipped_stats
 from ..stats import sigma_filter
-from ..var import dist, frame_center, pp_subplots
+from ..var import dist, frame_center, pp_subplots, Progressbar
 from ..stats import clip_array
 from ..conf import timing, time_ini
 
@@ -184,12 +183,10 @@ def cube_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
     if debug:
         pp_subplots(bpm_mask, title='Bad pixel mask')
 
-    bar = pyprind.ProgBar(n_frames, stream=1, title='Looping through frames')
-    for i in range(n_frames):
+    for i in Progressbar(range(n_frames), desc="frames"):
         frame = cube_out[i]
         smoothed = median_filter(frame, size, mode='mirror')
         frame[np.where(bpm_mask)] = smoothed[np.where(bpm_mask)]
-        bar.update()
     array_out = cube_out
     
     if verbose: 

--- a/vip_hci/var/__init__.py
+++ b/vip_hci/var/__init__.py
@@ -11,3 +11,5 @@ from .filters import *
 from .fit_2d import *
 from .shapes import *
 from .utils_var import *
+
+from .utils_var import Progressbar

--- a/vip_hci/var/filters.py
+++ b/vip_hci/var/filters.py
@@ -22,11 +22,11 @@ except ImportError:
     warnings.warn(msg, ImportWarning)
     no_opencv = True
 import numpy as np
-import pyprind
 from scipy.ndimage import gaussian_filter, median_filter      
 from astropy.convolution import convolve_fft, Gaussian2DKernel
 from astropy.stats import gaussian_fwhm_to_sigma
 from ..exlib import iuwt
+from .utils_var import Progressbar
 
 
 def cube_filter_iuwt(cube, coeff=5, rel_coeff=1, full_output=False):
@@ -59,14 +59,12 @@ def cube_filter_iuwt(cube, coeff=5, rel_coeff=1, full_output=False):
     cube_coeff = np.zeros((cube.shape[0], coeff, cube.shape[1], cube.shape[2]))
     n_frames = cube.shape[0]
     
-    msg = 'Decomposing frames with the Isotropic Undecimated Wavelet Transform.'
-    bar = pyprind.ProgBar(n_frames, stream=1, title=msg)
-    for i in range(n_frames):
+    print('Decomposing frames with the Isotropic Undecimated Wavelet Transform')
+    for i in Progressbar(range(n_frames)):
         res = iuwt.iuwt_decomposition(cube[i], coeff, store_smoothed=False)
         cube_coeff[i] = res
         for j in range(rel_coeff):
             cubeout[i] += cube_coeff[i][j] 
-        bar.update()
         
     if full_output:
         return cubeout, cube_coeff
@@ -99,12 +97,9 @@ def cube_filter_highpass(array, mode='laplacian', verbose=True, **kwargs):
     n_frames = array.shape[0]
     array_out = np.zeros_like(array)
     if verbose:
-        msg = 'Applying the high-pass filter on cube frames:'
-        bar = pyprind.ProgBar(n_frames, stream=1, title=msg, bar_char='.')
-    for i in range(n_frames):
+        print('Applying the high-pass filter on cube frames:')
+    for i in Progressbar(range(n_frames), verbose=verbose):
         array_out[i] = frame_filter_highpass(array[i], mode=mode, **kwargs)
-        if verbose:
-            bar.update()
         
     return array_out
     
@@ -406,13 +401,10 @@ def cube_filter_lowpass(array, mode='gauss', median_size=5, fwhm_size=5,
     n_frames = array.shape[0]
     array_out = np.zeros_like(array)
     if verbose:
-        msg = 'Applying the low-pass filter on cube frames:'
-        bar = pyprind.ProgBar(n_frames, stream=1, title=msg, bar_char='.')
-    for i in range(n_frames):
+        print('Applying the low-pass filter on cube frames:')
+    for i in Progressbar(range(n_frames), verbose=verbose):
         array_out[i] = frame_filter_lowpass(array[i], mode, median_size,
                                             fwhm_size, gauss_mode)
-        if verbose:
-            bar.update()
 
     return array_out
 


### PR DESCRIPTION
Wrapped all progressbar related logic (e.g. `verbose`) inside `vip.var.Progressbar`. By default, [pyprind](https://github.com/rasbt/pyprind) is used and the bars should look as before (with the exception that the bars are fixed-width now). The [tqdm](https://github.com/tqdm/tqdm) and `tqdm_notebook` backends additionally support nested bars (e.g. for SODINN), but from time to time the layout breaks, so I kept that as an option. The backend can be chosen with

``` python
from vip.var import Progressbar
Progressbar.backend = "tqdm_notebook"
```

Progressbars can be disabled by passing `verbose=False` to `Progressbar(...)`, or by using the `hide` backend.