### PR TITLE
REL/DOC: update Sphinx to latest 1.8.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,11 @@ users who want to experiment with the code.
 
 Other dependencies
 ^^^^^^^^^^^^^^^^^^
+
+
+OpenCV
+~~~~~~
+
 ``OpenCV`` (Open source Computer Vision) provides fast C++ image processing
 operations and is used by ``VIP`` for basic image transformations. If you don't
 have/want the ``OpenCV`` python bindings (``OpenCV`` is optional since ``VIP``
@@ -156,20 +161,37 @@ you could use ``conda``:
 
   $ conda install opencv
 
+
+pyds9
+~~~~~
+
 ``VIP`` contains a class ``vip_hci.fits.ds9`` that enables, through ``pyds9``,
 the interaction with a DS9 window (displaying numpy arrays, controlling the
-display options, etc). ``pyds9`` is an optional requirement and must be
-installed from the latest development version:
+display options, etc). ``pyds9`` is an optional requirement.
+
+pyds9 must be installed from the latest development version. Because of a regression between `sphinx > 1.5.6` and `astrophy_helpers` (which are both required by pyds9), it may be necessary to *downgrade* sphinx before installing pyds9. It can afterwards updated again:
+
 
 .. code-block:: bash
 
+    # downgrade sphinx to 1.5.6, as newer versions cause a RecursionError:
+    $ pip install sphinx==1.5.6
+    # install pyds9 from github:
     $ pip install git+git://github.com/ericmandel/pyds9.git#egg=pyds9
+    # upgrade sphinx to the latest version:
+    $ pip install -U sphinx
+
+
+MKL / blas
+~~~~~~~~~~
 
 Also, you can install the Intel Math Kernel Library (MKL) optimizations
 (provided that you have a recent version of ``conda``) or ``openblas``
 libraries. Either of them can be installed with ``conda install``. This is
 recommended along with ``OpenCV`` for maximum speed on ``VIP`` computations.
 
+GPU / CUDA
+~~~~~~~~~~
 ``VIP`` offers the possibility of computing SVDs on GPU by using ``CuPy``
 (starting from version 0.8.0) or ``PyTorch`` (from version 0.9.2). These remain
 as optional requirements, to be installed by the user, as well as a proper CUDA

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-sphinx <= 1.5.6
+sphinx ~=1.5.6
 pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,3 @@
 -r requirements.txt
-sphinx ~=1.5.6
+sphinx ==1.8.0
 pytest

--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -829,7 +829,7 @@ def aperture_flux(array, yc, xc, fwhm, ap_factor=1, mean=False, verbose=False):
     ----------
     array : array_like
         Input frame.
-    yc, xc : list or 1d arrays
+    yc,xc : list or 1d arrays
         List of y and x coordinates of sources.
     fwhm : float
         FWHM in pixels.
@@ -841,8 +841,8 @@ def aperture_flux(array, yc, xc, fwhm, ap_factor=1, mean=False, verbose=False):
     flux : list of floats
         List of fluxes.
 
-    Note
-    ----
+    Notes
+    -----
     From Photutils documentation, the aperture photometry defines the aperture
     using one of 3 methods:
 

