### PR TITLE
API: re-thinking HCIPostProcAlgo

### DIFF
--- a/vip_hci/conf/utils_conf.py
+++ b/vip_hci/conf/utils_conf.py
@@ -14,6 +14,7 @@ import sys
 import numpy as np
 
 import itertools as itt
+import inspect
 from multiprocessing import Pool
 
 from vip_hci import __version__
@@ -192,6 +193,72 @@ class NoProgressbar(object):
 
     def update(self):
         pass
+
+
+def algo_calculates(*calculated_attributes):
+    """
+    Decorator for HCIPostProcAlgo methods, describe what they calculate.
+    
+    There are three benefits from decorating a method:
+    
+    - if ``verbose=True``, prints a message about the calculated attributes and
+      the ones which can be calculated next.
+    - the attributes which *can* be calculated by this method are tracked, so
+      if a user tries to access them *before* the function is called, an
+      informative error message can be shown
+    - the object knows which attributes to reset when ``run()`` is called a
+      second time, on a different dataset.
+
+    Parameters
+    ----------
+    *calculated_attributes : list of strings
+        Strings denominating the attributes the decorated function calculates.
+    
+    Examples
+    --------
+    
+    .. code:: python
+
+        from .conf import algo_calculates as calculates
+    
+        class HCIMyAlgo(HCIPostPRocAlgo):
+            def __init__(self, my_algo_param):
+                self.store_args(locals())
+            
+            @calculates("final_frame", "snr_map")
+            def run(dataset=None, verbose=True):
+                frame, snr = my_heavy_calculation()
+                
+                self.final_frame = frame
+                self.snr_map = snr
+
+    """
+    def decorator(fkt):
+        def wrapper(self, *args, **kwargs):
+            # run the actual method
+            res = fkt(self, *args, **kwargs)
+
+            # get the kwargs the fkt sees. Note that this is a combination of
+            # the *default* kwargs and the kwargs *passed* by the user
+            a = inspect.getargspec(fkt)
+            all_kwargs = dict(zip(a.args[-len(a.defaults):], a.defaults))
+            all_kwargs.update(kwargs)
+            
+            if not hasattr(self, "_called_calculators"):
+                self._called_calculators = []
+            self._called_calculators.append(fkt.__name__)
+
+            # show help message
+            if all_kwargs.get("verbose", False):
+                self._show_attribute_help(fkt.__name__)
+
+
+            return res
+        
+        # set an attribute on the wrapper so _get_calculations() can find it.
+        wrapper._calculates = calculated_attributes
+        return wrapper
+    return decorator
 
 
 def check_array(input_array, dim, name=None):

--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -22,14 +22,14 @@ import numpy as np
 class HCIPostProcAlgo(BaseEstimator):
     """ Base HCI post-processing algorithm class.
     """
-    def print_parameters(self):
+    def _print_parameters(self):
         """ Printing out the parameters of the algorithm.
         """
         dicpar = self.get_params()
         for key in dicpar.keys():
             print("{}: {}".format(key, dicpar[key]))
 
-    def store_args(self, kwargs, *skip):
+    def _store_args(self, kwargs, *skip):
         # TODO: this could be integrated with sklearn's BaseEstimator methods
         for k in kwargs:
             if k == "self" or k in skip:
@@ -161,9 +161,9 @@ class HCIMedianSub(HCIPostProcAlgo):
         if not isinstance(dataset, (HCIDataset, type(None))):
             raise ValueError('`dataset` must be a HCIDataset object or None')
 
-        self.store_args(locals())
+        self._store_args(locals())
         if verbose:
-            self.print_parameters()
+            self._print_parameters()
 
     def run(self, dataset=None, nproc=1, verbose=True):
         """ Running the HCI median subtraction algorithm for model PSF
@@ -290,9 +290,9 @@ class HCIPca(HCIPostProcAlgo):
         if not isinstance(dataset, (HCIDataset, type(None))):
             raise ValueError('`dataset` must be a HCIDataset object or None')
 
-        self.store_args(locals())
+        self._store_args(locals())
         if verbose:
-            self.print_parameters()
+            self._print_parameters()
 
     def run(self, dataset=None, nproc=1, verbose=True, debug=False):
         """ Running the HCI PCA algorithm for model PSF subtraction.

--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -20,8 +20,60 @@ import numpy as np
 
 
 class HCIPostProcAlgo(BaseEstimator):
-    """ Base HCI post-processing algorithm class.
     """
