### PR TITLE
save HCIDataset as FITS

### DIFF
--- a/vip_hci/__init__.py
+++ b/vip_hci/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import (absolute_import)
 
+__version__ = "0.9.6"
+
 from . import andromeda
 from . import preproc
 from . import conf
@@ -17,9 +19,3 @@ from . import var
 from .hci_dataset import *
 from .hci_postproc import *
 from .vip_ds9 import *
-
-__version__ = "0.9.6"
-
-
-
-

--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -83,7 +83,7 @@ def open_fits(fitsfilename, n=0, header=False, slice=None,
             shape_info = "{} -> {}".format(shape_before_slice, data.shape)
 
         if header:
-            header = hdulist[0].header
+            header = hdulist[n].header
             if verbose:
                 print("Fits HDU-{} data and header successfully loaded. "
                       "Data shape: {}".format(n, shape_info))

--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -1,5 +1,3 @@
-#! /usr/bin/env python
-
 """
 Module with various fits handling functions.
 """
@@ -40,7 +38,7 @@ def open_fits(fitsfilename, n=0, header=False, slice=None,
     ignore_missing_end : {False, True}, bool optional
         Allows to open fits files with a header missing END card.
     verbose : bool, optional
-        If True prints message of completion.
+        If True prints message of completion and information on the data shape.
     
     Returns
     -------
@@ -134,7 +132,9 @@ def open_adicube(fitsfilename, verbose=True):
 
 
 def byteswap_array(array):
-    """ FITS files are stored in big-endian byte order. All modern CPUs are 
+    """ Byte-swaps a numpy array, so it is stored in native byte order.
+
+    FITS files are stored in big-endian byte order. All modern CPUs are 
     little-endian byte order, so at some point you have to byteswap the data. 
     Some FITS readers (cfitsio, the fitsio python module) do the byteswap when 
     reading the data from disk to memory, so we get numpy arrays in native 

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -508,6 +508,8 @@ class HCIDataset:
         if isinstance(cube, str):
             self.cube, self.cube_fits_header = open_fits(cube, hdu, header=True,
                                                          verbose=False)
+        elif isinstance(cube, tuple):
+            self.cube, self.cube_fits_header = cube
         elif isinstance(cube, np.ndarray):
             if not (cube.ndim == 3 or cube.ndim == 4):
                 raise ValueError('`Cube` array has wrong dimensions')
@@ -526,6 +528,8 @@ class HCIDataset:
             self.cuberef, self.cuberef_fits_header = open_fits(cuberef, hdu,
                                                                header=True,
                                                                verbose=False)
+        elif isinstance(cuberef, tuple):
+            self.cuberef, self.cuberef_fits_header = cuberef
         elif isinstance(cuberef, np.ndarray):
             msg = '`Cuberef` array has wrong dimensions'
             if not cuberef.ndim == 3:
@@ -550,6 +554,8 @@ class HCIDataset:
             self.angles, self.angles_fits_header = open_fits(angles,
                                                              header=True,
                                                              verbose=False)
+        elif isinstance(angles, tuple):
+            self.angles, self.angles_fits_header = angles
         else:
             self.angles = angles
         if self.angles is not None:
@@ -564,6 +570,8 @@ class HCIDataset:
         if isinstance(wavelengths, str):
             self.wavelengths, self.wavelengths_fits_header = open_fits(
                                         wavelengths, header=True, verbose=False)
+        elif isinstance(wavelengths, tuple):
+            self.wavelengths, self.wavelengths_fits_header = wavelengths
         else:
             self.wavelengths = wavelengths
         if self.wavelengths is not None:
@@ -578,6 +586,8 @@ class HCIDataset:
         if isinstance(psf, str):
             self.psf, self.psf_fits_header = open_fits(psf, header=True,
                                                        verbose=False)
+        elif isinstance(psf, tuple):
+            self.psf, self.psf_fits_header = psf
         else:
             self.psf = psf
         if self.psf is not None:
@@ -592,6 +602,8 @@ class HCIDataset:
         if isinstance(psfn, str):
             self.psfn, self.psfn_fits_header = open_fits(psfn, header=True,
                                                          verbose=False)
+        elif isinstance(psfn, tuple):
+            self.psfn, self.psfn_fits_header = psfn
         else:
             self.psfn = psfn
         if self.psfn is not None:

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -33,7 +33,7 @@ from .metrics import (frame_quick_report, cube_inject_companions, snr_ss,
                       snr_peakstddev, snrmap, snrmap_fast, detection,
                       normalize_psf)
 from .conf.utils_conf import check_array, print_precision
-from . import __version__ as vip_version
+from vip_hci import __version__ as vip_version
 
 
 class HCIFrame:

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -464,7 +464,8 @@ class HCIDataset:
         interpreted as the path of the FITS file containing the sequence.
     hdu : int, optional
         If ``cube`` is a String, ``hdu`` indicates the HDU from the FITS file.
-        By default the first HDU is used.
+        By default the first HDU is used. ``hdu`` is used for both ``cube``
+        and ``cuberef``.
     angles : list or numpy array, optional
         The vector of parallactic angles.
     wavelengths : list or numpy array, optional
@@ -481,6 +482,23 @@ class HCIDataset:
         this dataset.
     cuberef : str or numpy array
         3d or 4d high-contrast image sequence. To be used as a reference cube.
+
+    Attributes
+    ----------
+    cube : 3d or 4d ndarray
+    cuberef : 3d or 4d ndarray, or None
+    psf : 2d or 3d ndarray, or None
+    psfn : 2d or 3d ndarray, or None
+    fwhm : float or 1d ndarray, or None
+    n: int
+        Number of frames in cube.
+    x, y : int
+    w : int
+        Size of the zeroth dimension of a 4D cube. ``0`` for 3D cubes.
+    angles : 1d ndarray
+    wavelengths : 1d ndarray or None
+    px_scale: float or None
+
     """
     def __init__(self, cube, hdu=0, angles=None, wavelengths=None, fwhm=None,
                  px_scale=None, psf=None, psfn=None, cuberef=None):
@@ -800,7 +818,7 @@ class HCIDataset:
         ----------
         angles : str or 1d numpy.ndarray
             List or vector with the parallactic angles.
-        hdu : int, optional
+        hdu : int or str, optional
             If ``angles`` is a String, ``hdu`` indicates the HDU from the FITS
             file. By default the first HDU is used.
         """
@@ -820,7 +838,7 @@ class HCIDataset:
         ----------
         wavelengths : str or 1d numpy.ndarray
             List or vector with the wavelengths.
-        hdu : int, optional
+        hdu : int or str, optional
             If ``wavelengths`` is a String, ``hdu`` indicates the HDU from the
             FITS file. By default the first HDU is used.
 

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -513,6 +513,12 @@ class HCIDataset:
         if isinstance(cube, str):
             self.cube, self.cube_fits_header = open_fits(cube, hdu, header=True,
                                                          verbose=False)
+
+            if ("VIP-VERS" in self.cube_fits_header
+                or "VIP-ATTR" in self.cube_fits_header):
+                print("This is a multi-HDU FITS file created by VIP. You "
+                      "probably want to use `HCIDataset.load()` instead.")
+
         elif isinstance(cube, tuple):
             self.cube, self.cube_fits_header = cube
         elif isinstance(cube, np.ndarray):

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -6,7 +6,7 @@ Module with HCIDataset and HCIFrame classes.
 
 from __future__ import division, print_function
 
-__author__ = 'Carlos Alberto Gomez Gonzalez'
+__author__ = 'Carlos Alberto Gomez Gonzalez, Ralf Farkas'
 __all__ = ['HCIDataset',
            'HCIFrame']
 

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -33,6 +33,7 @@ from .metrics import (frame_quick_report, cube_inject_companions, snr_ss,
                       snr_peakstddev, snrmap, snrmap_fast, detection,
                       normalize_psf)
 from .conf.utils_conf import check_array, print_precision
+from . import __version__ as vip_version
 
 
 class HCIFrame:
@@ -1254,6 +1255,7 @@ class HCIDataset:
             datetime.datetime.now().replace(microsecond=0).isoformat(" "),
             "file creation date (ISO 8601)"
         )
+        primary.header["VIP-VERS"] = (vip_version, "VIP version number")
         primary.header["VIP-TYPE"] = ("HCIDataset", "VIP object type")
 
         hdul = ap_fits.HDUList()

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -516,6 +516,7 @@ class HCIDataset:
         print('Cube array shape: {}'.format(self.cube.shape))
         if self.cube.ndim == 3:
             self.n, self.y, self.x = self.cube.shape
+            self.w = 0
         elif self.cube.ndim == 4:
             self.w, self.n, self.y, self.x = self.cube.shape
 

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -506,7 +506,8 @@ class HCIDataset:
         """
         # Loading the 3d/4d cube or image sequence
         if isinstance(cube, str):
-            self.cube = open_fits(cube, hdu, verbose=False)
+            self.cube, self.cube_fits_header = open_fits(cube, hdu, header=True,
+                                                         verbose=False)
         elif isinstance(cube, np.ndarray):
             if not (cube.ndim == 3 or cube.ndim == 4):
                 raise ValueError('`Cube` array has wrong dimensions')
@@ -522,7 +523,9 @@ class HCIDataset:
 
         # Loading the reference cube
         if isinstance(cuberef, str):
-            self.cuberef = open_fits(cuberef, hdu, verbose=False)
+            self.cuberef, self.cuberef_fits_header = open_fits(cuberef, hdu,
+                                                               header=True,
+                                                               verbose=False)
         elif isinstance(cuberef, np.ndarray):
             msg = '`Cuberef` array has wrong dimensions'
             if not cuberef.ndim == 3:
@@ -544,7 +547,9 @@ class HCIDataset:
 
         # Loading the angles (ADI)
         if isinstance(angles, str):
-            self.angles = open_fits(angles, verbose=False)
+            self.angles, self.angles_fits_header = open_fits(angles,
+                                                             header=True,
+                                                             verbose=False)
         else:
             self.angles = angles
         if self.angles is not None:
@@ -557,7 +562,8 @@ class HCIDataset:
 
         # Loading the scaling factors (mSDI)
         if isinstance(wavelengths, str):
-            self.wavelengths = open_fits(wavelengths, verbose=False)
+            self.wavelengths, self.wavelengths_fits_header = open_fits(
+                                        wavelengths, header=True, verbose=False)
         else:
             self.wavelengths = wavelengths
         if self.wavelengths is not None:
@@ -570,7 +576,8 @@ class HCIDataset:
 
         # Loading the PSF
         if isinstance(psf, str):
-            self.psf = open_fits(psf, verbose=False)
+            self.psf, self.psf_fits_header = open_fits(psf, header=True,
+                                                       verbose=False)
         else:
             self.psf = psf
         if self.psf is not None:
@@ -583,7 +590,8 @@ class HCIDataset:
 
         # Loading the normalized PSF
         if isinstance(psfn, str):
-            self.psfn = open_fits(psfn, verbose=False)
+            self.psfn, self.psfn_fits_header = open_fits(psfn, header=True,
+                                                         verbose=False)
         else:
             self.psfn = psfn
         if self.psfn is not None:

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -28,7 +28,7 @@ from .stats import (frame_basic_stats, frame_histo_stats,
 from .metrics import (frame_quick_report, cube_inject_companions, snr_ss,
                       snr_peakstddev, snrmap, snrmap_fast, detection,
                       normalize_psf)
-from .conf.utils_conf import check_array
+from .conf.utils_conf import check_array, print_precision
 
 
 class HCIFrame:
@@ -927,7 +927,8 @@ class HCIDataset:
         self.psfn, self.aperture_flux, self.fwhm = res
         print('Normalized PSF array shape: {}'.format(self.psfn.shape))
         print('The attribute `psfn` contains the normalized PSF')
-        print("`fwhm` attribute set to {:.3f}".format(self.fwhm))
+        print("`fwhm` attribute set to")
+        print_precision(self.fwhm)
 
     def plot(self, wavelength=0, **kwargs):
         """ Plotting the frames of a 3D or 4d cube (``wavelength``).


### PR DESCRIPTION
Notable changes:

- `HCIDataset.save` updated, so the entire dataset is stored inside a single FITS file (including angles, pixel scale, normalized PSF, ...)
- new `HCIDataset.load` to load back such a dataset
- `open_fits` now accepts a `slice=` for subsetting an array (e.g. SPHERE IRDIS creates a `(2, 2, 64, 64)` PSF for a `(2, 104, 1024, 1024)` cube)