### PR TITLE
DOC: Enhance Readme and FAQ

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -6,15 +6,20 @@ Please go and check the repository now. Alternatively, you can run:
 
 .. code-block:: bash
 
-  $ pip install --upgrade vip_hci
+  pip install --upgrade vip_hci
 
 
-* On linux, why do I get a matplotlib related error when importing ``VIP``?
-*ImportError: Matplotlib qt-based backends require an external PyQt4, PyQt5,
-or PySide package to be installed, but it was not found.*
+.. rubric:: On linux, why do I get a matplotlib related error when importing ``VIP``?
+
+::
+
+    ImportError: Matplotlib qt-based backends require an external PyQt4,
+    PyQt5, or PySide package to be installed, but it was not found.
+
+
 You may need to change the matplotlib backend. Find your matplotlibrc
 configuration file and change the backend from WXAgg to TkAgg (or the appropriate
-backend for your sytem). More info here:
+backend for your system). More info here:
 http://matplotlib.org/faq/usage_faq.html#what-is-a-backend. On linux the
 matplotlibrc file is located in:
 
@@ -23,15 +28,15 @@ matplotlibrc file is located in:
   $HOME/.config/matplotlib/matplotlibrc
 
 
-* I get a RuntimeError (Python is not installed as a framework) in Macosx,
-when using python3 and conda. Why?
-This is caused by using matplotlib with virtual environments or conda in Macosx,
-and has nothing to do with VIP. See 'Working with Matplotlib on OSX' in the
+.. rubric:: I get a RuntimeError (Python is not installed as a framework) in macOS when using python3 and conda.
+
+This is caused by using matplotlib with virtual environments or conda in macOS,
+and has nothing to do with VIP. See `Working with Matplotlib on OSX <https://matplotlib.org/faq/osx_framework.html>`_ in the
 Matplotlib FAQ for more information.
 
 
-* The ``VIP`` setup.py script doesn't finish the job, it seems to be stuck. What
-to do?
+.. rubric:: The ``VIP`` setup.py script doesn't finish the job, it seems to be stuck.
+
 This is very unlikely to happen with the latest versions of pip, setuptools
 and ``VIP``'s setup script. If you encounter this situation just kill the process
 (Ctrl + C) and start it again by re-running the setup command. A workaround
@@ -42,17 +47,19 @@ is to install the problematic dependency before executing ``VIP`` setup:
   $ pip install <problematic_dependency>
 
 
-* Why the setup fails complaining about the lack of a Fortran compiler?
-Fortran compilers are apparently needed for compiling ``Scipy`` from source. Make
+.. rubric:: Why does the setup fail complaining about the lack of a Fortran compiler?
+
+Fortran compilers are apparently needed for compiling ``scipy`` from source. Make
 sure there is a Fortran compiler in your system. A workaround is to install
-``Scipy`` through conda before running the setup script:
+``scipy`` through conda before running the setup script:
 
 .. code-block:: bash
 
   $ conda install scipy
 
 
-* Why do I get and error related to importing ``cv2`` package when importing ``VIP``?
+.. rubric:: Why do I get and error related to importing ``cv2`` package when importing ``VIP``?
+
 ``cv2`` is the name of ``Opencv`` bindings for python. This library is needed for
 fast image transformations, it is the default library used although it is optional.
 You can install it with conda:
@@ -62,13 +69,15 @@ You can install it with conda:
   $ conda install opencv
 
 
-* Why do I get a warning related to ``DS9/XPA`` when importing ``VIP``?
+.. rubric:: Why do I get a warning related to ``DS9/XPA`` when importing ``VIP``?
+
 Please make sure you have ``DS9`` and ``XPA`` in your system path. Try installing
 them using your system's package management tool.
 
 
