### PR TITLE
DEV: Coverage reports with codecov.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,30 @@
-vip_hci.egg-info
+# optimized python files
+*.py[cod]
+_pycache__/
+
+# distribution / packaging
 build
 dist
+*.egg-info
 
+# documentation / sphinx
 docs/build
 docs/time
 
-submit_pypi.sh
-update_sphinx.sh
-
-.pytest_cache
+# unit test / coverage reports
+.coverage
 .cache
+.pytest_cache/
+
+# editors / IDEs
+.idea/
+*.sublime-project
+*.sublime-cache
+*.sublime-workspace
+.pydevproject
 .settings
 .project
-.pydevproject
-.idea
 
-*.pyc
-*/*.pyc
-*/*/*.pyc
-*/*/*/*.pyc
-
-*/.idea
-*/*/.idea
+# scripts
+submit_pypi.sh
+update_sphinx.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ python:
 install:
   - pip install -e .
 
-# command to run tests
+# command to run tests + coverage
 script:
-  pytest -v
+  pytest --cov=vip_hci -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,7 @@ install:
 
 # command to run tests + coverage
 script:
-  pytest --cov=vip_hci -v
+  - pytest --cov=vip_hci -v
+
+after_success:
+  - codecov

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@
 sphinx <= 1.5.6
 pytest
 pytest-cov ~=2.6.0
+codecov ~=2.0.15

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 sphinx <= 1.5.6
 pytest
+pytest-cov ~=2.6.0


### PR DESCRIPTION
This addresses issue https://github.com/vortex-exoplanet/VIP/issues/292.

I decided to go with codecov.io (instead of coveralls.io), as it has GitHub integration.<sup>1</sup>

Check here for how the coverage report looks like for this PR: https://codecov.io/gh/r4lv/VIP/branch/patch-cov

### set up

You'll have to

- log in at [codecov.io](https://codecov.io) with your GitHub account. This allows codecov to access the repo.
- codecov displays a "Repository Upload Token" / "CODECOV_TOKEN", which has to be added to the Travis CI **web interface** under the repo → settings → environment variables. The token has to stay secret, so do **not** add it to `.travis.yaml` or a `codecov.yml`!

The changes in this PR make Travis CI run `pytest-cov` (which runs `coveragepy`), and upload the results to codecov.io using the `codecov` package.


---

<sup>1</sup> [Here](https://coveralls.io/github/r4lv/VIP) is how the same PR would look with coveralls.io. I think I prefer codecov.io, but I could also add both to VIP, so that we can decide later?