### PR TITLE
FIX: np.median(fwhm) before calling snrmap in 4D case

### DIFF
--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -14,6 +14,7 @@ __all__ = ['HCIMedianSub',
 
 import pickle
 from sklearn.base import BaseEstimator
+
 from .hci_dataset import HCIDataset
 from .medsub import median_sub
 from .metrics import snrmap_fast, snrmap
@@ -61,7 +62,7 @@ class HCIPostProcAlgo(BaseEstimator):
             class MySuperAlgo(HCIPostProcAlgo):
                 def __init__(self, algo_param_1=42, cool=True):
                     super(MySuperAlgo, self).__init__(locals())
-                
+
                 @calculates("frame")
                 def run(self, dataset=None):
                     self.frame = 2 * self.algo_param_1
@@ -154,7 +155,7 @@ class HCIPostProcAlgo(BaseEstimator):
     def _reset_results(self):
         """
         Remove all calculated results from the object.
-        
+
         By design, the HCIPostPRocAlgo's can be initialized without a dataset,
         so the dataset can be provided to the ``run`` method. This makes it
         possible to run the same algorithm on multiple datasets. In order not to
@@ -171,7 +172,7 @@ class HCIPostProcAlgo(BaseEstimator):
     def __getattr__(self, a):
         """
         ``__getattr__`` is only called when an attribute does *not* exist.
-        
+
         Catching this event allows us to output proper error messages when an
         attribute was not calculated yet.
         """
@@ -202,7 +203,7 @@ class HCIPostProcAlgo(BaseEstimator):
         for a, f in calculations.items():
             if hasattr(self, a) and function_name == f:
                 print("\t{}".format(a))
-        
+
         not_calculated_yet = [(a, f) for a, f in calculations.items()
                               if (f not in self._called_calculators
                                   and not hasattr(self, a))]
@@ -366,7 +367,6 @@ class HCIMedianSub(HCIPostProcAlgo):
         self.cube_residuals, self.cube_residuals_der, self.frame_final = res
 
 
-
 class HCIPca(HCIPostProcAlgo):
     """ HCI PCA algorithm.
 
@@ -450,7 +450,7 @@ class HCIPca(HCIPostProcAlgo):
                  adimsdi='double', mask_central_px=None, source_xy=None,
                  delta_rot=1, imlib='opencv', interpolation='lanczos4',
                  collapse='median', check_mem=True, crop_ifs=True, verbose=True):
-        
+
         super(HCIPca, self).__init__(locals())
 
         # TODO: order/names of parameters are not consistent with ``pca`` core function
@@ -565,7 +565,7 @@ class HCILoci(HCIPostProcAlgo):
                     self.optim_scale_fact, self.adimsdi, self.imlib,
                     self.interpolation, self.collapse, verbose,
                     full_output=True)
-        
+
         self.cube_res, self.cube_der, self.frame_final = res
 
 
@@ -656,7 +656,7 @@ class HCIAndromeda(HCIPostProcAlgo):
                         nsmooth_snr=self.nsmooth_snr, iwa=self.iwa,
                         owa=self.owa,
                         precision=self.precision, fast=self.fast,
-                        homogeneous_variance=self.homogeneous_variance, 
+                        homogeneous_variance=self.homogeneous_variance,
                         ditimg=self.ditimg, ditpsf=self.ditpsf, tnd=self.tnd,
                         total=self.total,
                         multiply_gamma=self.multiply_gamma, nproc=nproc,

--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -12,6 +12,7 @@ __all__ = ['HCIMedianSub',
            'HCILoci',
            'HCIAndromeda']
 
+import pickle
 from sklearn.base import BaseEstimator
 from .hci_dataset import HCIDataset
 from .medsub import median_sub

--- a/vip_hci/hci_postproc.py
+++ b/vip_hci/hci_postproc.py
@@ -13,6 +13,7 @@ __all__ = ['HCIMedianSub',
            'HCIAndromeda']
 
 import pickle
+import numpy as np
 from sklearn.base import BaseEstimator
 
 from .hci_dataset import HCIDataset
@@ -241,12 +242,16 @@ class HCIPostProcAlgo(BaseEstimator):
         probability map, this method should be overwritten and thus disabled.
 
         """
+        if self.dataset.cube.ndim == 4:
+            fwhm = np.mean(self.dataset.fwhm)
+        else:
+            fwhm = self.dataset.fwhm
 
         if method == 'fast':
-            self.snr_map = snrmap_fast(self.frame_final, self.dataset.fwhm,
+            self.snr_map = snrmap_fast(self.frame_final, fwhm,
                                        nproc=nproc, verbose=verbose)
         elif method == 'xpx':
-            self.snr_map = snrmap(self.frame_final, self.dataset.fwhm,
+            self.snr_map = snrmap(self.frame_final, fwhm,
                                   plot=False, mode=mode, source_mask=None,
                                   nproc=nproc, save_plot=None, plot_title=None,
                                   verbose=verbose)


### PR DESCRIPTION
In the 4D case, the FWHM is a list/1D array, while the two `snrmap` and `snrmap_fast` functions require a single float. This breaks `HCIPostProc.make_snr_map()`.

In the `mediansub` subpackage, a median was used when a 1D FWHM was passed, so I propose to do the same in this case.