### PR TITLE
FIX: normalize_psf requires int size

### DIFF
--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -543,7 +543,7 @@ def throughput(cube, angle_list, psf_template, fwhm, pxscale, algo, nbranch=1,
 
     # We crop the PSF and check if PSF has been normalized (so that flux in
     # 1*FWHM aperture = 1) and fix if needed
-    new_psf_size = 3 * fwhm
+    new_psf_size = int(round(3 * fwhm))
     if new_psf_size % 2 == 0:
         new_psf_size += 1
 


### PR DESCRIPTION
closes #347.

`fakecomp.normalize_psf` requires an `int` as its `size`<sup>1</sup> parameter, but `contrast_curve.contrast_curve` passes the `fwhm` through it, which can be a float.

This PR forces `contrast_curve` to pass an `int` to `normalize_psf`.

---

<sup>1</sup> But accepts a `float` as `fwhm`, as expected.