### PR TITLE
MAINT/FEAT: slim down EvalRoc

### DIFF
--- a/tests/test_andromeda.py
+++ b/tests/test_andromeda.py
@@ -37,7 +37,10 @@ def test_andromeda(example_dataset):
     global IDL_DATA
 
     out = andromeda(example_dataset.cube,
-                    angles=example_dataset.angles,
+                    angles=-example_dataset.angles,
+                    # VIP uses other PA convention than IDL version.
+                    # the IDL_DATA was created with the IDL version, so we need
+                    # to match its PA convention.
                     psf=example_dataset.psf,
                     oversampling_fact=1,
                     filtering_fraction=1,  # turn off high pass

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -88,9 +88,7 @@ def algo_pca_annular(ds):
 
 def algo_andromeda(ds):
     res = vip.andromeda.andromeda(ds.cube, oversampling_fact=1,
-                                  angles=-ds.angles, psf=ds.psf)
-    # TODO: different angles convention!
-
+                                  angles=ds.angles, psf=ds.psf)
     contrast, snr, snr_n, stdcontrast, stdcontrast_n, likelihood, r = res
     return snr_n
 
@@ -98,9 +96,7 @@ def algo_andromeda(ds):
 def algo_andromeda_fast(ds):
     res = vip.andromeda.andromeda(ds.cube, oversampling_fact=0.5,
                                   fast=10,
-                                  angles=-ds.angles, psf=ds.psf)
-    # TODO: different angles convention!
-
+                                  angles=ds.angles, psf=ds.psf)
     contrast, snr, snr_n, stdcontrast, stdcontrast_n, likelihood, r = res
     return snr_n
 
@@ -151,18 +147,20 @@ def detect_max(frame, yx_exp, tolerance_percent=4):
     assert dist < tolerance, "Detected maximum does not match injection"
 
 
-@parametrize("algo, make_detmap",
-                         [
-                            (algo_medsub, snrmap_fast),
-                            (algo_medsub, snrmap),
-                            (algo_medsub_annular, snrmap_fast),
-                            (algo_xloci, snrmap_fast),
-                            (algo_pca, snrmap_fast),
-                            (algo_pca_annular, snrmap_fast),
-                            (algo_andromeda, None),
-                         ],
-                         ids=lambda x: (x.__name__.replace("algo_", "")
-                                        if callable(x) else x))
+@parametrize(
+    "algo, make_detmap",
+    [
+        (algo_medsub, snrmap_fast),
+        (algo_medsub, snrmap),
+        (algo_medsub_annular, snrmap_fast),
+        (algo_xloci, snrmap_fast),
+        (algo_pca, snrmap_fast),
+        (algo_pca_annular, snrmap_fast),
+        (algo_andromeda, None),
+        (algo_andromeda_fast, None),
+    ],
+    ids=lambda x: (x.__name__.replace("algo_", "") if callable(x) else x)
+)
 def test_algos(injected_cube_position, algo, make_detmap):
     ds, position = injected_cube_position
     frame = algo(ds)

--- a/vip_hci/andromeda/andromeda.py
+++ b/vip_hci/andromeda/andromeda.py
@@ -60,8 +60,11 @@ def andromeda(cube, oversampling_fact, angles, psf, filtering_fraction=.25,
         the filter and the Shannon wavelength).
         IDL parameter: ``OVERSAMPLING_1_INPUT``
     angles : array_like
-        List of parallactic angles associated with each frame in ``cube``.
-        IDL parameter: ``ANGLES_INPUT``
+        List of parallactic angles associated with each frame in ``cube``. Note
+        that, compared to the IDL version, the PA convention is different: If
+        you would pass ``[1,2,3]`` to the IDL version, you should pass ``[-1,
+        -2, -3]`` to this function to obtain the same results.
+        IDL parameter: ``- ANGLES_INPUT``
     psf : 2d array_like
         The experimental PSF used to model the planet signature in the
         subtracted images. This PSF is usually a non-coronographic or saturated
