### PR TITLE
Debug of mcmc routine and cube_planet_free, and modified full output for 2d fits

### DIFF
--- a/vip_hci/conf/utils_conf.py
+++ b/vip_hci/conf/utils_conf.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 """
 Module with utilities.

--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -496,7 +496,10 @@ def throughput(cube, angle_list, psf_template, fwhm, pxscale, algo, nbranch=1,
             else:
                 if algo_dict['scale_list'].shape[0] != array.shape[0]:
                     raise TypeError('Input wavelength vector has wrong length')
-                maxfcsep = int((array.shape[2] / 2.) / fwhm) - 1
+                if isinstance(fwhm, float) or isinstance(fwhm, int):
+                    maxfcsep = int((array.shape[2] / 2.) / fwhm) - 1
+                else:
+                    maxfcsep = int((array.shape[2] / 2.) / np.amin(fwhm)) - 1
                 if fc_rad_sep < 3 or fc_rad_sep > maxfcsep:
                     msg = 'Too large separation between companions in the '
                     msg += 'radial patterns. Should lie between 3 and {}'

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -178,8 +178,10 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
                     if isinstance(flevel, (int, float)):
                         array_out[:, fr] += shift * flevel
                     else:
-                        array_out[:, fr] += [shift[i] * flevel[i]
-                                             for i in range(len(flevel))]
+                        for i in range(len(flevel)):
+                            array_out[i, fr] += shift[i] * flevel[i]
+                        #array_out[:, fr] += [shift[i] * flevel[i]
+                        #                     for i in range(len(flevel))]
 
                 pos_y = rad * np.sin(ang) + ceny
                 pos_x = rad * np.cos(ang) + cenx

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -180,8 +180,6 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
                     else:
                         for i in range(len(flevel)):
                             array_out[i, fr] += shift[i] * flevel[i]
-                        #array_out[:, fr] += [shift[i] * flevel[i]
-                        #                     for i in range(len(flevel))]
 
                 pos_y = rad * np.sin(ang) + ceny
                 pos_x = rad * np.cos(ang) + cenx

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -357,9 +357,9 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     plsc: float
         The platescale, in arcsec per pixel.
     annulus_width: float, optional
-        The width in pixel of the annulus on which the PCA is performed.
+        The width in FWHM of the annulus on which the PCA is performed.
     aperture_radius: float, optional
-        The radius of the circular aperture.
+        The radius in FWHM of the circular aperture.
     nwalkers: int optional
         The number of Goodman & Weare 'walkers'.
     initial_state: numpy.array
@@ -490,8 +490,8 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     stop = np.inf
 
     if bounds is None:
-        bounds = [(initial_state[0] - annulus_width/2.,
-                   initial_state[0] + annulus_width/2.),  # radius
+        bounds = [(initial_state[0] - annulus_width*fwhm/2.,
+                   initial_state[0] + annulus_width*fwhm/2.),  # radius
                   (initial_state[1] - 10, initial_state[1] + 10),   # angle
                   (0, 2 * initial_state[2])]   # flux
     

--- a/vip_hci/negfc/utils_negfc.py
+++ b/vip_hci/negfc/utils_negfc.py
@@ -22,7 +22,8 @@ def cube_planet_free(planet_parameter, cube, angs, psfn, plsc, imlib='opencv',
     Parameters
     ----------
     planet_parameter: numpy.array or list
-        The (r, theta, flux) for all known companions.
+        The (r, theta, flux) for all known companions. For a 4d cube r, 
+        theta and flux must all be 1d arrays with length equal to cube.shape[0].
     cube: numpy.array
         The cube of fits images expressed as a numpy.array.
     angs: numpy.array
@@ -47,18 +48,34 @@ def cube_planet_free(planet_parameter, cube, angs, psfn, plsc, imlib='opencv',
 
     planet_parameter = np.array(planet_parameter)
 
+    if cube.ndim == 4:
+        if planet_parameter.shape[3] != cube.shape[0]:
+            raise TypeError("Input planet parameter with wrong dimensions.")
+        
     for i in range(planet_parameter.shape[0]):
         if i == 0:
             cube_temp = cube
         else:
             cube_temp = cpf
 
-        cpf = cube_inject_companions(cube_temp, psfn, angs,
-                                     flevel=-planet_parameter[i, 2], plsc=plsc,
-                                     rad_dists=[planet_parameter[i, 0]],
-                                     n_branches=1, theta=planet_parameter[i, 1],
-                                     imlib=imlib, interpolation=interpolation,
-                                     verbose=False)
+        if cube.ndim == 4:
+            for j in cube.shape[0]:
+                cpf[j] = cube_inject_companions(cube_temp[j], psfn[j], angs,
+                                                flevel=-planet_parameter[i, 2, j], 
+                                                plsc=plsc,
+                                                rad_dists=[planet_parameter[i, 0, j]],
+                                                n_branches=1, 
+                                                theta=planet_parameter[i, 1, j],
+                                                imlib=imlib, 
+                                                interpolation=interpolation,
+                                                verbose=False)
+        else:    
+            cpf = cube_inject_companions(cube_temp, psfn, angs,
+                                         flevel=-planet_parameter[i, 2], plsc=plsc,
+                                         rad_dists=[planet_parameter[i, 0]],
+                                         n_branches=1, theta=planet_parameter[i, 1],
+                                         imlib=imlib, interpolation=interpolation,
+                                         verbose=False)
     return cpf
 
 

--- a/vip_hci/var/fit_2d.py
+++ b/vip_hci/var/fit_2d.py
@@ -161,7 +161,8 @@ def fit_2dgaussian(array, crop=False, cent=None, cropsize=15, fwhmx=4, fwhmy=4,
         noise.
     full_output : bool, optional
         If False it returns just the centroid, if True also returns the
-        FWHM in X and Y (in pixels), the amplitude and the rotation angle.
+        FWHM in X and Y (in pixels), the amplitude and the rotation angle,
+        and the uncertainties on each parameter.
     debug : bool, optional
         If True, the function prints out parameters of the fit and plots the
         data, model and residuals.
@@ -226,6 +227,12 @@ def fit_2dgaussian(array, crop=False, cent=None, cropsize=15, fwhmx=4, fwhmy=4,
     fwhm_x = fit.x_stddev.value*gaussian_sigma_to_fwhm
     amplitude = fit.amplitude.value
     theta = np.rad2deg(fit.theta.value)
+    
+    # compute uncertainties
+    perr = np.sqrt(np.diag(fitter.fit_info['param_cov']))
+    amplitude_err, theta_err, mean_x_err, mean_y_err, fwhm_x_err, fwhm_y_err = perr
+    fwhm_x_err /= gaussian_fwhm_to_sigma
+    fwhm_y_err /= gaussian_fwhm_to_sigma
 
     if debug:
         if threshold:
@@ -246,7 +253,10 @@ def fit_2dgaussian(array, crop=False, cent=None, cropsize=15, fwhmx=4, fwhmy=4,
     if full_output:
         return pd.DataFrame({'centroid_y': mean_y, 'centroid_x': mean_x,
                              'fwhm_y': fwhm_y, 'fwhm_x': fwhm_x,
-                             'amplitude': amplitude, 'theta': theta}, index=[0])
+                             'amplitude': amplitude, 'theta': theta,
+                             'centroid_y_err': mean_y_err, 'centroid_x_err': mean_x_err,
+                             'fwhm_y_err': fwhm_y_err, 'fwhm_x_err': fwhm_x_err,
+                             'amplitude_err': amplitude_err, 'theta_err': theta_err}, index=[0])
     else:
         return mean_y, mean_x
 
@@ -344,6 +354,11 @@ def fit_2dmoffat(array, crop=False, cent=None, cropsize=15, fwhm=4,
     alpha = fit.alpha.value
     gamma = fit.gamma.value
 
+    # compute uncertainties
+    perr = np.sqrt(np.diag(fitter.fit_info['param_cov']))
+    amplitude_err, mean_x_err, mean_y_err, gamma_err, alpha_err = perr
+    fwhm_err = 2*gamma_err
+
     if debug:
         if threshold:
             label = ('Subimage thresholded', 'Model', 'Residuals')
@@ -363,7 +378,11 @@ def fit_2dmoffat(array, crop=False, cent=None, cropsize=15, fwhm=4,
     if full_output:
         return pd.DataFrame({'centroid_y': mean_y, 'centroid_x': mean_x,
                              'fwhm': fwhm, 'alpha': alpha, 'gamma': gamma,
-                             'amplitude': amplitude}, index=[0])
+                             'amplitude': amplitude, 'centroid_y_err': mean_y_err, 
+                             'centroid_x_err': mean_x_err,
+                             'fwhm_err': fwhm_err, 'alpha_err': alpha_err, 
+                             'gamma_err': gamma_err, 
+                             'amplitude_err': amplitude_err}, index=[0])
     else:
         return mean_y, mean_x
 
@@ -462,6 +481,11 @@ def fit_2dairydisk(array, crop=False, cent=None, cropsize=15, fwhm=4,
     radius = fit.radius.value
     fwhm = ((radius * 1.028) / 2.44) * 2
 
+    # compute uncertainties
+    perr = np.sqrt(np.diag(fitter.fit_info['param_cov']))
+    amplitude_err, mean_x_err, mean_y_err, radius_err = perr
+    fwhm_err = ((radius_err * 1.028) / 2.44) * 2
+
     if debug:
         if threshold:
             label = ('Subimage thresholded', 'Model', 'Residuals')
@@ -480,6 +504,9 @@ def fit_2dairydisk(array, crop=False, cent=None, cropsize=15, fwhm=4,
     if full_output:
         return pd.DataFrame({'centroid_y': mean_y, 'centroid_x': mean_x,
                              'fwhm': fwhm, 'radius': radius,
-                             'amplitude': amplitude}, index=[0])
+                             'amplitude': amplitude, 'centroid_y_err': mean_y_err, 
+                             'centroid_x_err': mean_x_err, 'fwhm_err': fwhm_err, 
+                             'radius_err': radius_err,
+                             'amplitude_err': amplitude_err}, index=[0])
     else:
         return mean_y, mean_x


### PR DESCRIPTION
Major changes:
- debug of negfc/mcmc_negfc_sampling(): description says that the annulus width and aperture radius should be provided in pixels. In practice the high level code of mcmc_negfc_sampling() assumes annulus_width is indeed in pixels, but that both annulus_width and aperture radius are in FWHM when called in the mcmc sampler, which makes use of PCA-annulus.
- debug of utils_negfc/cube_planet_free(): works fine for a 3d cube, but not for a 4d (ifs+adi) cube. In the latter case, one needs to use a different flux at each wavelength, hence r, theta and flux are all 1d array. Since input cube is 4d, it triggers the ifs mode of cube_inject_companions(), but given the loop on both r and flux, which are both n_wavelength dimension, the negative fake companion is injected n_wavelength x n_wavelength times (i.e. n_wavelength times too many).
- in the case of fits to 2d gaussian, moffat or airy, it is often desirable to have an idea of the uncertainty on the best-fit parameters (in particular on the centroid). The full_output keyword now adds additional entries in the output dictionary, including errors on the best-fit parameters.
- several other minor bugs, including making contrast_curve() compatible with an input fwhm that is 1d array or list. Note that a proper debugging of the contrast_curve() function in the case of a 4d input cube is still required.