### PR TITLE
MAINT: improve ANDROMEDA logging

### DIFF
--- a/vip_hci/andromeda/andromeda.py
+++ b/vip_hci/andromeda/andromeda.py
@@ -290,8 +290,10 @@ def andromeda(cube, oversampling_fact, angles, psf, filtering_fraction=.25,
 
     if np.asarray(tnd).ndim == 0:  # int or float
         log("Throughput map: Homogeneous transmission: {}%", tnd * 100)
-    else:  # TODO: test if really 2d map?
+    elif np.asarray(tnd).ndim == 2:
         log("Throughput map: Inhomogeneous 2D throughput map given.")
+    else:
+        raise ValueError("Throughput `tnd` should be an float or a 2d map")
 
     if nsmooth_snr != 0 and nsmooth_snr < 2:
         raise ValueError("`nsmooth_snr` must be >= 2")

--- a/vip_hci/andromeda/andromeda.py
+++ b/vip_hci/andromeda/andromeda.py
@@ -19,8 +19,7 @@ Based on ANDROMEDA v3.1 from 28/06/2018.
 
 """
 
-from __future__ import division, print_function
-from __future__ import absolute_import
+from __future__ import division, print_function, absolute_import
 
 __author__ = "Ralf Farkas"
 __all__ = ["andromeda"]
@@ -239,7 +238,7 @@ def andromeda(cube, oversampling_fact, angles, psf, filtering_fraction=.25,
     if iwa is None:
         for test_iwa in [0.5, 4, 0.25]:
             # keep first IWA which produces frame pairs
-            test_ang = 2*np.arcsin(min_sep / (2*test_iwa)) * 180/np.pi
+            test_ang = np.rad2deg(2 * np.arcsin(min_sep / (2 * test_iwa)))
             test_id, _, _ = create_indices(angles, angmin=test_ang,
                                            verbose=False)
             if test_id is not None:  # pairs found

--- a/vip_hci/andromeda/andromeda.py
+++ b/vip_hci/andromeda/andromeda.py
@@ -1181,6 +1181,50 @@ def couronne_img(image, xcen, ycen=None, lieu=None, step=0.5, rmax=None,
 
 
 def print_if(condition, indent=0, prefix=""):
+    """
+    Return a function which can be used like 'print', but which is silent if the
+    ``condition`` is not met.
+
+    Parameters
+    ----------
+    condition : bool
+        The returned function only produces output if this condition is met.
+    indent : int, optional
+        Indent the printed output to a level.
+    prefix : string, optional
+        String which is prepended to the output.
+
+
+    Returns
+    -------
+    print_function : callable
+        A function which can be used as alternative to ``print``. Additional
+        arguments are used as format strings. See the examples section for usage
+        details.
+
+    Examples
+    --------
+
+    .. code:: python
+        # old:
+        if debug:
+            print("   running the algorithm with parameter {}".format(my_param))
+
+        # new:
+        log = print_if(debug, level=1)
+        log("running the algorithm with parameter {}", my_param)
+
+        # old:
+        if verbose:
+            print("cannot find a matching frame for position "
+                  "({:.3f}, {:.3f})".format(x, y))
+
+        # new:
+        info = print_if(verbose)
+        info("cannot find a matching frame for position ({:.3f}, {:.3f})", x, y)
+
+
+    """
     def print_function(msg, *fmt, **kwfmt):
         if condition:
             print(" "*3*indent + prefix + msg.format(*fmt, **kwfmt))

--- a/vip_hci/andromeda/andromeda.py
+++ b/vip_hci/andromeda/andromeda.py
@@ -1060,7 +1060,6 @@ def normalize_snr(snr, nsmooth_snr=1, iwa=None, owa=None, oversampling=None,
                 if prof_snr[i] != 0:
                     k = i
             if k is None:  # error handling not present in IDL version.
-                set_trace()
                 raise RuntimeError("prof_snr is zero!")
 
             for i in range(j - nsmooth_snr, k):

--- a/vip_hci/andromeda/andromeda.py
+++ b/vip_hci/andromeda/andromeda.py
@@ -204,8 +204,8 @@ def andromeda(cube, oversampling_fact, angles, psf, filtering_fraction=.25,
         - variances (VARIANCE_1_INPUT, VARIANCE_2_INPUT)
 
     """
-    info = printer(verbose)
-    log = printer(debug)
+    info = print_if(verbose)
+    log = print_if(debug)
 
     global CUBE  # assigned after high-pass filter
 
@@ -459,7 +459,7 @@ def _process_annulus(i, annuli_limits, roa, min_sep, oversampling_fact, angles,
     """
     global CUBE
 
-    warn = printer(verbose, prefix="[annulus {}] WARNING: ".format(i))
+    warn = print_if(verbose, prefix="[annulus {}] WARNING: ".format(i))
 
     rhomin = annuli_limits[i]
     rhomax = annuli_limits[i+1]
@@ -612,7 +612,7 @@ def andromeda_core(diffcube, index_neg, index_pos, angles, psf_cube, rhomin,
             - this is just an empty ``DBLARR(npix, npix, kmax)``
 
     """
-    log = printer(debug, prefix="[core] ")
+    log = print_if(debug, prefix="[core] ")
 
     npairs, npix, _ = diffcube.shape
     npixpsf = psf_cube.shape[2]  # shape: (p+1, p+1, x, y)
@@ -791,7 +791,7 @@ def create_indices(angles, angmin, verbose=True):
     - ``WASTE`` flag removed, instead this function returns ``indices_not_used``
 
     """
-    warn = printer(verbose, prefix="[indices] ")
+    warn = print_if(verbose, prefix="[indices] ")
 
     # make array monotonic -> increasing
     if angles[-1] < angles[0]:
@@ -884,7 +884,7 @@ def diff_images(cube_pos, cube_neg, rint, rext, opt_method="lsq",
       etc.) are also accepted, but discouraged. Use the strings instead.
 
     """
-    log = printer(debug, prefix="[diff] ")
+    log = print_if(debug, prefix="[diff] ")
 
     nimg, npix, _ = cube_pos.shape
 
@@ -1144,7 +1144,7 @@ def couronne_img(image, xcen, ycen=None, lieu=None, step=0.5, rmax=None,
     - ``xcen`` was made a required positional argument.
 
     """
-    log = printer(debug, prefix="[couronne_img] ")
+    log = print_if(debug, prefix="[couronne_img] ")
 
     # ===== verify input
     if image.shape[0] != image.shape[1]:
@@ -1180,7 +1180,7 @@ def couronne_img(image, xcen, ycen=None, lieu=None, step=0.5, rmax=None,
     return intenmoy
 
 
-def printer(condition, indent=0, prefix=""):
+def print_if(condition, indent=0, prefix=""):
     def print_function(msg, *fmt, **kwfmt):
         if condition:
             print(" "*3*indent + prefix + msg.format(*fmt, **kwfmt))


### PR DESCRIPTION
This PR simplifies the code responsible of logging, using a new `printer()` factory function. It creates a function which can be used instead of `if verbose: print("...".format())`, like so:

``` python
def my_function(param=1, verbose=True):
    info = printer(verbose)

    # only prints when verbose is True:
    info("the user param is {}", param)
```

a more sophisticated example:

``` python
def my_function_2(loops=3, verbose=True, debug=False):
    info = printer(verbose)
    log = printer(debug, prefix="[debug] ")

    info("working with {} loops", loops)
   
    for i in range(loops):
        log("loop {} of {}...", i+1, loops)
```

``` pycon
>>> my_function_2()
working with 3 loops
>>> my_function_2(verbose=True)
working with 3 loops
[debug] loop 1 of 3...
[debug] loop 2 of 3...
[debug] loop 3 of 3...
```

For the other smaller changes please refer to the commit messages below.