### PR TITLE
FEAT: Make HCIDataset « Saveable »

### DIFF
--- a/tests/test_saveable.py
+++ b/tests/test_saveable.py
@@ -1,0 +1,27 @@
+from __future__ import print_function, division
+
+import tempfile
+import os
+
+import numpy as np
+import vip_hci as vip
+
+
+def test_saveable_dataset():
+    cube = np.zeros((5, 10, 10))
+    angles = np.linspace(1, 2, 5)
+    fwhm = 4  # test non-numpy type saving/loading
+
+    ds = vip.HCIDataset(cube=cube, angles=angles, fwhm=fwhm)
+
+    fd, fn = tempfile.mkstemp(prefix="vip_")
+
+    ds.save(fn)
+
+    ds2 = vip.HCIDataset.load(fn)
+
+    assert np.allclose(ds2.cube, cube)
+    assert np.allclose(ds2.angles, angles)
+    assert ds2.fwhm == fwhm
+
+    os.remove(fn)

--- a/vip_hci/conf/utils_conf.py
+++ b/vip_hci/conf/utils_conf.py
@@ -59,8 +59,8 @@ class Saveable(object):
                     if not isinstance(getattr(self, a), np.ndarray):
                         data["_item_{}".format(a)] = True
 
-                np.savez_compressed(filename, **data, _vip_version=__version__,
-                                    _vip_object=vip_object)
+                np.savez_compressed(filename, _vip_version=__version__,
+                                    _vip_object=vip_object, **data)
 
         else:
             raise RuntimeError("_saved_attributes not found for class {}"

--- a/vip_hci/conf/utils_conf.py
+++ b/vip_hci/conf/utils_conf.py
@@ -16,6 +16,8 @@ import numpy as np
 import itertools as itt
 from multiprocessing import Pool
 
+from vip_hci import __version__
+
 sep = '-' * 80
 vip_figsize = (10, 5)
 
@@ -24,6 +26,81 @@ def print_precision(array, precision=3):
     """ Prints an array with a given floating point precision. 3 by default.
     """
     return print(np.array2string(array.astype(float), precision=precision))
+
+
+class SaveableEmpty(object):
+    """
+    Empty object. Used by ``Saveable`` to restore the state of an object wihtout
+    calling __init__. Similar to what pickle/copy do.
+    """
+    pass
+
+
+class Saveable(object):
+    def save(self, filename):
+        """
+        Save a VIP object to a npz file.
+
+
+        """
+
+        vip_object = self.__class__.__name__
+
+        if hasattr(self, "_saved_attributes"):
+
+            data = {}
+
+            for a in self._saved_attributes:
+                if hasattr(self, a):
+                    data[a] = getattr(self, a)
+
+                    # set marker to re-build the original datatype
+                    # (for non-np types like float, string, ...)
+                    if not isinstance(getattr(self, a), np.ndarray):
+                        data["_item_{}".format(a)] = True
+
+                np.savez_compressed(filename, **data, _vip_version=__version__,
+                                    _vip_object=vip_object)
+
+        else:
+            raise RuntimeError("_saved_attributes not found for class {}"
+                               "".format(vip_object))
+
+    @classmethod
+    def load(cls, filename):
+        if not filename.endswith(".npz"):
+            filename += ".npz"
+
+        data = np.load(filename)
+
+        if "_vip_object" not in data:
+            raise RuntimeError("The file you specified is not a VIP object.")
+
+        file_vip_object = data["_vip_object"].item()
+        if file_vip_object != cls.__name__:
+            raise RuntimeError("The object in the file is of type '{}', please "
+                               "use that classes 'load()' method instead."
+                               "".format(file_vip_object))
+
+        file_vip_version = data["_vip_version"].item()
+        if file_vip_version != __version__:
+            print("The file was saved with VIP {}. There may be some"
+                  "compatibility issues. Use with care."
+                  "".format(file_vip_version))
+
+        self = SaveableEmpty()
+        self.__class__ = cls
+
+        for k in data:
+            if k.startswith("_"):
+                continue
+
+            if "_item_{}".format(k) in data:
+                setattr(self, k, data[k].item())  # un-pack np array
+            else:
+                setattr(self, k, data[k])
+
+        return self
 
 
 class Progressbar(object):
@@ -157,7 +234,7 @@ def check_array(input, dim=1, name=None):
 
 def eval_func_tuple(f_args):
     """ Takes a tuple of a function and args, evaluates and returns result"""
-    return f_args[0](*f_args[1:])                       
+    return f_args[0](*f_args[1:])
 
 
 class FixedObj(object):
@@ -188,7 +265,7 @@ def fixed(v):
         pool_map(3, worker, fixed(words), method)
 
         # this results in calling
-        # 
+        #
         # worker(words[0], 1)
         # worker(words[1], 1)
         # worker(words[2], 1)
@@ -288,11 +365,11 @@ def pool_imap(nproc, fkt, *args, **kwargs):
     .. code-block:: python
 
         # using pool_map
-    
+
         res = pool_map(2, my_worker_function, *args)
-    
+
         # using pool_imap with a progessbar:
-    
+
         res = list(Progressbar(pool_imap(2, my_worker_function, *args)))
 
     """
@@ -311,7 +388,7 @@ def repeat(*args):
     # instead of using
 
     import itertools as itt
-    
+
     my_fkt(itt.repeat(a), itt.repeat(b), itt.repeat(c), d, itt.repeat(e))
 
     # you could use `repeat`:

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -454,7 +454,7 @@ class HCIFrame(object):
         _ = frame_quick_report(self.image, self.fwhm, source_xy, verbose)
 
 
-class HCIDataset(object):
+class HCIDataset(Saveable):
     """ High-contrast imaging dataset class.
 
     Parameters
@@ -482,6 +482,10 @@ class HCIDataset(object):
     cuberef : str or numpy array
         3d or 4d high-contrast image sequence. To be used as a reference cube.
     """
+
+    _saved_attributes = ["cube", "psf", "psfn", "angles", "fwhm", "wavelengths",
+                         "px_scale"]
+
     def __init__(self, cube, hdu=0, angles=None, wavelengths=None, fwhm=None,
                  px_scale=None, psf=None, psfn=None, cuberef=None):
         """ Initialization of the HCIDataset object.

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -1184,7 +1184,7 @@ class HCIDataset(Saveable):
         self.cube = cube_px_resampling(self.cube, scale, imlib, interpolation,
                                        verbose)
 
-    def save(self, path, precision=np.float32):
+    def export_fits(self, path, precision=np.float32):
         """ Writing to FITS file. If self.angles is present, then the angles
         are appended to the FITS file.
 

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -28,7 +28,7 @@ from .stats import (frame_basic_stats, frame_histo_stats,
 from .metrics import (frame_quick_report, cube_inject_companions, snr_ss,
                       snr_peakstddev, snrmap, snrmap_fast, detection,
                       normalize_psf)
-from .conf.utils_conf import check_array
+from .conf.utils_conf import check_array, Saveable
 
 
 class HCIFrame(object):

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -30,7 +30,6 @@ from .metrics import (frame_quick_report, cube_inject_companions, snr_ss,
                       normalize_psf)
 
 from .conf.utils_conf import check_array, Saveable, print_precision
-from .conf.utils_conf import check_array, print_precision
 
 
 class HCIFrame(object):


### PR DESCRIPTION
The new `Saveable` superclass allows objects to be saved as `npz`.


#### prepare classes to be saveable
Two things need to be done for an object to be saveable:

- inherit from the `Saveable` class and
- add a `_saved_attributes` class attribute.

The `_saved_attributes` tell the `Saveable` class which attributes it should save and load. This allows to e.g. exclude keras models etc, which cannot be saved with numpy.


#### internals

Internally, the `np.savez_compressed` function is used. It creates a zip file with the ending `.npz`, and each keyword argument is stored as separate `npy` file in it. The `npy` format was built for numpy arrays, so **each** object attribute is **stored as numpy array**.

The `Saveable` class checks for non-array attributes (e.g. float, int, string, ...) and marks them, so when loading the object from an `.npz` file it transforms those back to the original data type.