### PR TITLE
Remove old FITS functions

### DIFF
--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -7,10 +7,8 @@ from __future__ import division, print_function
 
 __author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['open_fits',
-           'open_adicube',
            'info_fits',
            'write_fits',
-           'append_extension',
            'verify_fits',
            'byteswap_array']
 
@@ -67,44 +65,6 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
                 print("Fits HDU-{} data successfully loaded. "
                       "Data shape: {}".format(n, data.shape))
             return data
-
-
-def open_adicube(fitsfilename, verbose=True):
-    """ Opens an ADI cube with the parallactic angles appended (see function
-    append_par_angles).
-    
-    Parameters
-    ----------
-    fitsfilename : string or pathlib.Path
-        Name of the fits file or ``pathlib.Path`` object
-    verbose : {True, False}, bool optional
-        If True prints message.
-        
-    Returns
-    -------
-    data : array_like
-        Array containing the frames of the fits-cube.
-    parangles : array_like
-        1d array containing the corresponding parallactic angles.
-          
-    """
-    fitsfilename = str(fitsfilename)
-    if not fitsfilename.endswith('.fits'):
-        fitsfilename = fitsfilename+'.fits'
-    with ap_fits.open(fitsfilename, memmap=True) as hdulist:
-        data = hdulist[0].data
-        parangles = hdulist[1].data
-    
-    if data.ndim != 3:
-        raise TypeError('Input fits file does not contain a cube or 3d array.')
-
-    if verbose:
-        print("Fits HDU-0 data successfully loaded. "
-              "Data shape: {}".format(data.shape))
-        print("Fits HDU-1 data successfully loaded. "
-              "Data shape: {}".format(parangles.shape))
-    
-    return data, parangles
 
 
 def byteswap_array(array):
@@ -198,23 +158,3 @@ def write_fits(fitsfilename, array, header=None, precision=np.float32,
         ap_fits.writeto(fitsfilename, array, header)
         if verbose:
             print("Fits file successfully saved")
-
-
-def append_extension(fitsfilename, array, verbose=True):
-    """Appends an extension to fits file. 
-
-    Parameters
-    ----------
-    fitsfilename : str
-        Path to the fits file.
-    array : array_like
-        Data to append.
-    verbose : bool, optional
-        Print success message.
-    """
-    ap_fits.append(fitsfilename, array)
-    if verbose:
-        print("Fits extension appended")
-        
-        
-    

--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -20,8 +20,9 @@ from astropy.io import fits as ap_fits
 
 def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
               precision=np.float32, verbose=True):
-    """Loads a fits file into a memory as numpy array.
-    
+    """
+    Load a fits file into a memory as numpy array.
+
     Parameters
     ----------
     fitsfilename : string or pathlib.Path
@@ -36,14 +37,14 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
         Allows to open fits files with a header missing END card.
     verbose : bool, optional
         If True prints message of completion.
-    
+
     Returns
     -------
     data : array_like
         Array containing the frames of the fits-cube.
-    If header is True:
     header : dict
-        Dictionary containing the fits header.
+        [header=True] Dictionary containing the fits header.
+
     """
     fitsfilename = str(fitsfilename)
     if not os.path.isfile(fitsfilename):
@@ -68,28 +69,27 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
 
 
 def byteswap_array(array):
-    """ FITS files are stored in big-endian byte order. All modern CPUs are 
-    little-endian byte order, so at some point you have to byteswap the data. 
-    Some FITS readers (cfitsio, the fitsio python module) do the byteswap when 
-    reading the data from disk to memory, so we get numpy arrays in native 
-    (little-endian) byte order. Unfortunately, astropy.io.fits does not 
-    byteswap for us, and we get numpy arrays in non-native byte order. 
-    However, most of the time we never notice this because when you do any 
-    numpy operations on such arrays, numpy uses an intermediate buffer to 
-    byteswap the array behind the scenes and returns the result as a native 
-    byte order array. Some operations require the data to be byteswaped 
-    before and will complain about it. This function will help in this cases.
-    
+    """ FITS files are stored in big-endian byte order. All modern CPUs are
+    little-endian byte order, so at some point you have to byteswap the data.
+    Some FITS readers (cfitsio, the fitsio python module) do the byteswap when
+    reading the data from disk to memory, so we get numpy arrays in native
+    (little-endian) byte order. Unfortunately, astropy.io.fits does not byteswap
+    for us, and we get numpy arrays in non-native byte order. However, most of
+    the time we never notice this because when you do any numpy operations on
+    such arrays, numpy uses an intermediate buffer to byteswap the array behind
+    the scenes and returns the result as a native byte order array. Some
+    operations require the data to be byteswaped before and will complain about
+    it. This function will help in this cases.
+
     Parameters
     ----------
     array : array_like
         2d input array.
-        
+
     Returns
     -------
     array_out : array_like
         2d resulting array after the byteswap operation.
-
 
     Notes
     -----
@@ -101,24 +101,28 @@ def byteswap_array(array):
 
 
 def info_fits(fitsfilename):
-    """Prints the information about a fits file. 
+    """
+    Print the information about a fits file.
 
     Parameters
     ----------
     fitsfilename : str
         Path to the fits file.
+
     """
     with ap_fits.open(fitsfilename, memmap=True) as hdulist:
         hdulist.info()
 
