### PR TITLE
cube_inject_companions: return x and y coordinates

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,25 @@
+from __future__ import division, print_function, absolute_import
+
+import numpy as np
+import vip_hci as vip
+import pytest
+
+
+def aarc(actual, desired, rtol=1e-5, atol=1e-6):
+    """
+    Assert array-compare. Like ``np.allclose``, but with different defaults.
+
+    Notes
+    -----
+    Default values for
+    - ``np.allclose``: ``atol=1e-8, rtol=1e-5``
+    - ``np.testing.assert_allclose``: ``atol=0, rtol=1e-7``
+
+    IDL's `FLOAT` is 32bit (precision of ~1e-6 to ~1e-7), while python uses
+    64-bit floats internally. To pass the comparison, `atol` has to be chosen
+    accordingly. The contribution of `rtol` is dominant for large numbers, where
+    an absolute comparison to `1e-6` would not make sense.
+
+    """
+    __tracebackhide__ = True  # Hide traceback for pytest
+    np.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol)

--- a/tests/test_metrics_fakecomp.py
+++ b/tests/test_metrics_fakecomp.py
@@ -1,0 +1,80 @@
+from __future__ import division, print_function
+
+import numpy as np
+
+import vip_hci as vip
+from vip_hci.metrics.fakecomp import cube_inject_companions
+
+
+# ===== utility functions
+
+def aarc(actual, desired, rtol=1e-5, atol=1e-6):
+    """
+    Assert array-compare. Like ``np.allclose``, but with different defaults.
+
+    Notes
+    -----
+    Default values for
+    - ``np.allclose``: ``atol=1e-8, rtol=1e-5``
+    - ``np.testing.assert_allclose``: ``atol=0, rtol=1e-7``
+
+    IDL's `FLOAT` is 32bit (precision of ~1e-6 to ~1e-7), while python uses
+    64-bit floats internally. To pass the comparison, `atol` has to be chosen
+    accordingly. The contribution of `rtol` is dominant for large numbers, where
+    an absolute comparison to `1e-6` would not make sense.
+
+    """
+    __tracebackhide__ = True  # Hide traceback for pytest
+    np.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol)
+
+
+def test_cube_inject_companions():
+    cube = np.zeros((3, 5, 5))
+    psf = np.ones((1, 1))
+    angles = np.array([0, 90, 180])
+
+    cube4 = np.zeros((2, 3, 5, 5))
+    psf4 = np.ones((2, 1, 1))
+
+    # single injection:
+    c, yx = cube_inject_companions(cube, psf_template=psf, angle_list=angles,
+                                   flevel=3, rad_dists=2, n_branches=1,
+                                   full_output=True,
+                                   plsc=1, verbose=True)
+
+    c_ref = np.array([[[0., 0., 0., 0., 0.],
+                       [0., 0., 0., 0., 0.],
+                       [0., 0., 0., 0., 3.],
+                       [0., 0., 0., 0., 0.],
+                       [0., 0., 0., 0., 0.]],
+
+                      [[0., 0., 3., 0., 0.],
+                       [0., 0., 0., 0., 0.],
+                       [0., 0., 0., 0., 0.],
+                       [0., 0., 0., 0., 0.],
+                       [0., 0., 0., 0., 0.]],
+
+                      [[0., 0., 0., 0., 0.],
+                       [0., 0., 0., 0., 0.],
+                       [3., 0., 0., 0., 0.],
+                       [0., 0., 0., 0., 0.],
+                       [0., 0., 0., 0., 0.]]])
+
+    aarc(c, c_ref)
+    aarc(yx, [(2, 4)])
+
+    # multiple injections:
+    c, yx = cube_inject_companions(cube, psf_template=psf, angle_list=angles,
+                                   flevel=3, rad_dists=[1, 2], n_branches=2,
+                                   full_output=True,
+                                   plsc=1, verbose=True)
+
+    aarc(yx, [(2, 3), (2, 4), (2, 1), (2, 0)])
+
+    # 4D case:
+    c, yx = cube_inject_companions(cube4, psf_template=psf4, angle_list=angles,
+                                   flevel=3, rad_dists=[1, 2], n_branches=2,
+                                   full_output=True,
+                                   plsc=1, verbose=True)
+
+    aarc(yx, [(2, 3), (2, 4), (2, 1), (2, 0)])

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -738,7 +738,7 @@ class HCIDataset:
 
     def inject_companions(self, flux, rad_dists, n_branches=1, theta=0,
                           imlib='opencv', interpolation='lanczos4',
-                          verbose=True):
+                          full_output=False, verbose=True):
         """ Injection of fake companions in 3d or 4d cubes.
 
         Parameters
@@ -770,14 +770,16 @@ class HCIDataset:
             For 'opencv' library: 'nearneig', 'bilinear', 'bicubic', 'lanczos4'.
             The 'nearneig' interpolation is the fastest and the 'lanczos4' the
             slowest and accurate. 'lanczos4' is the default.
+        full_output : bool, optional
+            Return the coordinates of the injected companions.
         verbose : bool, optional
             If True prints out additional information.
 
         Returns
         -------
         yx : list of tuple(y,x)
-            Pixel coordinates of the injections in the first frame (and first
-            wavelength for 4D cubes).
+            [if full_output] Pixel coordinates of the injections in the first
+            frame (and first wavelength for 4D cubes).
 
         """
         # TODO: support the injection of a Gaussian/Moffat kernel.
