### PR TITLE
pass verbose parameter while calling normalize_psf

### DIFF
--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -549,7 +549,7 @@ def throughput(cube, angle_list, psf_template, fwhm, pxscale, algo, nbranch=1,
 
     if cube.ndim == 3:
         n, y, x = array.shape
-        psf_template = normalize_psf(psf_template, fwhm=fwhm,
+        psf_template = normalize_psf(psf_template, fwhm=fwhm, verbose=verbose,
                                      size=min(new_psf_size,
                                               psf_template.shape[1]))
 
@@ -631,7 +631,7 @@ def throughput(cube, angle_list, psf_template, fwhm, pxscale, algo, nbranch=1,
         w, n, y, x = array.shape
         if isinstance(fwhm, (int, float)):
             fwhm = [fwhm] * w
-        psf_template = normalize_psf(psf_template, fwhm=fwhm,
+        psf_template = normalize_psf(psf_template, fwhm=fwhm, verbose=verbose,
                                      size=min(new_psf_size,
                                               psf_template.shape[1]))
 


### PR DESCRIPTION
In contrastcurve.py, throughput() is calling normalize_psf() twice. 
Passing the verbose parameter allows to completely remove all prints during a call to throughput() or contrast_curve(). This is useful while parallelizing multiple contrast_curve() calls, to avoid printing simultaneously from different workers.