-         
+
 def verify_fits(fitsfilename):
-    """Verifies "the FITS standard" of a fits file or list of fits.
+    """
+    Verify "the FITS standard" of a fits file or list of fits.
 
     Parameters
     ----------
     fitsfilename : string or list
         Path to the fits file or list with fits filename paths.
+
     """
     if isinstance(fitsfilename, list):
         for ffile in fitsfilename:
@@ -127,13 +131,15 @@ def verify_fits(fitsfilename):
     else:
         with ap_fits.open(fitsfilename) as f:
             f.verify()
-    
-    
+
+
 def write_fits(fitsfilename, array, header=None, precision=np.float32,
                verbose=True):
-    """Writes array and header into FTIS file, if there is a previous file with
-    the same filename then it's replaced.
-    
+    """
+    Write array and header into FTIS file.
+
+    If there is a previous file with the same filename then it's replaced.
+
     Parameters
     ----------
     fitsfilename : string
@@ -141,7 +147,7 @@ def write_fits(fitsfilename, array, header=None, precision=np.float32,
     array : array_like
         Array to be written into a fits file.
     header : array_like, optional
-        Array with header. 
+        Array with header.
     precision : numpy dtype, optional
         Float precision, by default np.float32 or single precision float.
     verbose : bool, optional
@@ -150,7 +156,7 @@ def write_fits(fitsfilename, array, header=None, precision=np.float32,
     """
     array = array.astype(precision, copy=False)
     if os.path.exists(fitsfilename):
-        os.remove(fitsfilename)                                     
+        os.remove(fitsfilename)
         ap_fits.writeto(fitsfilename, array, header)
         if verbose:
             print("Fits file successfully overwritten")

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -1109,7 +1109,6 @@ class HCIDataset(Saveable):
             Whether to plot the shifts.
 
         """
-        
 
         if method == '2dfit':
             if self.fwhm is None:
@@ -1226,8 +1225,6 @@ class HCIDataset(Saveable):
         """
         if self.angles is not None:
             self.cube, self.angles = cube_subsample(self.cube, window,
-                                                     mode, self.angles)
+                                                    mode, self.angles)
         else:
             self.cube = cube_subsample(self.cube, window, mode)
-
-

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -11,7 +11,7 @@ __all__ = ['HCIDataset',
            'HCIFrame']
 
 import numpy as np
-from .fits import open_fits, write_fits, append_extension
+from .fits import open_fits
 from .preproc import (frame_crop, frame_px_resampling, frame_rotate,
                       frame_shift, frame_center_satspots, frame_center_radon)
 from .preproc import (cube_collapse, cube_crop_frames, cube_derotate,
@@ -287,16 +287,6 @@ class HCIFrame(object):
         """
         self.image = frame_rotate(self.image, angle, imlib, interpolation, cxy)
         print('Image successfully rotated')
-
-    def save(self, path):
-        """ Writing to FITS file.
-
-        Parameters
-        ----------
-        path : string
-            Full path of the fits file to be written.
-        """
-        write_fits(path, self.image)
 
     def shift(self, shift_y, shift_x, imlib='opencv', interpolation='lanczos4'):
         """ Shifting the image.
@@ -1223,21 +1213,6 @@ class HCIDataset(Saveable):
         """
         self.cube = cube_px_resampling(self.cube, scale, imlib, interpolation,
                                        verbose)
-
-    def export_fits(self, path, precision=np.float32):
-        """ Writing to FITS file. If self.angles is present, then the angles
-        are appended to the FITS file.
-
-        Parameters
-        ----------
-        filename : string
-            Full path of the fits file to be written.
-        precision : numpy dtype, optional
-            Float precision, by default np.float32 or single precision float.
-        """
-        write_fits(path, self.cube, precision=precision)
-        if self.angles is not None:
-            append_extension(path, self.angles)
 
     def subsample(self, window, mode='mean'):
         """ Temporally sub-sampling the sequence (3d or 4d cube).


### PR DESCRIPTION
The following functions were removed:

- `fits/fits.py::open_adicube()`
- `fits/fits.py::append_extension()`
- `HCIFrame.save()`
- `HCIDataset.export_fits()`