### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: required
 python:
   - 2.7
   - 3.6
+  - 3.7
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 
 sudo: required
+dist: xenial # no 3.7 on 14.04 Trusty
 
 python:
   - 2.7

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ VIP - Vortex Image Processing package
 .. image:: https://badge.fury.io/py/vip-hci.svg
     :target: https://pypi.python.org/pypi/vip-hci
 
-.. image:: https://img.shields.io/badge/Python-2.7%2C%203.6-brightgreen.svg
+.. image:: https://img.shields.io/badge/Python-2.7%2C%203.6%2C%203.7-brightgreen.svg
     :target: https://pypi.python.org/pypi/vip-hci
 
 .. image:: https://travis-ci.org/vortex-exoplanet/VIP.svg?branch=master
@@ -42,7 +42,7 @@ Introduction
 
 ``VIP`` is a python package for angular, reference star and spectral
 differential imaging for exoplanet/disk detection through high-contrast imaging.
-``VIP`` is compatible with Python 2.7 and 3.6.
+``VIP`` is compatible with Python 2.7, 3.6 and 3.7.
 
 The goal of ``VIP`` is to incorporate open-source, efficient, easy-to-use and
 well-documented implementations of high-contrast image processing algorithms to

--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,7 @@ setup(
                  'Natural Language :: English',
                  'Programming Language :: Python :: 2.7',
                  'Programming Language :: Python :: 3.6',
+                 'Programming Language :: Python :: 3.7',
                  'Topic :: Scientific/Engineering :: Astronomy'
                  ]
 )


### PR DESCRIPTION
The code and dependencies of VIP are fully compatible with Python 3.7 (now that the new `photutils` 0.5 was released), so we can officially support the latest version!

Resolves https://github.com/vortex-exoplanet/VIP/issues/252.