### PR TITLE
FIX: normalize_psf creates wrong shapes

### DIFF
--- a/tests/test_fakecomp.py
+++ b/tests/test_fakecomp.py
@@ -1,0 +1,43 @@
+"""
+
+Tests for `metrics/fakecomp.py`.
+
+"""
+
+from __future__ import division, print_function
+
+import numpy as np
+import pytest
+
+import vip_hci as vip
+
+allclose = np.testing.assert_allclose
+array = np.array
+
+
+@pytest.mark.filterwarnings("ignore:invalid value encountered in true_divide")
+def test_normalize_psf_shapes():
+    """
+    Test if normalize_psf produces the expected shapes.
+    """
+    # `Force_odd` is True therefore `size` was set to 19
+    res_even = vip.metrics.normalize_psf(np.ones((20, 20)), size=18)
+    res_odd = vip.metrics.normalize_psf(np.ones((21, 21)), size=18)
+    assert res_even.shape == res_odd.shape == (19, 19)
+
+    res_even = vip.metrics.normalize_psf(np.ones((20, 20)), size=18,
+                                         force_odd=False)
+    res_odd = vip.metrics.normalize_psf(np.ones((21, 21)), size=18,
+                                        force_odd=False)
+    assert res_even.shape == res_odd.shape == (18, 18)
+
+    # set to odd size
+    res_even = vip.metrics.normalize_psf(np.ones((20, 20)), size=19)
+    res_odd = vip.metrics.normalize_psf(np.ones((21, 21)), size=19)
+    assert res_even.shape == res_odd.shape == (19, 19)
+
+    res_even = vip.metrics.normalize_psf(np.ones((20, 20)), size=19,
+                                         force_odd=False)
+    res_odd = vip.metrics.normalize_psf(np.ones((21, 21)), size=19,
+                                        force_odd=False)
+    assert res_even.shape == res_odd.shape == (19, 19)

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -321,7 +321,7 @@ def normalize_psf(array, fwhm='fit', size=None, threshold=None, mask_core=None,
         """ 2d case """
         if size is not None:
             if size < array.shape[0]:
-                psfs = frame_crop(array, size, force=force_odd, verbose=False)
+                psfs = frame_crop(array, size, force=True, verbose=False)
             else:
                 psfs = array.copy()
         else:
@@ -338,7 +338,7 @@ def normalize_psf(array, fwhm='fit', size=None, threshold=None, mask_core=None,
             psfs = frame_shift(array, -shifty, -shiftx, imlib=imlib,
                                interpolation=interpolation)
             if size is not None:
-                psfs = frame_crop(psfs, size, force=force_odd, verbose=False)
+                psfs = frame_crop(psfs, size, force=True, verbose=False)
 
             for _ in range(2):
                 centry, centrx = fit_2d(psfs)


### PR DESCRIPTION
I have a PSF with shape `(39, 39)`, loaded into a `HCIDataset`. Before this patch:

``` pycon
>>> hcidataset.normalize_psf(size=36)
`Force_odd` is True therefore `size` was set to 37
Mean FWHM: 4.801
Flux in 1xFWHM aperture: 1.307
Normalized PSF array shape: (37, 37)
The attribute `psfn` contains the normalized PSF
`fwhm` attribute set to 4.801

>>> hcidataset.normalize_psf(size=36, force_odd=False)
Mean FWHM: 4.801
Subframe size is even (while frame size is odd)
Setting subframe size to 37 pixels
Subframe size is even (while frame size is odd)
Setting subframe size to 37 pixels
Flux in 1xFWHM aperture: 1.307
Normalized PSF array shape: (37, 37)
The attribute `psfn` contains the normalized PSF
`fwhm` attribute set to 4.801
```

While `force_odd=False` tells `normalize_psf` to skip its checks, it is then erroneously passed as `force=force_odd` to the internal call to `frame_crop`.

After the patch, it works as expected:

``` pycon
>>> hcidataset.normalize_psf(size=36, force_odd=False)
Mean FWHM: 4.801
Flux in 1xFWHM aperture: 1.301
Normalized PSF array shape: (36, 36)
The attribute `psfn` contains the normalized PSF
`fwhm` attribute set to 4.801
```