-* Why Python crashes when using some of the parallel functions, e.g.
-``pca_adi_annular`` and ``run_mcmc_astrometry``?
+.. rubric:: Why does Python crash when using some of the parallel functions, e.g. ``pca_adi_annular`` and ``run_mcmc_strometry``?
+
+
 These functions require running SVD on several processes and this can be
 problematic depending on the linear algebra libraries on your machine. We've
 encountered this problem on OSX systems that use the ACCELERATE library for
@@ -85,11 +94,14 @@ the existing cores. With ``conda`` you can run:
   $ conda install mkl
 
 
-* I get an error: ValueError: "unknown locale: UTF-8" when importing ``VIP``.
+.. rubric:: I get an error: ValueError: "unknown locale: UTF-8" when importing ``VIP``.
+
 It's not ``VIP``'s fault. The problem must be solved if you add these lines in
-your ~/.bash_profile:
+your ``~/.bash_profile``:
 
 .. code-block:: bash
 
   export LC_ALL=en_US.UTF-8
   export LANG=en_US.UTF-8
+
+

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -89,8 +89,7 @@ The benefits of using a Python package manager (distribution), such as
 (ana)conda or Canopy, are many. Mainly, it brings easy and robust package
 management and avoids messing up with your system's default python. An
 alternative is to use package managers like apt-get for Ubuntu or
-Homebrew/MacPorts/Fink for macOS. I personally recommend using Miniconda which
-you can find here: https://conda.io/miniconda.html.
+Homebrew/MacPorts/Fink for macOS. I personally recommend using `Miniconda <https://conda.io/miniconda>`_.
 
 ``VIP`` depends on existing packages from the Python ecosystem, such as
 ``numpy``, ``scipy``, ``matplotlib``, ``pandas``, ``astropy``, ``scikit-learn``,

--- a/docs/source/readme.rst
+++ b/docs/source/readme.rst
@@ -47,17 +47,17 @@ differential imaging for exoplanet/disk detection through high-contrast imaging.
 The goal of ``VIP`` is to incorporate open-source, efficient, easy-to-use and
 well-documented implementations of high-contrast image processing algorithms to
 the interested scientific community. The main repository of ``VIP`` resides on
-`Github <https://github.com/vortex-exoplanet/VIP>`_, the standard for scientific
+`GitHub <https://github.com/vortex-exoplanet/VIP>`_, the standard for scientific
 open source code distribution, using Git as a version control system.
 
 ``VIP`` started as the effort of `Carlos Alberto Gomez Gonzalez <https://carlgogo.github.io/>`_,
 a former PhD student of the `VORTEX team <http://www.vortex.ulg.ac.be/>`_
 (ULiege, Belgium). ``VIP``'s development is led by C. Gomez with contributions
