### PR TITLE
FIX: HCIDataset.load fails if HCIDataset class changed

### DIFF
--- a/vip_hci/conf/utils_conf.py
+++ b/vip_hci/conf/utils_conf.py
@@ -100,6 +100,11 @@ class Saveable(object):
             else:
                 setattr(self, k, data[k])
 
+        # add non-saved, but expected attributes (backwards compatibility)
+        for exp_k in self._saved_attributes:
+            if exp_k not in data:
+                setattr(self, exp_k, None)
+
         return self
 
 


### PR DESCRIPTION
#### current situation

When a HCIDataset `ds` is stored to disk using `ds.save("filename")`, all the attributes listed in `HCIDataset._saved_attributes` are saved. When loading them using `HCIDataset.load("filename")`, only the attributes, which were *stored in the file* are restored.

#### problem

However, e.g. when updating VIP and adding a new attribute to HCIDataset (like it is the case with https://github.com/vortex-exoplanet/VIP/pull/325), that attribute will be *not there* after loading an *old* savefile, resulting in an AttributeError.

#### solution

When loading a dataset, we compare the attributes which were *stored* with the ones the HCIDataset *expects* (= are listed in `_saved_attributes`), and set the missing attributes to `None`.