+    Base HCI post-processing algorithm class.
+    """
+
+    def __init__(self, locals_dict, *skip):
+        """
+        Set up the algorithm parameters.
+
+        This does multiple things:
+
+        - verify that ``dataset`` is a HCIDataset object or ``None`` (it could
+          also be provided to ``run``)
+        - store all the keywords (from ``locals_dict``) as object attributes, so
+          they can be accessed e.g. in the ``run()`` method
+        - print out the full algorithm settings (user provided parameters +
+          default ones) if ``verbose=True``
+
+        Parameters
+        ----------
+        locals_dict : dict
+            This should be ``locals()``. ``locals()`` contains *all* the
+            variables defined in the local scope. Passed to
+            ``self._store_args``.
+        *skip : list of strings
+            Passed on to ``self._store_args``. Refer to its documentation.
+
+        Examples
+        --------
+
+        .. code:: python
+
+            # when subclassing HCIPostProcAlgo, make sure you call super()
+            # with locals()! This means:
+
+            class MySuperAlgo(HCIPostProcAlgo):
+                def __init__(self, algo_param_1=42, cool=True):
+                    super(MySuperAlgo, self).__init__(locals())
+                
+                @calculates("frame")
+                def run(self, dataset=None):
+                    self.frame = 2 * self.algo_param_1
+
+        """
+
+        dataset = locals_dict.get("dataset", None)
+        if not isinstance(dataset, (HCIDataset, type(None))):
+            raise ValueError('`dataset` must be a HCIDataset object or None')
+
+        self._store_args(locals_dict, *skip)
+
+        verbose = locals_dict.get("verbose", True)
+        if verbose:
+            self._print_parameters()
+
     def _print_parameters(self):
         """ Printing out the parameters of the algorithm.
         """
@@ -157,13 +209,7 @@ class HCIMedianSub(HCIPostProcAlgo):
                  delta_rot=1, delta_sep=(0.2, 1), nframes=4, imlib='opencv',
                  interpolation='lanczos4', collapse='median',
                  verbose=True):
-        """ """
-        if not isinstance(dataset, (HCIDataset, type(None))):
-            raise ValueError('`dataset` must be a HCIDataset object or None')
-
-        self._store_args(locals())
-        if verbose:
-            self._print_parameters()
+        super(HCIMedianSub, self).__init__(locals())
 
     def run(self, dataset=None, nproc=1, verbose=True):
         """ Running the HCI median subtraction algorithm for model PSF
@@ -284,15 +330,10 @@ class HCIPca(HCIPostProcAlgo):
                  adimsdi='double', mask_central_px=None, source_xy=None,
                  delta_rot=1, imlib='opencv', interpolation='lanczos4',
                  collapse='median', check_mem=True, crop_ifs=True, verbose=True):
-        """ """
+        
+        super(HCIPca, self).__init__(locals())
 
         # TODO: order/names of parameters are not consistent with ``pca`` core function
-        if not isinstance(dataset, (HCIDataset, type(None))):
-            raise ValueError('`dataset` must be a HCIDataset object or None')
-
-        self._store_args(locals())
-        if verbose:
-            self._print_parameters()
 
     def run(self, dataset=None, nproc=1, verbose=True, debug=False):
         """ Running the HCI PCA algorithm for model PSF subtraction.

--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -121,15 +121,10 @@ class HCIPostProcAlgo(BaseEstimator):
 
         return dataset
 
-    def get_detection_map(self):
-        """
-        used in ``EvalRoc.postprocess()``. Overwritten by methods which directly
-        output a probability map, like Andromeda.
-        """
-        return self.snr_map
-
     def make_snr_map(self, method='fast', mode='sss', nproc=1, verbose=True):
         """
+        Calculate a SNR map from ``self.frame_final``.
+
         Parameters
         ----------
         method : {'xpx', 'fast'}, str optional
@@ -144,6 +139,14 @@ class HCIPostProcAlgo(BaseEstimator):
             Number of processes. Defaults to single-process (serial) processing.
         verbose : bool, optional
             Show more output.
+
+        Notes
+        -----
+        This is needed for "classic" algorithms that produce a final residual
+        image in their ``.run()`` method. To obtain a "detection map", which can
+        be used for counting true/false positives, a SNR map has to be created.
+        For other algorithms (like ANDROMEDA) which directly create a SNR or a
+        probability map, this method should be overwritten and thus disabled.
 
         """
         if not hasattr(self, "frame_final"):
@@ -161,6 +164,7 @@ class HCIPostProcAlgo(BaseEstimator):
         else:
             raise ValueError('`method` not recognized')
 
+        self.detection_map = self.snr_map
 
     def save(self, filename):
         """

--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -19,7 +19,7 @@ from .metrics import snrmap_fast, snrmap
 from .andromeda import andromeda
 from .pca import pca
 from .leastsq import xloci
-from .conf.utils_conf import algo_calculates as calculates
+from .conf.utils_conf import algo_calculates_decorator as calculates
 
 
 class HCIPostProcAlgo(BaseEstimator):

--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -161,7 +161,6 @@ class HCIPostProcAlgo(BaseEstimator):
         else:
             raise ValueError('`method` not recognized')
 