-made by collaborators from several teams (take a look at the tab contributors on
-``VIP``'s Github repository). Most of ``VIP``'s functionalities are mature but
+made by collaborators from several teams (take a look at the `contributors tab <https://github.com/vortex-exoplanet/VIP/graphs/contributors>`_ on
+``VIP``'s GitHub repository). Most of ``VIP``'s functionalities are mature but
 it doesn't mean it's free from bugs. The code is continuously evolving and
 therefore feedback/contributions are greatly appreciated. If you want to report
-a bug or suggest a functionality please create an issue on Github. Pull
+a bug or suggest a functionality please create an issue on GitHub. Pull
 requests are very welcomed!
 
 
@@ -89,7 +89,7 @@ The benefits of using a Python package manager (distribution), such as
 (ana)conda or Canopy, are many. Mainly, it brings easy and robust package
 management and avoids messing up with your system's default python. An
 alternative is to use package managers like apt-get for Ubuntu or
-Homebrew/MacPorts/Fink for Macos. I personally recommend using Miniconda which
+Homebrew/MacPorts/Fink for macOS. I personally recommend using Miniconda which
 you can find here: https://conda.io/miniconda.html.
 
 ``VIP`` depends on existing packages from the Python ecosystem, such as
@@ -98,10 +98,10 @@ you can find here: https://conda.io/miniconda.html.
 installing ``VIP`` suitable for different scenarios.
 
 
-Using PIP
+Using pip
 ^^^^^^^^^
 The easiest way to install ``VIP`` is through the Python Package Index, aka
-`Pypi <https://pypi.org/>`_, with the ``pip`` package manager. Simply run:
+`PyPI <https://pypi.org/>`_, with the ``pip`` package manager. Simply run:
 
 .. code-block:: bash
 
@@ -114,7 +114,7 @@ With ``pip`` you can easily uninstall, upgrade or install a specific version of
 
   $ pip install --upgrade vip_hci
 
-Alternatively, you can use ``pip install`` and point to the Github repo:
+Alternatively, you can use ``pip install`` and point to the GitHub repo:
 
 .. code-block:: bash
 
@@ -122,15 +122,15 @@ Alternatively, you can use ``pip install`` and point to the Github repo:
 
 Using the setup.py file
 ^^^^^^^^^^^^^^^^^^^^^^^
-You can download ``VIP`` from its Github repository as a zip file. A setup.py
-file (Setuptools) is included in the root folder of ``VIP``. Enter the package's
+You can download ``VIP`` from its GitHub repository as a zip file. A ``setup.py``
+file (setuptools) is included in the root folder of ``VIP``. Enter the package's
 root folder and run:
 
 .. code-block:: bash
 
   $ python setup.py install
 
-Using GIT
+Using Git
 ^^^^^^^^^
 If you want to benefit from the ``git`` functionalities, you need to clone the
 repository (make sure your system has ``git`` installed):
@@ -140,16 +140,16 @@ repository (make sure your system has ``git`` installed):
   $ git clone https://github.com/vortex-exoplanet/VIP.git
 
 Then you can install the package by following the previous steps, using the
-setup.py file. Creating a fork with Github is recommended to developers or to
+setup.py file. Creating a fork with GitHub is recommended to developers or to
 users who want to experiment with the code.
 
 Other dependencies
 ^^^^^^^^^^^^^^^^^^
-``Opencv`` (Open source Computer Vision) provides fast c++ image processing
+``OpenCV`` (Open source Computer Vision) provides fast C++ image processing
 operations and is used by ``VIP`` for basic image transformations. If you don't
-have/want the ``opencv`` python bindings (``opencv`` is optional since ``VIP``
-v0.5.2), ``VIP`` will use the much slower ``ndimage/scikit-image`` libraries
-transparently. Fortunately, installing ``opencv`` library is nowadays and easy
+have/want the ``OpenCV`` python bindings (``OpenCV`` is optional since ``VIP``
+v0.5.2), ``VIP`` will use the much slower ``ndimage``/``scikit-image`` libraries
+transparently. Fortunately, installing ``OpenCV`` library is nowadays and easy
 process that is done automatically with the ``VIP`` installation. Alternatively,
 you could use ``conda``:
 
@@ -169,10 +169,10 @@ installed from the latest development version:
 Also, you can install the Intel Math Kernel Library (MKL) optimizations
 (provided that you have a recent version of ``conda``) or ``openblas``
 libraries. Either of them can be installed with ``conda install``. This is
-recommended along with ``Opencv`` for maximum speed on ``VIP`` computations.
+recommended along with ``OpenCV`` for maximum speed on ``VIP`` computations.
 
-``VIP`` offers the possibility of computing SVDs on GPU by using ``cupy``
-(starting from version 0.8.0) or ''pytorch`` (from version 0.9.2). These remain
+``VIP`` offers the possibility of computing SVDs on GPU by using ``CuPy``
+(starting from version 0.8.0) or ``PyTorch`` (from version 0.9.2). These remain
 as optional requirements, to be installed by the user, as well as a proper CUDA
 environment (and a decent GPU card).
 
@@ -191,8 +191,8 @@ Now you can start finding exoplanets!
 
 Mailing list
 ------------
-Please subscribe to our `mailing <http://lists.astro.caltech.edu:88/mailman/listinfo/vip>`_
-list if you want to be informed of ``VIP``'s latest developments (new versions
+Please subscribe to our `mailing list <http://lists.astro.caltech.edu:88/mailman/listinfo/vip>`_
+if you want to be informed of ``VIP``'s latest developments (new versions
 and/or updates).
 
 

--- a/readme.rst
+++ b/readme.rst
@@ -89,8 +89,7 @@ The benefits of using a Python package manager (distribution), such as
 (ana)conda or Canopy, are many. Mainly, it brings easy and robust package
 management and avoids messing up with your system's default python. An
 alternative is to use package managers like apt-get for Ubuntu or
-Homebrew/MacPorts/Fink for macOS. I personally recommend using Miniconda which
-you can find here: https://conda.io/miniconda.html.
+Homebrew/MacPorts/Fink for macOS. I personally recommend using `Miniconda <https://conda.io/miniconda>`_.
 
 ``VIP`` depends on existing packages from the Python ecosystem, such as
 ``numpy``, ``scipy``, ``matplotlib``, ``pandas``, ``astropy``, ``scikit-learn``,

--- a/readme.rst
+++ b/readme.rst
@@ -47,17 +47,17 @@ differential imaging for exoplanet/disk detection through high-contrast imaging.
 The goal of ``VIP`` is to incorporate open-source, efficient, easy-to-use and
 well-documented implementations of high-contrast image processing algorithms to
 the interested scientific community. The main repository of ``VIP`` resides on
-`Github <https://github.com/vortex-exoplanet/VIP>`_, the standard for scientific
+`GitHub <https://github.com/vortex-exoplanet/VIP>`_, the standard for scientific
 open source code distribution, using Git as a version control system.
 
 ``VIP`` started as the effort of `Carlos Alberto Gomez Gonzalez <https://carlgogo.github.io/>`_,
 a former PhD student of the `VORTEX team <http://www.vortex.ulg.ac.be/>`_
 (ULiege, Belgium). ``VIP``'s development is led by C. Gomez with contributions
-made by collaborators from several teams (take a look at the tab contributors on
-``VIP``'s Github repository). Most of ``VIP``'s functionalities are mature but
+made by collaborators from several teams (take a look at the `contributors tab <https://github.com/vortex-exoplanet/VIP/graphs/contributors>`_ on
+``VIP``'s GitHub repository). Most of ``VIP``'s functionalities are mature but
 it doesn't mean it's free from bugs. The code is continuously evolving and
 therefore feedback/contributions are greatly appreciated. If you want to report
-a bug or suggest a functionality please create an issue on Github. Pull
+a bug or suggest a functionality please create an issue on GitHub. Pull
 requests are very welcomed!
 
 
@@ -89,7 +89,7 @@ The benefits of using a Python package manager (distribution), such as
 (ana)conda or Canopy, are many. Mainly, it brings easy and robust package
 management and avoids messing up with your system's default python. An
 alternative is to use package managers like apt-get for Ubuntu or
-Homebrew/MacPorts/Fink for Macos. I personally recommend using Miniconda which
+Homebrew/MacPorts/Fink for macOS. I personally recommend using Miniconda which
 you can find here: https://conda.io/miniconda.html.
 
 ``VIP`` depends on existing packages from the Python ecosystem, such as
@@ -98,10 +98,10 @@ you can find here: https://conda.io/miniconda.html.
 installing ``VIP`` suitable for different scenarios.
 
 
-Using PIP
+Using pip
 ^^^^^^^^^
 The easiest way to install ``VIP`` is through the Python Package Index, aka
-`Pypi <https://pypi.org/>`_, with the ``pip`` package manager. Simply run:
+`PyPI <https://pypi.org/>`_, with the ``pip`` package manager. Simply run:
 
 .. code-block:: bash
 
@@ -114,7 +114,7 @@ With ``pip`` you can easily uninstall, upgrade or install a specific version of
 
   $ pip install --upgrade vip_hci
 
-Alternatively, you can use ``pip install`` and point to the Github repo:
+Alternatively, you can use ``pip install`` and point to the GitHub repo:
 
 .. code-block:: bash
 
@@ -122,15 +122,15 @@ Alternatively, you can use ``pip install`` and point to the Github repo:
 
 Using the setup.py file
 ^^^^^^^^^^^^^^^^^^^^^^^
-You can download ``VIP`` from its Github repository as a zip file. A setup.py
-file (Setuptools) is included in the root folder of ``VIP``. Enter the package's
+You can download ``VIP`` from its GitHub repository as a zip file. A ``setup.py``
+file (setuptools) is included in the root folder of ``VIP``. Enter the package's
 root folder and run:
 
 .. code-block:: bash
 
   $ python setup.py install
 
-Using GIT
+Using Git
 ^^^^^^^^^
 If you want to benefit from the ``git`` functionalities, you need to clone the
 repository (make sure your system has ``git`` installed):
@@ -140,16 +140,16 @@ repository (make sure your system has ``git`` installed):
   $ git clone https://github.com/vortex-exoplanet/VIP.git
 
 Then you can install the package by following the previous steps, using the
-setup.py file. Creating a fork with Github is recommended to developers or to
+setup.py file. Creating a fork with GitHub is recommended to developers or to
 users who want to experiment with the code.
 
 Other dependencies
 ^^^^^^^^^^^^^^^^^^
-``Opencv`` (Open source Computer Vision) provides fast c++ image processing
+``OpenCV`` (Open source Computer Vision) provides fast C++ image processing
 operations and is used by ``VIP`` for basic image transformations. If you don't
-have/want the ``opencv`` python bindings (``opencv`` is optional since ``VIP``
-v0.5.2), ``VIP`` will use the much slower ``ndimage/scikit-image`` libraries
-transparently. Fortunately, installing ``opencv`` library is nowadays and easy
+have/want the ``OpenCV`` python bindings (``OpenCV`` is optional since ``VIP``
+v0.5.2), ``VIP`` will use the much slower ``ndimage``/``scikit-image`` libraries
+transparently. Fortunately, installing ``OpenCV`` library is nowadays and easy
 process that is done automatically with the ``VIP`` installation. Alternatively,
 you could use ``conda``:
 
@@ -169,10 +169,10 @@ installed from the latest development version:
 Also, you can install the Intel Math Kernel Library (MKL) optimizations
 (provided that you have a recent version of ``conda``) or ``openblas``
 libraries. Either of them can be installed with ``conda install``. This is
-recommended along with ``Opencv`` for maximum speed on ``VIP`` computations.
+recommended along with ``OpenCV`` for maximum speed on ``VIP`` computations.
 
-``VIP`` offers the possibility of computing SVDs on GPU by using ``cupy``
-(starting from version 0.8.0) or ''pytorch`` (from version 0.9.2). These remain
+``VIP`` offers the possibility of computing SVDs on GPU by using ``CuPy``
+(starting from version 0.8.0) or ``PyTorch`` (from version 0.9.2). These remain
 as optional requirements, to be installed by the user, as well as a proper CUDA
 environment (and a decent GPU card).
 
@@ -191,8 +191,8 @@ Now you can start finding exoplanets!
 
 Mailing list
 ------------
-Please subscribe to our `mailing <http://lists.astro.caltech.edu:88/mailman/listinfo/vip>`_
-list if you want to be informed of ``VIP``'s latest developments (new versions
+Please subscribe to our `mailing list <http://lists.astro.caltech.edu:88/mailman/listinfo/vip>`_
+if you want to be informed of ``VIP``'s latest developments (new versions
 and/or updates).
 
 


### PR DESCRIPTION
- correct capitalisation for proper names (e.g. `PyPI`, `GitHub`, etc.)
- use `rubric` directive for FAQ, so that the headings do not show up in TOC