### PR TITLE
ENH: don’t force .npz when loading HCIDataset

### DIFF
--- a/vip_hci/conf/utils_conf.py
+++ b/vip_hci/conf/utils_conf.py
@@ -70,10 +70,10 @@ class Saveable(object):
 
     @classmethod
     def load(cls, filename):
-        if not filename.endswith(".npz"):
-            filename += ".npz"
-
-        data = np.load(filename)
+        try:
+            data = np.load(filename)
+        except FileNotFoundError:
+            data = np.load(filename + ".npz")
 
         if "_vip_object" not in data:
             raise RuntimeError("The file you specified is not a VIP object.")


### PR DESCRIPTION
We faced something similar with `open_fits` already, now this PR extends the support for files *without* a file extension to HCIDataset's `.load`.

This is especially useful when using `astropy.utils.data.download_file` (which creates files without file extension), e.g. in tests.