--- a/vip_hci/metrics/detection.py
+++ b/vip_hci/metrics/detection.py
@@ -74,7 +74,7 @@ def detection(array, psf, bkg_sigma=1, mode='lpeaks', matched_filter=False,
 
     Returns
     -------
-    yy, xx : array_like
+    yy,xx : array_like
         Two vectors with the y and x coordinates of the centers of the sources
         (potential planets).
     If full_output is True then a table with all the candidates that passed the
@@ -439,7 +439,7 @@ def mask_source_centers(array, fwhm, y, x):
         Input frame.
     fwhm : float
         Size in pixels of the FWHM.
-    y, x : tuples of int
+    y,x : tuples of int
         Coordinates of the center of the sources.
 
     Returns

--- a/vip_hci/preproc/badframes.py
+++ b/vip_hci/preproc/badframes.py
@@ -141,7 +141,7 @@ def cube_detect_badfr_ellipticipy(array, fwhm, roundlo=-0.2, roundhi=0.2,
         Input 3d array, cube.
     fwhm : float
         FWHM size in pixels.
-    roundlo, roundhi : float, optional
+    roundlo,roundhi : float, optional
         Lower and higher bounds for the ellipticipy.
     verbose : {True, False}, bool optional
         Whether to print to stdout or not.

--- a/vip_hci/preproc/badpixremoval.py
+++ b/vip_hci/preproc/badpixremoval.py
@@ -212,7 +212,7 @@ def cube_fix_badpix_annuli(array, cy, cx, fwhm, sig=5., protect_psf=True,
     ----------
     array : 3D or 2D array 
         Input 3d cube or 2d image.
-    cy, cx : float or 1D array
+    cy,cx : float or 1D array
         Vector with approximate y and x coordinates of the star for each channel
         (cube_like), or single 2-elements vector (frame_like)
     fwhm: float or 1D array

--- a/vip_hci/preproc/recentering.py
+++ b/vip_hci/preproc/recentering.py
@@ -509,7 +509,7 @@ def frame_center_radon(array, cropsize=101, hsize=0.4, step=0.01,
 
     Returns
     -------
-    optimy, optimx : float
+    optimy,optimx : float
         Values of the Y, X coordinates of the center of the frame based on the
         radon optimization.
     If full_output is True then the radon cost function surface is returned
@@ -698,7 +698,7 @@ def cube_recenter_radon(array, full_output=False, verbose=True, imlib='opencv',
     -------
     array_rec : 3d ndarray
         Recentered cube.
-    y, x : 1d arrays of floats
+    y,x : 1d arrays of floats
         [full_output] Shifts in y and x.
 
     """
@@ -781,7 +781,7 @@ def cube_recenter_dft_upsampling(array, cy_1=None, cx_1=None, negative=False,
     array_recentered : array_like
         The recentered cube. Frames have now odd size.
     If full_output is True:
-    y, x : array_like
+    y,x : array_like
         1d arrays with the shifts in y and x.
 
     Notes
@@ -958,7 +958,7 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
     array_recentered : array_like
         The recentered cube. Frames have now odd size.
     If full_output is True:
-    y, x : array_like
+    y,x : array_like
         1d arrays with the shifts in y and x.
 
     """

--- a/vip_hci/var/fit_2d.py
+++ b/vip_hci/var/fit_2d.py
@@ -145,7 +145,7 @@ def fit_2dgaussian(array, crop=False, cent=None, cropsize=15, fwhmx=4, fwhmy=4,
         PSF is assumed to be ~ at the center of the frame).
     cropsize : int, optional
         Size of the subimage.
-    fwhmx, fwhmy : float, optional
+    fwhmx,fwhmy : float, optional
         Initial values for the standard deviation of the fitted Gaussian, in px.
     theta : float, optional
         Angle of inclination of the 2d Gaussian counting from the positive X

--- a/vip_hci/var/shapes.py
+++ b/vip_hci/var/shapes.py
@@ -160,7 +160,7 @@ def frame_center(array, verbose=False):
 
     Returns
     -------
-    cy, cx : float
+    cy,cx : float
         Coordinates of the center.
 
     """
@@ -209,7 +209,7 @@ def get_square(array, size, y, x, position=False, force=False, verbose=True):
     -------
     array_out : array_like
         Sub array.
-    y0, x0 : int
+    y0,x0 : int
         [position=True] Coordinates of the bottom-left vertex.
 
     """
@@ -287,7 +287,7 @@ def get_circle(array, radius, cy=None, cx=None, mode="mask"):
         The radius of the circular region.
     output_values : bool, optional
         Sets the type of output.
-    cy, cx : int, optional
+    cy,cx : int, optional
         Coordinates of the circle center. If one of them is ``None``, the center
         of ``array`` is used.
     mode : {'mask', 'val'}, optional
@@ -305,9 +305,9 @@ def get_circle(array, radius, cy=None, cx=None, mode="mask"):
     Notes
     -----
     An alternative implementation would use ``skimage.draw.circle``. ``circle``
-    performs better on large ``array``s (e.g. 1000px, 10.000px), while the
-    current implementation is faster for small ``array``s (e.g. 100px). See
-    `test_shapes.py` for benchmark details.
+    performs better on large ``array`` (e.g. 1000px, 10.000px), while the
+    current implementation is faster for small ``array`` (e.g. 100px). See
+    ``test_shapes.py`` for benchmark details.
 
     """
     if array.ndim != 2:
@@ -342,7 +342,7 @@ def get_ellipse(data, a, b, pa, cy=None, cx=None, mode="ind"):
         Semi-minor axis.
     pa : deg, float
         The PA of the semi-major axis in degrees.
-    cy, cx : int or None, optional
+    cy,cx : int or None, optional
         Coordinates of the circle center. If ``None``, the center is determined
         by the ``frame_center`` function.
     mode : {'ind', 'val', 'mask', 'bool'}, optional
@@ -516,7 +516,7 @@ def get_ell_annulus(data, a, b, PA, width, cy=None, cx=None, mode="ind"):
         thinner along the semi-minor axis.
     output_values : {False, True}, optional
         If True returns the values of the pixels in the annulus.
-    cy, cx : int or None, optional
+    cy,cx : int or None, optional
         Coordinates of the circle center. If ``None``, the center is determined
         by the ``frame_center`` function.
     mode : {'ind', 'val', 'mask'}, optional
@@ -574,7 +574,7 @@ def matrix_scaling(matrix, scaling):
             temporal px-wise mean subtraction
         ``"spat-mean"``
             the spatial mean is subtracted
-        ``temp-standard"``
+        ``"temp-standard"``
             temporal mean centering plus scaling to unit variance
         ``"spat-standard"``
             spatial mean centering plus scaling to unit variance
@@ -688,7 +688,7 @@ def reshape_matrix(array, y, x):
     array : 2d ndarray
         Input data of shape ``(nframes, npixels)``. Every row (``array[n]``)
         corresponds to one vectorized ("flattened") 2d frame.
-    y, x : int
+    y,x : int
         desired height and width of the frames. ``y*x = npixels``
 
     Returns


### PR DESCRIPTION
The optional dependency `pyds9` prevent us from using a recent version of sphinx. Because building the documentation for VIP is important, I made the decision in favour of VIP. This PR

- makes use of the latest Sphinx 1.8.0
- pins Sphinx to exactly 1.8.0, so no matter which machine builds the documentation (various developers, readthedocs, ...), it always results in the same output.

and thus 

- makes the installation of pyds9 even more complicated.

This means now:

``` bash
# downgrade:
pip install sphinx==1.5.6
# install pyds9:
pip install git+https://github.com/ericmandel/pyds9.git#egg=pyds9
# update sphinx again:
pip install -U sphinx
```

This *only* concerns developers, as only developers have installed the `dev` release of VIP. Users do not have Sphinx installed (as it is not listed in VIP's `requirements.txt`), so they can upgrade VIP as they wish and never see the effect of this PR.

I also updated the documentation accordingly.