@@ -800,7 +802,8 @@ class HCIDataset:
                                                full_output=True,
                                                verbose=verbose)
 
-        return yx
+        if full_output:
+            return yx
 
     def load_angles(self, angles, hdu=0):
         """ Loads the PA vector from a FITS file. It is possible to specify the

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -773,6 +773,12 @@ class HCIDataset:
         verbose : bool, optional
             If True prints out additional information.
 
+        Returns
+        -------
+        yx : list of tuple(y,x)
+            Pixel coordinates of the injections in the first frame (and first
+            wavelength for 4D cubes).
+
         """
         # TODO: support the injection of a Gaussian/Moffat kernel.
         # TODO: return array/HCIDataset object instead?
@@ -787,10 +793,13 @@ class HCIDataset:
             if self.wavelengths is None:
                 raise ValueError('The wavelengths vector has not been set')
 
-        self.cube = cube_inject_companions(self.cube, self.psfn, self.angles,
-                                           flux, self.px_scale, rad_dists,
-                                           n_branches, theta, imlib,
-                                           interpolation, verbose)
+        self.cube, yx = cube_inject_companions(self.cube, self.psfn,
+                                               self.angles, flux, self.px_scale,
+                                               rad_dists, n_branches, theta,
+                                               imlib, interpolation, verbose,
+                                               full_output=True)
+
+        return yx
 
     def load_angles(self, angles, hdu=0):
         """ Loads the PA vector from a FITS file. It is possible to specify the

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -796,8 +796,9 @@ class HCIDataset:
         self.cube, yx = cube_inject_companions(self.cube, self.psfn,
                                                self.angles, flux, self.px_scale,
                                                rad_dists, n_branches, theta,
-                                               imlib, interpolation, verbose,
-                                               full_output=True)
+                                               imlib, interpolation,
+                                               full_output=True,
+                                               verbose=verbose)
 
         return yx
 

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -135,7 +135,7 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
 
     # ADI+IFS case
     if array.ndim == 4 and psf_template.ndim == 3:
-        ceny, cenx = frame_center(array[0,0])
+        ceny, cenx = frame_center(array[0, 0])
         ceny = int(float(ceny))
         cenx = int(float(cenx))
         if isinstance(rad_dists, (int, float)):
@@ -150,10 +150,10 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
 
         sizey = array.shape[2]
         sizex = array.shape[3]
-        size_fc = psf_template.shape[2] # considering square frames
+        size_fc = psf_template.shape[2]  # considering square frames
         nframes_wav = array.shape[0]
         nframes_adi = array.shape[1]
-        fc_fr = np.zeros((nframes_wav, sizey, sizex), dtype=np.float64) #-> 3d
+        fc_fr = np.zeros((nframes_wav, sizey, sizex), dtype=np.float64)  # -> 3d
         n_fc_rad = rad_dists.shape[0]
 
         for i in range(nframes_wav):
@@ -284,7 +284,7 @@ def collapse_psf_cube(array, size, fwhm=4, verbose=True, collapse='mean'):
     psf_normd = normalize_psf(psf, size=size, fwhm=fwhm)
 
     if verbose:
-        print("Done scaled PSF template from the average of", n,"frames.")
+        print("Done scaled PSF template from the average of", n, "frames.")
     return psf_normd
 
 
@@ -480,6 +480,3 @@ def normalize_psf(array, fwhm='fit', size=None, threshold=None, mask_core=None,
             return array_out, fwhm_flux, fwhm
         else:
             return array_out
-
-
-

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -27,16 +27,19 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
 
     Parameters
     ----------
-    array : array_like
-        Input frame or cube.
+    array : 3d/4d array_like
+        Input cube.
     psf_template : array_like
         2d array with the normalized psf template. It should have an odd shape.
         It's recommended to run the function ``normalize_psf`` to get a proper
         PSF template. In the ADI+mSDI case it must be a 3d array.
+    angle_list : 1d array_like
+        List of parallactic angles, in degrees.
     flevel : float or list
         Factor for controlling the brightness of the fake companions.
     plsc : float
-        Value of the plsc in arcsec/px.
+        Value of the plsc in arcsec/px. Only used for printing debug output when
+        ``verbose=True``.
     rad_dists : float, list or array 1d
         Vector of radial distances of fake companions in pixels.
     n_branches : int, optional

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -22,7 +22,8 @@ from ..conf.utils_conf import print_precision
 
 def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
                            rad_dists, n_branches=1, theta=0, imlib='opencv',
-                           interpolation='lanczos4', verbose=True):
+                           interpolation='lanczos4', full_output=False,
+                           verbose=True):
     """ Injects fake companions in branches, at given radial distances.
 
     Parameters