@@ -214,6 +217,10 @@ def andromeda(cube, oversampling_fact, angles, psf, filtering_fraction=.25,
     global CUBE  # assigned after high-pass filter
 
     # ===== verify input
+
+    # the andromeda algorithm handles PAs differently from the other algos in
+    # VIP. This normalizes the API:
+    angles = -angles
 
     frames, npix, _ = cube.shape
     npixpsf, _ = psf.shape

--- a/vip_hci/conf/utils_conf.py
+++ b/vip_hci/conf/utils_conf.py
@@ -100,6 +100,11 @@ class Saveable(object):
             else:
                 setattr(self, k, data[k])
 
+        # add non-saved, but expected attributes (backwards compatibility)
+        for exp_k in self._saved_attributes:
+            if exp_k not in data:
+                setattr(self, exp_k, None)
+
         return self
 
 

--- a/vip_hci/conf/utils_conf.py
+++ b/vip_hci/conf/utils_conf.py
@@ -14,6 +14,8 @@ import sys
 import numpy as np
 
 import itertools as itt
+from inspect import getargspec
+from functools import wraps
 from multiprocessing import Pool
 
 from vip_hci import __version__
@@ -197,6 +199,72 @@ class NoProgressbar(object):
 
     def update(self):
         pass
+
+
+def algo_calculates_decorator(*calculated_attributes):
+    """
+    Decorator for HCIPostProcAlgo methods, describe what they calculate.
+    
+    There are three benefits from decorating a method:
+    
+    - if ``verbose=True``, prints a message about the calculated attributes and
+      the ones which can be calculated next.
+    - the attributes which *can* be calculated by this method are tracked, so
+      if a user tries to access them *before* the function is called, an
+      informative error message can be shown
+    - the object knows which attributes to reset when ``run()`` is called a
+      second time, on a different dataset.
+
+    Parameters
+    ----------
+    *calculated_attributes : list of strings
+        Strings denominating the attributes the decorated function calculates.
+    
+    Examples
+    --------
+    
+    .. code:: python
+
+        from .conf import algo_calculates_decorator as calculates
+
+        class HCIMyAlgo(HCIPostPRocAlgo):
+            def __init__(self, my_algo_param):
+                self.store_args(locals())
+            
+            @calculates("final_frame", "snr_map")
+            def run(dataset=None, verbose=True):
+                frame, snr = my_heavy_calculation()
+                
+                self.final_frame = frame
+                self.snr_map = snr
+
+    """
+    def decorator(fkt):
+        @wraps(fkt)
+        def wrapper(self, *args, **kwargs):
+            # run the actual method
+            res = fkt(self, *args, **kwargs)
+
+            # get the kwargs the fkt sees. Note that this is a combination of
+            # the *default* kwargs and the kwargs *passed* by the user
+            a = getargspec(fkt)
+            all_kwargs = dict(zip(a.args[-len(a.defaults):], a.defaults))
+            all_kwargs.update(kwargs)
+            
+            if not hasattr(self, "_called_calculators"):
+                self._called_calculators = []
+            self._called_calculators.append(fkt.__name__)
+
+            # show help message
+            if all_kwargs.get("verbose", False):
+                self._show_attribute_help(fkt.__name__)
+
+            return res
+
+        # set an attribute on the wrapper so _get_calculations() can find it:
+        wrapper._calculates = calculated_attributes
+        return wrapper
+    return decorator
 
 
 def check_array(input_array, dim, name=None):

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -856,14 +856,12 @@ class HCIDataset(Saveable):
 
         return fake_datasets
 
-
-
-
     def copy(self, deep=True):
         """
         Create an in-memory copy of this HCIDataset.
 
-        This is especially useful when creating a 
+        This is especially useful for keeping a backup copy of the original
+        dataset before modifying if (e.g. with injections).
 
         Parameters
         ----------

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -777,8 +777,8 @@ class HCIDataset(Saveable):
         Returns
         -------
         yx : list of tuple(y,x)
-            [full_output] Pixel coordinates of the injections in the first frame
-            (and first wavelength for 4D cubes). These are only the new
+            [full_output=True] Pixel coordinates of the injections in the first
+            frame (and first wavelength for 4D cubes). These are only the new
             injections - all injections (from multiple calls to this function)
             are stored in ``self.injections_yx``.
 

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -475,7 +475,7 @@ class HCIDataset(Saveable):
     """
 
     _saved_attributes = ["cube", "psf", "psfn", "angles", "fwhm", "wavelengths",
-                         "px_scale"]
+                         "px_scale", "cuberef"]
 
     def __init__(self, cube, hdu=0, angles=None, wavelengths=None, fwhm=None,
                  px_scale=None, psf=None, psfn=None, cuberef=None):

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -480,7 +480,7 @@ class HCIDataset(Saveable):
     """
 
     _saved_attributes = ["cube", "psf", "psfn", "angles", "fwhm", "wavelengths",
-                         "px_scale", "cuberef"]
+                         "px_scale", "cuberef", "injections_yx"]
 
     def __init__(self, cube, hdu=0, angles=None, wavelengths=None, fwhm=None,
                  px_scale=None, psf=None, psfn=None, cuberef=None):
@@ -584,7 +584,7 @@ class HCIDataset(Saveable):
         if self.px_scale is not None:
             print('Pixel/plate scale: {}'.format(self.px_scale))
 
-        self.injections_yx = []
+        self.injections_yx = None
 
     def collapse(self, mode='median', n=50):
         """ Collapsing the sequence into a 2d array.
