### PR TITLE
FIX: HCIDataset should also store cuberef

### DIFF
--- a/vip_hci/hci_dataset.py
+++ b/vip_hci/hci_dataset.py
@@ -475,7 +475,7 @@ class HCIDataset(Saveable):
     """
 
     _saved_attributes = ["cube", "psf", "psfn", "angles", "fwhm", "wavelengths",
-                         "px_scale"]
+                         "px_scale", "cuberef"]
 
     def __init__(self, cube, hdu=0, angles=None, wavelengths=None, fwhm=None,
                  px_scale=None, psf=None, psfn=None, cuberef=None):


### PR DESCRIPTION
Even if `cuberef` is `None`, it should still be stored inside the npz file, as it is expected that a HCIDataset has that attribute.