### PR TITLE
FIX: Change ANDROMEDA's angles convention

### DIFF
--- a/tests/test_andromeda.py
+++ b/tests/test_andromeda.py
@@ -37,7 +37,10 @@ def test_andromeda(example_dataset):
     global IDL_DATA
 
     out = andromeda(example_dataset.cube,
-                    angles=example_dataset.angles,
+                    angles=-example_dataset.angles,
+                    # VIP uses other PA convention than IDL version.
+                    # the IDL_DATA was created with the IDL version, so we need
+                    # to match its PA convention.
                     psf=example_dataset.psf,
                     oversampling_fact=1,
                     filtering_fraction=1,  # turn off high pass

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -88,9 +88,7 @@ def algo_pca_annular(ds):
 
 def algo_andromeda(ds):
     res = vip.andromeda.andromeda(ds.cube, oversampling_fact=1,
-                                  angles=-ds.angles, psf=ds.psf)
-    # TODO: different angles convention!
-
+                                  angles=ds.angles, psf=ds.psf)
     contrast, snr, snr_n, stdcontrast, stdcontrast_n, likelihood, r = res
     return snr_n
 
@@ -98,9 +96,7 @@ def algo_andromeda(ds):
 def algo_andromeda_fast(ds):
     res = vip.andromeda.andromeda(ds.cube, oversampling_fact=0.5,
                                   fast=10,
-                                  angles=-ds.angles, psf=ds.psf)
-    # TODO: different angles convention!
-
+                                  angles=ds.angles, psf=ds.psf)
     contrast, snr, snr_n, stdcontrast, stdcontrast_n, likelihood, r = res
     return snr_n
 
@@ -151,18 +147,20 @@ def detect_max(frame, yx_exp, tolerance_percent=4):
     assert dist < tolerance, "Detected maximum does not match injection"
 
 
-@parametrize("algo, make_detmap",
-                         [
-                            (algo_medsub, snrmap_fast),
-                            (algo_medsub, snrmap),
-                            (algo_medsub_annular, snrmap_fast),
-                            (algo_xloci, snrmap_fast),
-                            (algo_pca, snrmap_fast),
-                            (algo_pca_annular, snrmap_fast),
-                            (algo_andromeda, None),
-                         ],
-                         ids=lambda x: (x.__name__.replace("algo_", "")
-                                        if callable(x) else x))
+@parametrize(
+    "algo, make_detmap",
+    [
+        (algo_medsub, snrmap_fast),
+        (algo_medsub, snrmap),
+        (algo_medsub_annular, snrmap_fast),
+        (algo_xloci, snrmap_fast),
+        (algo_pca, snrmap_fast),
+        (algo_pca_annular, snrmap_fast),
+        (algo_andromeda, None),
+        (algo_andromeda_fast, None),
+    ],
+    ids=lambda x: (x.__name__.replace("algo_", "") if callable(x) else x)
+)
 def test_algos(injected_cube_position, algo, make_detmap):
     ds, position = injected_cube_position
     frame = algo(ds)

--- a/vip_hci/andromeda/andromeda.py
+++ b/vip_hci/andromeda/andromeda.py
@@ -60,8 +60,11 @@ def andromeda(cube, oversampling_fact, angles, psf, filtering_fraction=.25,
         the filter and the Shannon wavelength).
         IDL parameter: ``OVERSAMPLING_1_INPUT``
     angles : array_like
-        List of parallactic angles associated with each frame in ``cube``.
-        IDL parameter: ``ANGLES_INPUT``
+        List of parallactic angles associated with each frame in ``cube``. Note
+        that, compared to the IDL version, the PA convention is different: If
+        you would pass ``[1,2,3]`` to the IDL version, you should pass ``[-1,
+        -2, -3]`` to this function to obtain the same results.
+        IDL parameter: ``- ANGLES_INPUT``
     psf : 2d array_like
         The experimental PSF used to model the planet signature in the
         subtracted images. This PSF is usually a non-coronographic or saturated
@@ -214,6 +217,10 @@ def andromeda(cube, oversampling_fact, angles, psf, filtering_fraction=.25,
     global CUBE  # assigned after high-pass filter
 
     # ===== verify input
+
+    # the andromeda algorithm handles PAs differently from the other algos in
+    # VIP. This normalizes the API:
+    angles = -angles
 
     frames, npix, _ = cube.shape
     npixpsf, _ = psf.shape


### PR DESCRIPTION
The IDL ANDROMEDA uses a different convention for the parallactic angles. Until now, vip.andromeda followed the same conventions as the IDL version, so that for the same input, both implementations produce the same result.

This is now changed, so that vip.andromeda follows the same convention as the other algorithms in VIP.