### PR TITLE
Added a few optional features in pca and recentering functions

### DIFF
--- a/vip_hci/preproc/badpixremoval.py
+++ b/vip_hci/preproc/badpixremoval.py
@@ -303,7 +303,7 @@ def cube_fix_badpix_annuli(array, cy, cx, fwhm, sig=5., protect_psf=True,
         big_ell_frame = np.zeros_like(obj_tmp)
         sma_ell_frame = np.zeros_like(obj_tmp)
         ann_frame_cumul = np.zeros_like(obj_tmp)
-        n_neig = np.zeros(nrad)
+        n_neig = np.zeros(nrad, dtype=np.int16)
         med_neig = np.zeros(nrad)
         std_neig = np.zeros(nrad)
         neighbours = np.zeros([nrad,n_y*n_x])


### PR DESCRIPTION
*Added features in pca and pca_annular (and propagated in utils_pca.py):
when processing mSDI+ADI cubes, possibility to combine residual frames only in a range of wavelengths. This is done with a new keyword, a tuple which should correspond to the first and last index of the relevant spectral channels. This is particularly useful when one wants to use the whole spectral range of the IFS for mSDI, but preserve some spectral information in the output.

*Modified features in recentering.py:
1) tests on SPHERE data suggest that recentering based on satellite spots is more robust using a 2d moffat fit than the 2d gaussian fit, currently implemented in VIP. I added an optional keyword to pick between the 2 kinds of fit, and set the default value to be the 2d moffat fit.
2) In case full_output is True, 2 additional arrays are returned from cube_recenter_sat_spots: the x and y centroid positions of the 4 satellite spots. This is useful for either debugging, or measuring the flux of the satellite spots.  

*Fixed bug:
-non-integer numpy index in badpixremoval.py