### PR TITLE
FIX: readthedocs autodoc

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,22 +18,7 @@
 #
 import os
 import sys
-from mock import Mock as MagicMock
 
-
-class Mock(MagicMock):
-    @classmethod
-    def __getattr__(cls, name):
-        return MagicMock()
-
-
-MOCK_MODULES = ['photutils', 'astropy', 'astropy.stats', 'astropy.convolution',
-                'astropy.io', 'astropy.modeling', 'astropy.table',
-                'astropy.coordinates', 'astropy.time', 'astropy.units', 'pyds9',
-                'matplotlib', 'matplotlib.externals', 'matplotlib.pyplot',
-                'matplotlib.ticker', 'matplotlib.mlab', 'matplotlib.colors',
-                'matplotlib.cm', 'pandas', 'pandas.core']
-sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 
 sys.path.insert(0, os.path.abspath('../../vip_hci/'))

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,6 +19,9 @@
 import os
 import sys
 
+# fix for `ImportError: No module named _tkinter`:
+import matplotlib
+matplotlib.use("agg")
 
 
 sys.path.insert(0, os.path.abspath('../../vip_hci/'))

--- a/vip_hci/metrics/fakedisk.py
+++ b/vip_hci/metrics/fakedisk.py
@@ -19,19 +19,20 @@ from ..var import frame_center
 def create_fakedisk_cube(fakedisk, angle_list, psf=None, imlib='opencv',
                          interpolation='lanczos4', cxy=None, nproc=1,
                          border_mode='constant'):
-    """ Rotates an ADI cube to a common north given a vector with the 
-    corresponding parallactic angles for each frame of the sequence. By default
-    bicubic interpolation is used (opencv). 
-    
+    """
+    Rotates an ADI cube to a common north given a vector with the corresponding
+    parallactic angles for each frame of the sequence. By default bicubic
+    interpolation is used (opencv).
+
     Parameters
     ----------
-    fakedisk : array_like 
+    fakedisk : array_like
         Input image of a fake disc
     angle_list : list
         Vector containing the parallactic angles.
     psf : (optionnal) the PSF to convolve the disk image with. It can be a
         small numpy.ndarray (we advise to use odd sizes to make sure the center
-        s not shifted through the convolution). It forces normalization of the 
+        s not shifted through the convolution). It forces normalization of the
         PSF to preserve the flux. It can also be a float representing
         the FWHM of the gaussian to be used for convolution.
     imlib : str, optional
@@ -39,8 +40,8 @@ def create_fakedisk_cube(fakedisk, angle_list, psf=None, imlib='opencv',
     interpolation : str, optional
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
     cxy : tuple of int, optional
-        Coordinates X,Y  of the point with respect to which the rotation will be 
-        performed. By default the rotation is done with respect to the center 
+        Coordinates X,Y  of the point with respect to which the rotation will be
+        performed. By default the rotation is done with respect to the center
         of the frames, as it is returned by the function
         vip_hci.var.frame_center.
     nproc : int, optional
@@ -49,23 +50,26 @@ def create_fakedisk_cube(fakedisk, angle_list, psf=None, imlib='opencv',
         number of frames).
     border_mode : str, optional
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
-        
+
     Returns
     -------
     fakedisk_cube : array_like
-        Resulting cube with the fake disc inserted at the correct angles and 
+        Resulting cube with the fake disc inserted at the correct angles and
         convolved with the psf if a psf was provided.
 
     Notes
     -----
-    import numpy as np
+    .. code-block:: python
 
-    fakedisk = np.zeros((200,200))
-    fakedisk[:,99:101] = 1
-    angle_list = np.arange(10)
-    c = create_fakedisk_cube(fakedisk, angle_list, psf=None, imlib='opencv',
-                             interpolation='lanczos4',cxy=None, nproc=1,
-                             border_mode='constant')
+        import numpy as np
+
+        fakedisk = np.zeros((200,200))
+        fakedisk[:,99:101] = 1
+        angle_list = np.arange(10)
+        c = create_fakedisk_cube(fakedisk, angle_list, psf=None, imlib='opencv',
+                                 interpolation='lanczos4',cxy=None, nproc=1,
+                                 border_mode='constant')
+
     """
     if not fakedisk.ndim == 2:
         raise TypeError('Fakedisk is not a frame or a 2d array.')


### PR DESCRIPTION
I was playing with sphinx and readthedocs, and found out the entire `Mock` is not needed. Although, I had to set the matplotlib backend to `agg`, as readthedocs complained about `ImportError: No module named _tkinter`.

Please check the [documentation created from this PR](https://vip-test-.readthedocs.io/en/patch-rtd/) (it tracks my `patch-rtd` branch), and its [build log](https://readthedocs.org/projects/vip-test-/builds/7595259/).