-        return self.snr_map
 
     def save(self, filename):
         """
@@ -172,7 +171,7 @@ class HCIPostProcAlgo(BaseEstimator):
         """
         pickle.dump(self, open(filename, "wb"))
 
-    def run(self, dataset=None, full_output=False, nproc=1, verbose=True):
+    def run(self, dataset=None, nproc=1, verbose=True):
         """
         Run the algorithm. Should at least set `` self.frame_final``.
 

--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -8,7 +8,8 @@ from __future__ import division, print_function
 
 __author__ = 'Carlos Alberto Gomez Gonzalez, Ralf Farkas'
 __all__ = ['HCIMedianSub',
-           'HCIPca']
+           'HCIPca',
+           'HCILoci']
 
 from sklearn.base import BaseEstimator
 from .hci_dataset import HCIDataset
@@ -17,6 +18,7 @@ from .metrics import snrmap_fast, snrmap
 from .pca import pca
 import pickle
 import numpy as np
+from .leastsq import xloci
 from .conf.utils_conf import algo_calculates as calculates
 
 
@@ -534,6 +536,34 @@ class HCIPca(HCIPostProcAlgo):
                 self.frame_final = frame
 
 
+class HCILoci(HCIPostProcAlgo):
+    """
+    HCI LOCI algorithm.
+    """
 
+    def __init__(self, dataset=None, scale_list=None, metric="manhattan",
+                 dist_threshold=90, delta_rot=0.5, delta_sep=(0.1, 1),
+                 radius_int=0, asize=4, n_segments=4, solver="lstsq", tol=1e-3,
+                 optim_scale_fact=1, adimsdi="skipadi", imlib="opencv",
+                 interpolation="lanczos4", collapse="median", verbose=True):
+        super(HCILoci, self).__init__(locals())
 
+    @calculates("frame_final", "cube_res", "cube_der")
+    def run(self, dataset=None, nproc=1, verbose=True):
+        """
+        Run the HCI LOCI algorithm for model PSF subtraction.
+
+        """
+
+        dataset = self._get_dataset(dataset, verbose)
+
+        res = xloci(dataset.cube, dataset.angles, self.scale_list, dataset.fwhm,
+                    self.metric, self.dist_threshold, self.delta_rot,
+                    self.delta_sep, self.radius_int, self.asize,
+                    self.n_segments, nproc, self.solver, self.tol,
+                    self.optim_scale_fact, self.adimsdi, self.imlib,
+                    self.interpolation, self.collapse, verbose,
+                    full_output=True)
+        
+        self.cube_res, self.cube_der, self.frame_final = res
 

--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -81,12 +81,12 @@ class HCIPostProcAlgo(BaseEstimator):
         for key in dicpar.keys():
             print("{}: {}".format(key, dicpar[key]))
 
-    def _store_args(self, kwargs, *skip):
+    def _store_args(self, locals_dict, *skip):
         # TODO: this could be integrated with sklearn's BaseEstimator methods
-        for k in kwargs:
+        for k in locals_dict:
             if k == "self" or k in skip:
                 continue
-            setattr(self, k, kwargs[k])
+            setattr(self, k, locals_dict[k])
 
     def _get_dataset(self, dataset=None, verbose=True):
         if dataset is None:

--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -165,7 +165,7 @@ class HCIMedianSub(HCIPostProcAlgo):
         if verbose:
             self.print_parameters()
 
-    def run(self, dataset=None, full_output=False, nproc=1, verbose=True):
+    def run(self, dataset=None, nproc=1, verbose=True):
         """ Running the HCI median subtraction algorithm for model PSF
         subtraction.
 
@@ -193,14 +193,12 @@ class HCIMedianSub(HCIPostProcAlgo):
                          dataset.fwhm, self.radius_int, self.asize,
                          self.delta_rot, self.delta_sep, self.mode,
                          self.nframes, self.imlib, self.interpolation,
-                         self.collapse, nproc, full_output, verbose)
+                         self.collapse, nproc, full_output=True,
+                         verbose=verbose)
 
-        if full_output:
-            self.cube_residuals, self.cube_residuals_der, self.frame_final = res
-            return self.cube_residuals, self.cube_residuals_der, self.frame_final
-        else:
-            self.frame_final = res
-            return self.frame_final
+
+        self.cube_residuals, self.cube_residuals_der, self.frame_final = res
+
 
 
 class HCIPca(HCIPostProcAlgo):


### PR DESCRIPTION
The goal of this PR was to

- simplify the code we write when creating a new algorithm class
- unify the way algorithms handle their different *results*, like residual frames, SNR maps, etc
- help the user by providing useful error messages and information about what happened

I added two more algorithms as `HCIPostProcAlgo` subclasses, namely `HCILoci` and `HCIAndromeda`, by using the new features.

I'll upload a notebook to Binder shortly, to highlight the most important changes.