@@ -802,6 +802,9 @@ class HCIDataset(Saveable):
             rad_dists, n_branches, theta, imlib, interpolation,
             full_output=True, verbose=verbose
         )
+
+        if self.injections_yx is None:
+            self.injections_yx = []
 
         self.injections_yx += yx
 

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -772,12 +772,13 @@ class HCIDataset(Saveable):
         Returns
         -------
         yx : list of tuple(y,x)
-            [if full_output] Pixel coordinates of the injections in the first
-            frame (and first wavelength for 4D cubes).
+            [full_output] Pixel coordinates of the injections in the first frame
+            (and first wavelength for 4D cubes). These are only the new
+            injections - all injections (from multiple calls to this function)
+            are stored in ``self.injections_yx``.
 
         """
         # TODO: support the injection of a Gaussian/Moffat kernel.
-        # TODO: return array/HCIDataset object instead?
 
         if self.angles is None:
             raise ValueError('The PA angles have not been set')
@@ -789,12 +790,19 @@ class HCIDataset(Saveable):
             if self.wavelengths is None:
                 raise ValueError('The wavelengths vector has not been set')
 
-        self.cube, yx = cube_inject_companions(self.cube, self.psfn,
-                                               self.angles, flux, self.px_scale,
-                                               rad_dists, n_branches, theta,
-                                               imlib, interpolation,
-                                               full_output=True,
-                                               verbose=verbose)
+        self.cube, yx = cube_inject_companions(
+            self.cube, self.psfn, self.angles, flux, self.px_scale,
+            rad_dists, n_branches, theta, imlib, interpolation,
+            full_output=True, verbose=verbose
+        )
+
+        if not hasattr(self, "injections_yx"):
+            self.injections_yx = []
+
+        self.injections_yx += yx
+
+        if verbose:
+            print("Coordinates of the injections stored in self.injections_yx")
 
         if full_output:
             return yx

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -851,7 +851,7 @@ class HCIDataset(Saveable):
             dsi = self.copy()
             dsi.cube = r["cube"]
             dsi.injections_yx = r["position"]
-            datasets.append(dsi)
+            fake_datasets.append(dsi)
             # dist, theta, and flux are not stored.
 
         return fake_datasets

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -582,6 +582,8 @@ class HCIDataset(Saveable):
         if self.px_scale is not None:
             print('Pixel/plate scale: {}'.format(self.px_scale))
 
+        self.injections_yx = []
+
     def collapse(self, mode='median', n=50):
         """ Collapsing the sequence into a 2d array.
 
@@ -798,9 +800,6 @@ class HCIDataset(Saveable):
             rad_dists, n_branches, theta, imlib, interpolation,
             full_output=True, verbose=verbose
         )
