### PR TITLE
store HCIDataset to disk

### DIFF
--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -1324,8 +1324,13 @@ class HCIDataset:
         """
         Used by ``pickle``. Filters out the attributes listed in
         ``self.SAVE_WITH_NP``.
+
+        Warning: `copy.copy()` also uses this function, so the ``SAVE_WITH_NP``
+        attributes get missing. Use `self.copy()` instead!
         """
-        state = {k:v for k in self.__dict__ if k not in self.SAVE_WITH_NP}
+        # TODO: use `from six import iteritems; for k,v in iteritems(...)` 
+        state = {k:self.__dict__[k] for k in self.__dict__
+                                                  if k not in self.SAVE_WITH_NP}
         return state
 
     @classmethod

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -290,7 +290,7 @@ class HCIFrame(object):
         self.image = frame_rotate(self.image, angle, imlib, interpolation, cxy)
         print('Image successfully rotated')
 
-    def save(self, path):
+    def write_fits(self, path, precision=np.float32):
         """ Writing to FITS file.
 
         Parameters
@@ -298,7 +298,7 @@ class HCIFrame(object):
         path : string
             Full path of the fits file to be written.
         """
-        write_fits(path, self.image)
+        write_fits(path, self.image, precision=precision)
 
     def shift(self, shift_y, shift_x, imlib='opencv', interpolation='lanczos4'):
         """ Shifting the image.
@@ -1190,7 +1190,7 @@ class HCIDataset(object):
         self.cube = cube_px_resampling(self.cube, scale, imlib, interpolation,
                                        verbose)
 
-    def export(self, path, precision=np.float32):
+    def write_fits(self, path, precision=np.float32):
         """ Write ``self.cube`` to FITS file. If ``self.angles`` is present,
         then the angles are appended to the FITS file.
 

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -1305,6 +1305,21 @@ class HCIDataset:
         new_p = "{}-{suffix}{}".format(*os.path.splitext(p), suffix=suffix)
         return new_p
 
+    def copy(self):
+        """
+        Creates a new instance of the dataset.
+
+        behaves like `copy.copy()`, but does not ignore self.SAVE_WITH_NP
+        """
+        
+        import copy
+        new_obj = copy.copy(self)
+        for k in self.SAVE_WITH_NP:
+            if k in self.__dict__:
+                new_obj.__dict__[k] = self.__dict__[k]
+
+        return new_obj
+
     def __getstate__(self):
         """
         Used by ``pickle``. Filters out the attributes listed in

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -34,7 +34,7 @@ from .metrics import (frame_quick_report, cube_inject_companions, snr_ss,
 from .conf.utils_conf import check_array
 
 
-class HCIFrame:
+class HCIFrame(object):
     """ High-contrast imaging frame (2d array).
 
     Parameters
@@ -457,7 +457,7 @@ class HCIFrame:
         _ = frame_quick_report(self.image, self.fwhm, source_xy, verbose)
 
 
-class HCIDataset:
+class HCIDataset(object):
     """ High-contrast imaging dataset class.
 
     Parameters

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -465,7 +465,7 @@ class HCIDataset:
         3d or 4d high-contrast image sequence. If a string is provided, cube is
         interpreted as the path of the FITS file containing the sequence.
     hdu : int, optional
-        If ``cube`` is a String, ``hdu`` indicates the HDU from the FITS file.
+        If ``cube`` is a string, ``hdu`` indicates the HDU from the FITS file.
         By default the first HDU is used.
     angles : list or numpy array, optional
         The vector of parallactic angles.
@@ -481,7 +481,7 @@ class HCIDataset:
     psfn : numpy array, optional
         Normalized/cropped/centered version of the PSF template associated with
         this dataset.
-    cuberef : str or numpy array
+    cuberef : str, numpy array or HCIDataset, optional
         3d or 4d high-contrast image sequence. To be used as a reference cube.
     """
 

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -1183,13 +1183,13 @@ class HCIDataset:
         self.cube = cube_px_resampling(self.cube, scale, imlib, interpolation,
                                        verbose)
 
-    def save(self, path, precision=np.float32):
-        """ Writing to FITS file. If self.angles is present, then the angles
-        are appended to the FITS file.
+    def export(self, path, precision=np.float32):
+        """ Write ``self.cube`` to FITS file. If ``self.angles`` is present,
+        then the angles are appended to the FITS file.
 
         Parameters
         ----------
-        filename : string
+        path : string
             Full path of the fits file to be written.
         precision : numpy dtype, optional
             Float precision, by default np.float32 or single precision float.


### PR DESCRIPTION
This PR renames the existing `HCIDataset.save` method to `export`, as it just stores the cube and angles to a FITS file.

A new `save` method was introduced which:
- stores the cube, angles and PSF arrays using numpy's efficient `savez` function
- stores the rest of the object using `pickle`.

``` python
dataset = HCIDataset(cube=...)
dataset.save("data1")
```

Once written to disk the HCIDataset object can be restored using

``` python
dataset = HCIDataset.from_file("data1")
```