@@ -52,6 +53,9 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
         See the documentation of the ``vip_hci.preproc.frame_shift`` function.
     interpolation : str, optional
         See the documentation of the ``vip_hci.preproc.frame_shift`` function.
+    full_output : bool, optional
+        Returns the ``x`` and ``y`` coordinates of the injection, additionally
+        to the new array.
     verbose : bool, optional
         If True prints out additional information.
 
@@ -120,7 +124,6 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
                           '({:.2f} pxs)'.format(posx, posy, rad_arcs,
                                                rad_dists[i]))
 
-        return array_out
 
     # ADI+IFS case
     if array.ndim == 4 and psf_template.ndim == 3:
@@ -184,7 +187,10 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
                           '({:.2f} pxs)'.format(posx, posy, rad_arcs,
                                                 rad_dists[i]))
 
-    return array_out
+    if full_output:
+        return array_out, posx, posy
+    else:
+        return array_out
 
 
 def _cube_shift(cube, y, x, imlib, interpolation):

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -111,7 +111,7 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
             for branch in range(n_branches):
                 ang = (branch * 2 * np.pi / n_branches) + np.deg2rad(theta)
 
-                if verbose:
+                if verbose and fr == 0:
                     print('Branch {}:'.format(branch+1))
 
                 for rad in rad_dists:

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -178,7 +178,7 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
                     rad = rad_dists[i]
                     y = rad * np.sin(ang - np.deg2rad(angle_list[fr]))
                     x = rad * np.cos(ang - np.deg2rad(angle_list[fr]))
-                    if isinstance(flevel, int) or isinstance(flevel, float):
+                    if isinstance(flevel, (int, float)):
                         tmp += _cube_shift(fc_fr, y, x, imlib=imlib,
                                            interpolation=interpolation) * flevel
                     else:

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -63,6 +63,8 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
     -------
     array_out : array_like
         Output array with the injected fake companions.
+    posx, posy : int
+        Coordinates of the injection. Only returned when ``full_output=True``.
 
     """
     if array.ndim not in [3, 4]:

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -61,11 +61,10 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
         Output array with the injected fake companions.
 
     """
-    if array.ndim != 3 and array.ndim != 4:
+    if array.ndim not in [3, 4]:
         raise ValueError('Array is not a cube, 3d or 4d array')
-    if array.ndim == 4:
-        if not psf_template.ndim == 3:
-            raise ValueError('Psf must be a 3d array')
+    if array.ndim == 4 and psf_template.ndim != 3:
+        raise ValueError('PSF must be a 3d array')
 
     # ADI case
     if array.ndim == 3:
@@ -73,7 +72,7 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
         ceny = int(ceny)
         cenx = int(cenx)
 
-        rad_dists = np.asarray(rad_dists).reshape(-1)
+        rad_dists = np.asarray(rad_dists).reshape(-1)  # forces ndim=1
 
         if not rad_dists[-1] < array[0].shape[0]/2:
             raise ValueError('rad_dists last location is at the border (or '
@@ -111,7 +110,7 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
 
         if verbose:
             for branch in range(n_branches):
-                print('Branch '+str(branch+1)+':')
+                print('Branch {}:'.format(branch+1))
                 for i in range(len(rad_dists)):
                     ang = (branch * 2 * np.pi / n_branches) + np.deg2rad(theta)
                     posy = rad_dists[i] * np.sin(ang) + ceny
@@ -175,7 +174,7 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
 
         if verbose:
             for branch in range(n_branches):
-                print('Branch '+str(branch+1)+':')
+                print('Branch {}:'.format(branch+1))
                 for i in range(n_fc_rad):
                     ang = (branch * 2 * np.pi / n_branches) + np.deg2rad(theta)
                     rad_arcs = rad_dists[i]*plsc


### PR DESCRIPTION
With the new `full_output=True` parameter, `cube_inject_companions` returns the x and y coordinates together with the modified array.

This could be interesting for plotting, or for simplifying the EvalRoc logic.