-
-        if not hasattr(self, "injections_yx"):
-            self.injections_yx = []
 
         self.injections_yx += yx
 

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -28,7 +28,8 @@ from .var import (cube_filter_highpass, cube_filter_lowpass, mask_circle,
 from .stats import (frame_basic_stats, frame_histo_stats,
                     frame_average_radprofile, cube_basic_stats, cube_distance)
 from .metrics import (frame_quick_report, cube_inject_companions,
-                      cube_copies_with_injections, snr_ss,
+                      cube_copies_with_injections,
+                      generate_cube_copies_with_injections, snr_ss,
                       snr_peakstddev, snrmap, snrmap_fast, detection,
                       normalize_psf)
 
@@ -809,6 +810,53 @@ class HCIDataset(Saveable):
 
         if full_output:
             return yx
+
+    def generate_copies_with_injections(self, n_copies, inrad=8, outrad=12,
+                                        dist_flux=("uniform", 2, 500)):
+        """
+        Create copies of this dataset, containing different random injections.
+
+        Parameters
+        ----------
+        n_copies : int
+            This is the number of 'cube copies' returned.
+        inrad,outrad : float
+            Inner and outer radius of the injections. The actual injection
+            position is chosen randomly.
+        dist_flux : tuple('method', *params)
+            Tuple describing the flux selection. Method can be a function, the
+            ``*params`` are passed to it. Method can also be a string, for a
+            pre-defined random function:
+
+                ``("skewnormal", skew, mean, var)``
+                    uses scipy.stats.skewnorm.rvs
+                ``("uniform", low, high)``
+                    uses np.random.uniform
+                ``("normal", loc, scale)``
+                    uses np.random.normal
+
+        check_mem : bool, optional
+            If True, verifies that the system has enough memory to store the
+            result.
+
+        Yields
+        -------
+        fake_dataset : HCIDataset
+            Copy of the original HCIDataset, with injected companions.
+
+        """
+        
+        for data in generate_cube_copies_with_injections(
+            self.cube, self.psf, self.angles, self.px_scale, n_copies=n_copies,
+            inrad=inrad, outrad=outrad, dist_flux=dist_flux, check_mem=False
+        ):
+
+            dsi = self.copy()
+            dsi.cube = data["cube"]
+            dsi.injections_yx = data["position"]
+            # data["dist"], data["theta"], data["flux"] are not used.
+            
+            yield dsi
 
     def copies_with_injections(self, n_copies, inrad=8, outrad=12,
                                dist_flux=("uniform", 2, 500), check_mem=True):

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -28,7 +28,6 @@ from .var import (cube_filter_highpass, cube_filter_lowpass, mask_circle,
 from .stats import (frame_basic_stats, frame_histo_stats,
                     frame_average_radprofile, cube_basic_stats, cube_distance)
 from .metrics import (frame_quick_report, cube_inject_companions,
-                      cube_copies_with_injections,
                       generate_cube_copies_with_injections, snr_ss,
                       snr_peakstddev, snrmap, snrmap_fast, detection,
                       normalize_psf)
@@ -848,7 +847,7 @@ class HCIDataset(Saveable):
             Copy of the original HCIDataset, with injected companions.
 
         """
-        
+
         for data in generate_cube_copies_with_injections(
             self.cube, self.psf, self.angles, self.px_scale, n_copies=n_copies,
             inrad=inrad, outrad=outrad, dist_flux=dist_flux, check_mem=False
@@ -858,63 +857,8 @@ class HCIDataset(Saveable):
             dsi.cube = data["cube"]
             dsi.injections_yx = data["position"]
             # data["dist"], data["theta"], data["flux"] are not used.
-            
+
             yield dsi
-
-    def copies_with_injections(self, n_copies, inrad=8, outrad=12,
-                               dist_flux=("uniform", 2, 500), check_mem=True):
-        """
-        Create copies of this dataset, containing different random injections.
-
-        Parameters
-        ----------
-        n_copies : int
-            This is the number of 'cube copies' returned.
-        inrad,outrad : float
-            Inner and outer radius of the injections. The actual injection
-            position is chosen randomly.
-        dist_flux : tuple('method', *params)
-            Tuple describing the flux selection. Method can be a function, the
-            ``*params`` are passed to it. Method can also be a string, for a
-            pre-defined random function:
-
-                ``("skewnormal", skew, mean, var)``
-                    uses scipy.stats.skewnorm.rvs
-                ``("uniform", low, high)``
-                    uses np.random.uniform
-                ``("normal", loc, scale)``
-                    uses np.random.normal
-
-        check_mem : bool, optional
-            If True, verifies that the system has enough memory to store the
-            result.
-
-        Returns
-        -------
-        fake_datasets : list of HCIDataset
-            List containing ``n_copies`` fake datasets.
-
-        """
-
-        if check_mem and not check_enough_memory(n_copies * self.get_nbytes(),
-                                                 1.5, verbose=False):
-            raise RuntimeError("copies_with_injections would require more "
-                               "memory than available.")
-        
-        res = cube_copies_with_injections(self.cube, self.psf, self.angles,
-                                          self.px_scale, n_copies=n_copies,
-                                          inrad=inrad, outrad=outrad,
-                                          dist_flux=dist_flux, check_mem=False)
-
-        fake_datasets = []
-        for r in res:
-            dsi = self.copy()
-            dsi.cube = r["cube"]
-            dsi.injections_yx = r["position"]
-            fake_datasets.append(dsi)
-            # dist, theta, and flux are not stored.
-
-        return fake_datasets
 
     def get_nbytes(self):
         """

--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -11,6 +11,8 @@ __all__ = ['HCIDataset',
            'HCIFrame']
 
 import numpy as np
+import copy
+
 from .fits import open_fits
 from .preproc import (frame_crop, frame_px_resampling, frame_rotate,
                       frame_shift, frame_center_satspots, frame_center_radon)
@@ -806,6 +808,34 @@ class HCIDataset(Saveable):
 
         if full_output:
             return yx
+
+    def copy(self, deep=True):
+        """
+        Create an in-memory copy of this HCIDataset.
+
+        This is especially useful when creating a 
+
+        Parameters
+        ----------
+        deep : bool, optional
+            By default, a deep copy is created. That means every (sub)attribute
+            is copied in memory. While this requires more memory, one can safely
+            modify the attributes without touching the original HCIDataset. When
+            ``deep=False``, a shallow copy of the HCIDataset is returned
+            instead. That means all attributes (e.g. ``self.cube``) point back
+            to the original object's attributes. Pay attention when modifying
+            such a shallow copy!
+
+        Returns
+        -------
+        new_dataset : HCIDataset
+            (deep) copy of this HCIDataset.
+
+        """
+        if deep:
+            return copy.deepcopy(self)
+        else:
+            return copy.copy(self)
 
     def load_angles(self, angles, hdu=0):
         """ Loads the PA vector from a FITS file. It is possible to specify the

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -20,6 +20,7 @@ from ..preproc import cube_crop_frames, frame_shift, frame_crop, cube_shift
 from ..var import (frame_center, fit_2dgaussian, fit_2dairydisk, fit_2dmoffat,
                    get_circle, get_annulus_segments)
 from ..conf.utils_conf import print_precision, Progressbar
+from ..conf.mem import check_enough_memory
 
 
 def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
@@ -203,7 +204,8 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
 
 def cube_copies_with_injections(array, psf_template, angle_list, plsc,
                                 n_copies=100, inrad=8, outrad=12, 
-                                dist_flux=("uniform", 2, 500)):
+                                dist_flux=("uniform", 2, 500),
+                                check_mem=True):
     """
     Create multiple copies of ``array`` with different random injections.
 
@@ -241,6 +243,9 @@ def cube_copies_with_injections(array, psf_template, angle_list, plsc,
             ``("normal", loc, scale)``
                 uses np.random.normal
 
+    check_mem : bool, optional
+        If True, verifies that the system has enough memory to store the result.
+
     Returns
     -------
     fake_data : list of dict
@@ -263,6 +268,12 @@ def cube_copies_with_injections(array, psf_template, angle_list, plsc,
 
     """
     # TODO: 'mask' parameter for known companions?
+
+    if check_mem and not check_enough_memory(array.nbytes * n_copies, 1.5,
+                                             verbose=False):
+        raise RuntimeError("cube_copies_with_injections would require more "
+                           "memory than available.")
+
     
     fake_data = []
 

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -10,6 +10,7 @@ __author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['collapse_psf_cube',
            'normalize_psf',
            'cube_inject_companions',
+           'cube_copies_with_injections',
            'frame_inject_companion']
 
 import numpy as np

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -13,11 +13,12 @@ __all__ = ['collapse_psf_cube',
            'frame_inject_companion']
 
 import numpy as np
+from scipy import stats
 import photutils
 from ..preproc import cube_crop_frames, frame_shift, frame_crop, cube_shift
 from ..var import (frame_center, fit_2dgaussian, fit_2dairydisk, fit_2dmoffat,
-                   get_circle)
-from ..conf.utils_conf import print_precision
+                   get_circle, get_annulus_segments)
+from ..conf.utils_conf import print_precision, Progressbar
 
 
 def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
@@ -29,7 +30,8 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
     Parameters
     ----------
     array : 3d/4d array_like
-        Input cube.
+        Input cube. This is copied before the injections take place, so
+        ``array`` is never modified.
     psf_template : array_like
         2d array with the normalized psf template. It should have an odd shape.
         It's recommended to run the function ``normalize_psf`` to get a proper
@@ -196,6 +198,108 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
         return array_out, positions
     else:
         return array_out
+
+
+def cube_copies_with_injections(array, psf_template, angle_list, plsc,
+                                n_copies=100, inrad=8, outrad=12, 
+                                dist_flux=("uniform", 2, 500)):
+    """
+    Create multiple copies of ``array`` with different random injections.
+
+    This is a wrapper around ``metrics.cube_inject_companions``, which deals
+    with multiple copies of the original data cube and generates random
+    parameters.
+
+    Parameters
+    ----------
+    array : 3d/4d array_like
+        Original input cube.
+    psf_template : 2d/3d array_like
+        Array with the normalized psf template. It should have an odd shape.
+        It's recommended to run the function ``normalize_psf`` to get a proper
+        PSF template. In the ADI+mSDI case it must be a 3d array.
+    angle_list : 1d array_like
+        List of parallactic angles, in degrees.
+    plsc : float
+        Value of the plsc in arcsec/px. Only used for printing debug output when
+        ``verbose=True``.
+    n_copies : int
+        This is the number of 'cube copies' returned.
+    inrad,outrad : float
+        Inner and outer radius of the injections. The actual injection position
+        is chosen randomly.
+    dist_flux : tuple('method', *params)
+        Tuple describing the flux selection. Method can be a function, the
+        ``*params`` are passed to it. Method can also be a string, for a
+        pre-defined random function:
+
+            ``("skewnormal", skew, mean, var)``
+                uses scipy.stats.skewnorm.rvs
+            ``("uniform", low, high)``
+                uses np.random.uniform
+            ``("normal", loc, scale)``
+                uses np.random.normal
+
+    Returns
+    -------
+    fake_data : list of dict
+        List of length ``n_copies``. Each element is a dictionary representing a
+        copy of the original ``array``, with fake injections. The dictionary
+        keys are:
+
+            ``cube``
+                Array shaped like the input ``array``, with the fake injections.
+            ``position`` : list of tuples(y,x)
+                List containing the positions of the injected companions, as
+                (y,x) tuples.
+            ``dist`` : float
+                The distance of the injected companions, which was passed to
+                ``cube_inject_companions``.
+            ``theta`` : float, degrees
+                The initial angle, as passed to ``cube_inject_companions``.
+            ``flux`` : float
+                The flux passed to ``cube_inject_companions``.
+
+    """
+    # TODO: 'mask' parameter for known companions?
+    
+    fake_data = []
+
+    width = outrad - inrad
+    yy, xx = get_annulus_segments(array[0], inrad, width)[0]
+    num_patches = yy.shape[0]
+
+    # Defining Fluxes according to chosen distribution
+    dist_fkt = dict(skewnormal=stats.skewnorm.rvs,
+                    normal=np.random.normal,
+                    uniform=np.random.uniform).get(dist_flux[0],
+                                                   dist_flux[0])
+    fluxes = sorted(dist_fkt(*dist_flux[1:], size=n_copies))
+
+    inds_inj = np.random.randint(0, num_patches, size=n_copies)
+
+    # Injections
+    for n in Progressbar(range(n_copies), desc="injecting"):
+
+        injx = xx[inds_inj[n]] - frame_center(array[0])[1]
+        injy = yy[inds_inj[n]] - frame_center(array[0])[0]
+        dist = np.sqrt(injx**2 + injy**2)
+        theta = np.mod(np.arctan2(injy, injx) / np.pi * 180, 360)
+        
+        fake_cube, positions = cube_inject_companions(
+            array, psf_template, angle_list, plsc=plsc,
+            flevel=fluxes[n], theta=theta,
+            rad_dists=dist, n_branches=1,  # TODO: multiple injections?
+            full_output=True, verbose=False
+        )
+
+        fake_data.append(dict(
+            positions=positions,
+            dist=dist, theta=theta, flux=fluxes[n],
+            cube=fake_cube
+        ))
+    
+    return fake_data
 
 
 def frame_inject_companion(array, array_fc, pos_y, pos_x, flux,

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -11,6 +11,7 @@ __all__ = ['collapse_psf_cube',
            'normalize_psf',
            'cube_inject_companions',
            'cube_copies_with_injections',
+           'generate_cube_copies_with_injections',
            'frame_inject_companion']
 
 import numpy as np
@@ -274,7 +275,6 @@ def cube_copies_with_injections(array, psf_template, angle_list, plsc,
         raise RuntimeError("cube_copies_with_injections would require more "
                            "memory than available.")
 
-    
     fake_data = []
 
     width = outrad - inrad
@@ -312,6 +312,103 @@ def cube_copies_with_injections(array, psf_template, angle_list, plsc,
         ))
     
     return fake_data
+
+
+def generate_cube_copies_with_injections(array, psf_template, angle_list, plsc,
+                                         n_copies=100, inrad=8, outrad=12, 
+                                         dist_flux=("uniform", 2, 500)):
+    """
+    Create multiple copies of ``array`` with different random injections.
+
+    This is a wrapper around ``metrics.cube_inject_companions``, which deals
+    with multiple copies of the original data cube and generates random
+    parameters.
+
+    Parameters
+    ----------
+    array : 3d/4d array_like
+        Original input cube.
+    psf_template : 2d/3d array_like
+        Array with the normalized psf template. It should have an odd shape.
+        It's recommended to run the function ``normalize_psf`` to get a proper
+        PSF template. In the ADI+mSDI case it must be a 3d array.
+    angle_list : 1d array_like
+        List of parallactic angles, in degrees.
+    plsc : float
+        Value of the plsc in arcsec/px. Only used for printing debug output when
+        ``verbose=True``.
+    n_copies : int
+        This is the number of 'cube copies' returned.
+    inrad,outrad : float
+        Inner and outer radius of the injections. The actual injection position
+        is chosen randomly.
+    dist_flux : tuple('method', *params)
+        Tuple describing the flux selection. Method can be a function, the
+        ``*params`` are passed to it. Method can also be a string, for a
+        pre-defined random function:
+
+            ``("skewnormal", skew, mean, var)``
+                uses scipy.stats.skewnorm.rvs
+            ``("uniform", low, high)``
+                uses np.random.uniform
+            ``("normal", loc, scale)``
+                uses np.random.normal
+
+    Yields
+    ------
+    fake_data : dict
+        Represents a copy of the original ``array``, with fake injections. The
+        dictionary keys are:
+
+            ``cube``
+                Array shaped like the input ``array``, with the fake injections.
+            ``position`` : list of tuples(y,x)
+                List containing the positions of the injected companions, as
+                (y,x) tuples.
+            ``dist`` : float
+                The distance of the injected companions, which was passed to
+                ``cube_inject_companions``.
+            ``theta`` : float, degrees
+                The initial angle, as passed to ``cube_inject_companions``.
+            ``flux`` : float
+                The flux passed to ``cube_inject_companions``.
+
+    """
+    # TODO: 'mask' parameter for known companions?
+
+    width = outrad - inrad
+    yy, xx = get_annulus_segments(array[0], inrad, width)[0]
+    num_patches = yy.shape[0]
+
+    # Defining Fluxes according to chosen distribution
+    dist_fkt = dict(skewnormal=stats.skewnorm.rvs,
+                    normal=np.random.normal,
+                    uniform=np.random.uniform).get(dist_flux[0],
+                                                   dist_flux[0])
+    fluxes = sorted(dist_fkt(*dist_flux[1:], size=n_copies))
+
+    inds_inj = np.random.randint(0, num_patches, size=n_copies)
+
+    # Injections
+    for n in n_copies: # Progressbar(range(n_copies), desc="injecting"):
+
+        injx = xx[inds_inj[n]] - frame_center(array[0])[1]
+        injy = yy[inds_inj[n]] - frame_center(array[0])[0]
+        dist = np.sqrt(injx**2 + injy**2)
+        theta = np.mod(np.arctan2(injy, injx) / np.pi * 180, 360)
+        
+        fake_cube, positions = cube_inject_companions(
+            array, psf_template, angle_list, plsc=plsc,
+            flevel=fluxes[n], theta=theta,
+            rad_dists=dist, n_branches=1,  # TODO: multiple injections?
+            full_output=True, verbose=False
+        )
+
+        yield dict(
+            positions=positions,
+            dist=dist, theta=theta, flux=fluxes[n],
+            cube=fake_cube
+        )
 
 
 def frame_inject_companion(array, array_fc, pos_y, pos_x, flux,

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -64,8 +64,8 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
     array_out : array_like
         Output array with the injected fake companions.
     positions : list of tuple(y, x)
-        Coordinates of the injections in the first frame (and first wavelength
-        for 4D cubes). Only returned when ``full_output=True``.
+        [full_output] Coordinates of the injections in the first frame (and
+        first wavelength for 4D cubes).
 
     """
     if array.ndim not in [3, 4]:
@@ -78,8 +78,6 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
     # ADI case
     if array.ndim == 3:
         ceny, cenx = frame_center(array[0])
-        ceny = int(ceny)
-        cenx = int(cenx)
 
         rad_dists = np.asarray(rad_dists).reshape(-1)  # forces ndim=1
 
@@ -91,8 +89,8 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
         fc_fr = np.zeros_like(array[0])
 
         w = int(np.ceil(size_fc/2)) - 1
-        starty = ceny - w
-        startx = cenx - w
+        starty = int(ceny) - w
+        startx = int(cenx) - w
 
         # fake companion in the center of a zeros frame
         fc_fr[starty:starty+size_fc, startx:startx+size_fc] = psf_template
@@ -135,8 +133,6 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
     # ADI+IFS case
     if array.ndim == 4 and psf_template.ndim == 3:
         ceny, cenx = frame_center(array[0, 0])
-        ceny = int(float(ceny))
-        cenx = int(float(cenx))
         if isinstance(rad_dists, (int, float)):
             check_coor = rad_dists
             rad_dists = np.array([rad_dists])
@@ -158,9 +154,11 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
             w = int(np.floor(size_fc/2.))
             # fake companion in the center of a zeros frame
             if (psf_template[0].shape[1] % 2) == 0:
-                fc_fr[i, ceny-w:ceny+w, cenx-w:cenx+w] = psf_template[i]
+                fc_fr[i, int(ceny)-w:int(ceny)+w,
+                      int(cenx)-w:int(cenx)+w] = psf_template[i]
             else:
-                fc_fr[i, ceny-w:ceny+w+1, cenx-w:cenx+w+1] = psf_template[i]
+                fc_fr[i, int(ceny)-w:int(ceny)+w+1,
+                      int(cenx)-w:int(cenx)+w+1] = psf_template[i]
 
         array_out = array.copy()
 


### PR DESCRIPTION
This PR factors out some functionalities from the EvalRoc class, making them more accessible.

## 1. HCIDataset and injections

I think the HCIDataset itself could be a good location to keep track of all the injection positions.

Changes:

- `HCIDataset.inject_companions()` creates a `.injections_yx` attribute with all the injections (useful later on for ROC curves)
- `HCIDataset.copy()` which creates a full separate copy of the dataset


 How it could be used in the future:

``` python
# original dataset object:
ds = HCIDataset(cube=...)

# create a new HCIDataset with injections:
dsi = ds.copy()
dsi.inject_companions(flux=1000, rad_dists=[10, 20])
dsi.inject_companions(flux=500, rad_dists=[10, 20], theta=90)  # more injections

# process data cube:
algo = HCIMedianSub(...)
algo.run(dsi)

# make ROC curve out of it:
r = Roc()
r.add(algo.detection_map, dsi.injections_yx)
r.plot()
```