### PR TITLE
PCA-ASDI contrast curve bug fixed + other minor bugs corrected

### DIFF
--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -151,14 +151,14 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
     if transmission is not None:
         if not isinstance(transmission, tuple) or not len(transmission) == 2:
             raise TypeError('transmission must be a tuple with 2 1d vectors')
-    if isinstance(starphot, float) or isinstance(starphot, int):
-        pass
-    else:
-        if starphot.shape[0] != cube.shape[0]:
-            raise TypeError('Correction vector has bad size')
-        cube = cube.copy()
-        for i in range(cube.shape[0]):
-            cube[i] = cube[i] / starphot[i]
+#    if isinstance(starphot, float) or isinstance(starphot, int):
+#        pass
+#    else:
+#        if starphot.shape[0] != cube.shape[0]:
+#            raise TypeError('Correction vector has bad size')
+#        cube = cube.copy()
+#        for i in range(cube.shape[0]):
+#            cube[i] = cube[i] / starphot[i]
 
     if isinstance(fwhm, (np.ndarray,list)):
         fwhm_med = np.median(fwhm)
@@ -251,7 +251,7 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
     if isinstance(starphot, float) or isinstance(starphot, int):
         cont_curve_samp = ((sigma * noise_samp_sm) / thruput_interp) / starphot
     else:
-        cont_curve_samp = (sigma * noise_samp_sm) / thruput_interp
+        cont_curve_samp = ((sigma * noise_samp_sm) / thruput_interp) / np.median(starphot)
     cont_curve_samp[np.where(cont_curve_samp < 0)] = 1
     cont_curve_samp[np.where(cont_curve_samp > 1)] = 1
 
@@ -264,7 +264,8 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
             cont_curve_samp_corr = ((sigma_corr * noise_samp_sm)/thruput_interp
                                    )/starphot
         else:
-            cont_curve_samp_corr = (sigma_corr * noise_samp_sm)/thruput_interp
+            cont_curve_samp_corr = ((sigma_corr * noise_samp_sm)/thruput_interp
+                                   ) / np.median(starphot)
         cont_curve_samp_corr[np.where(cont_curve_samp_corr < 0)] = 1
         cont_curve_samp_corr[np.where(cont_curve_samp_corr > 1)] = 1
 
@@ -535,10 +536,24 @@ def throughput(cube, angle_list, psf_template, fwhm, pxscale, algo, nbranch=1,
         if 'fwhm' in argl:
             frame_nofc = algo(cube=array, angle_list=parangles, fwhm=fwhm_med,
                               verbose=False, **algo_dict)
+            if algo_dict.pop('scaling',None):
+                new_algo_dict = algo_dict.copy()
+                new_algo_dict['scaling'] = None
+                frame_nofc_noscal = algo(cube=array, angle_list=parangles, fwhm=fwhm_med,
+                                  verbose=False, **new_algo_dict)
+            else:
+                frame_nofc_noscal = frame_nofc
         else:
             frame_nofc = algo(array, angle_list=parangles, verbose=False,
                               **algo_dict)
-
+            if algo_dict.pop('scaling',None):
+                new_algo_dict = algo_dict.copy()
+                new_algo_dict['scaling'] = None
+                frame_nofc_noscal = algo(cube=array, angle_list=parangles,
+                                  verbose=False, **new_algo_dict)
+            else:
+                frame_nofc_noscal = frame_nofc
+                
     if verbose:
         msg1 = 'Cube without fake companions processed with {}'
         print(msg1.format(algo.__name__))
@@ -546,8 +561,11 @@ def throughput(cube, angle_list, psf_template, fwhm, pxscale, algo, nbranch=1,
 
     noise, vector_radd = noise_per_annulus(frame_nofc, separation=fwhm_med,
                                            fwhm=fwhm_med, wedge=wedge)
+    noise_noscal, vector_radd = noise_per_annulus(frame_nofc_noscal, separation=fwhm_med,
+                                           fwhm=fwhm_med, wedge=wedge)                                       
     vector_radd = vector_radd[inner_rad-1:]
     noise = noise[inner_rad-1:]
+    noise_noscal = noise_noscal[inner_rad-1:]
     if verbose:
         print('Measured annulus-wise noise in resulting frame')
         timing(start_time)
@@ -583,7 +601,7 @@ def throughput(cube, angle_list, psf_template, fwhm, pxscale, algo, nbranch=1,
                 fcy = []
                 fcx = []
                 for i in range(radvec.shape[0]):
-                    flux = fc_snr * noise[irad + i * fc_rad_sep]
+                    flux = fc_snr * noise_noscal[irad + i * fc_rad_sep]
                     cube_fc = cube_inject_companions(cube_fc, psf_template,
                                                      parangles, flux, pxscale,
                                                      rad_dists=[radvec[i]],
@@ -668,7 +686,7 @@ def throughput(cube, angle_list, psf_template, fwhm, pxscale, algo, nbranch=1,
                 fcy = []
                 fcx = []
                 for i in range(radvec.shape[0]):
-                    flux = fc_snr * noise[irad + i * fc_rad_sep]
+                    flux = fc_snr * noise_noscal[irad + i * fc_rad_sep]
                     cube_fc = cube_inject_companions(cube_fc, psf_template,
                                                      parangles, flux, pxscale,
                                                      rad_dists=[radvec[i]],

--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -151,14 +151,6 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
     if transmission is not None:
         if not isinstance(transmission, tuple) or not len(transmission) == 2:
             raise TypeError('transmission must be a tuple with 2 1d vectors')
-#    if isinstance(starphot, float) or isinstance(starphot, int):
-#        pass
-#    else:
-#        if starphot.shape[0] != cube.shape[0]:
-#            raise TypeError('Correction vector has bad size')
-#        cube = cube.copy()
-#        for i in range(cube.shape[0]):
-#            cube[i] = cube[i] / starphot[i]
 
     if isinstance(fwhm, (np.ndarray,list)):
         fwhm_med = np.median(fwhm)

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -458,13 +458,12 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     # If required, one create the output folder.
     if save:
         
-        if output_file is None:
-            output_file = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        output_file_tmp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
             
         try:
-            os.makedirs(output_dir+output_file)
+            os.makedirs(output_dir)
         except OSError as exc:
-            if exc.errno == 17 and os.path.isdir(output_dir+output_file):
+            if exc.errno == 17 and os.path.isdir(output_dir):
                 # errno.EEXIST == 17 -> File exists
                 pass
             else:
@@ -566,7 +565,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
                 
             if save:
                 import pickle
-                fname = '{d}{f}/{f}_temp_k{k}'.format(d=output_dir,f=output_file, k=k)
+                fname = '{d}/{f}_temp_k{k}'.format(d=output_dir,f=output_file_tmp, k=k)
                 data = {'chain': sampler.chain,
                         'lnprob': sampler.lnprobability,
                          'AR': sampler.acceptance_fraction}
@@ -641,11 +640,13 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
                   'AR': sampler.acceptance_fraction,
                   'lnprobability': sampler.lnprobability}
                   
-        with open(output_dir+output_file+'/MCMC_results', 'wb') as fileSave:
+        if output_file is None:
+            output_file = 'MCMC_results'
+        with open(output_dir+'/'+output_file, 'wb') as fileSave:
             pickle.dump(output, fileSave)
         
         msg = "\nThe file MCMC_results has been stored in the folder {}"
-        print(msg.format(output_dir+output_file+'/'))
+        print(msg.format(output_dir+'/'))
 
     if verbosity == 1 or verbosity == 2:
         timing(start_time)

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -853,22 +853,22 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
         test = 0
         pourcentage = 0
         for k, jj in enumerate(n_arg_sort):
-            test = test + bins_width*n[jj]
+            test = test + bins_width*n[int(jj)]
             pourcentage = test/surface_total*100
             if pourcentage > cfd:
                 if verbose:
                     msg = 'percentage for {}: {}%'
                     print(msg.format(label_file[j], pourcentage))
                 break
-        n_arg_min = n_arg_sort[:k].min()
-        n_arg_max = n_arg_sort[:k+1].max()
+        n_arg_min = int(n_arg_sort[:k].min())
+        n_arg_max = int(n_arg_sort[:k+1].max())
         
         if n_arg_min == 0:
             n_arg_min += 1
         if n_arg_max == bins:
             n_arg_max -= 1
         
-        val_max[pKey[j]] = bin_vertices[n_arg_sort[0]]+bins_width/2.
+        val_max[pKey[j]] = bin_vertices[int(n_arg_sort[0])]+bins_width/2.
         confidenceInterval[pKey[j]] = np.array([bin_vertices[n_arg_min-1],
                                                bin_vertices[n_arg_max+1]]
                                                - val_max[pKey[j]])
@@ -879,7 +879,7 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
             ax[0][j].hist(isamples[arg,j], bins=bin_vertices,
                           facecolor='gray', edgecolor='darkgray',
                           histtype='stepfilled', alpha=0.5)
-            ax[0][j].vlines(val_max[pKey[j]], 0, n[n_arg_sort[0]],
+            ax[0][j].vlines(val_max[pKey[j]], 0, n[int(n_arg_sort[0])],
                             linestyles='dashed', color='red')
             ax[0][j].set_xlabel(label[j])
             if j == 0:
@@ -907,7 +907,7 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
             ax[j].hist(isamples[arg,j],bins=bin_vertices, facecolor='gray',
                        edgecolor='darkgray', histtype='stepfilled',
                        alpha=0.5)
-            ax[j].vlines(val_max[pKey[j]], 0, n[n_arg_sort[0]],
+            ax[j].vlines(val_max[pKey[j]], 0, n[int(n_arg_sort[0])],
                          linestyles='dashed', color='red')
             ax[j].set_xlabel(label[j])
             if j == 0:

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -163,7 +163,8 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
 
 def lnprob(param,bounds, cube, angs, plsc, psf_norm, fwhm,
            annulus_width, ncomp, aperture_radius, initial_state, cube_ref=None,
-           svd_mode='lapack', scaling='temp-mean', fmerit='sum', imlib='opencv',
+           svd_mode='lapack', scaling='temp-mean', algo=pca_annulus,
+           delta_rot=1, fmerit='sum', imlib='opencv',
            interpolation='lanczos4', collapse='median', display=False):
     """ Define the probability log-function as the sum between the prior and
     likelihood log-funtions.
@@ -232,7 +233,8 @@ def lnprob(param,bounds, cube, angs, plsc, psf_norm, fwhm,
     
     return lp + lnlike(param, cube, angs, plsc, psf_norm, fwhm,
                        annulus_width, ncomp, aperture_radius, initial_state,
-                       cube_ref, svd_mode, scaling, fmerit, imlib,
+                       cube_ref, svd_mode, scaling, algo,
+                       delta_rot, fmerit, imlib,
                        interpolation, collapse, display)
 
 
@@ -325,7 +327,8 @@ def gelman_rubin_from_chain(chain, burnin):
 
 def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
                         annulus_width=3, aperture_radius=4, cube_ref=None,
-                        svd_mode='lapack', scaling='temp-mean', fmerit='sum',
+                        svd_mode='lapack', scaling='temp-mean', 
+                        algo=pca_annulus, delta_rot=1, fmerit='sum',
                         imlib='opencv', interpolation='lanczos4',
                         collapse='median', nwalkers=1000, bounds=None, a=2.0,
                         burnin=0.3, rhat_threshold=1.01, rhat_count_threshold=1,
@@ -510,8 +513,9 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
                                     args=([bounds, cube, angs, plsc, psfn,
                                            fwhm, annulus_width, ncomp,
                                            aperture_radius, initial_state,
-                                           cube_ref, svd_mode, scaling, fmerit,
-                                           imlib, interpolation, collapse]),
+                                           cube_ref, svd_mode, scaling, algo,
+                                           delta_rot, fmerit, imlib, 
+                                           interpolation, collapse]),
                                     threads=nproc)
     start = datetime.datetime.now()
 

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -459,7 +459,9 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     if save:
         
         output_file_tmp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-            
+          
+        if output_dir[-1] == '/':
+            output_dir = output_dir[:-1]
         try:
             os.makedirs(output_dir)
         except OSError as exc:

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -24,6 +24,7 @@ from scipy.stats import norm
 from ..metrics import cube_inject_companions
 from ..conf import time_ini, timing
 from ..conf.utils_conf import sep
+from ..pca import pca_annulus
 from .simplex_fmerit import get_values_optimize
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -67,7 +68,8 @@ def lnprior(param, bounds):
 
 def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
            ncomp, aperture_radius, initial_state, cube_ref=None,
-           svd_mode='lapack', scaling='temp-mean', fmerit='sum', imlib='opencv',
+           svd_mode='lapack', scaling='temp-mean', algo=pca_annulus,
+           delta_rot=1, fmerit='sum', imlib='opencv',
            interpolation='lanczos4', collapse='median', debug=False):
     """ Define the likelihood log-function.
     
@@ -102,6 +104,11 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
         "temp-mean" then temporal px-wise mean subtraction is done and with
         "temp-standard" temporal mean centering plus scaling to unit variance
         is done.
+    algo: vip function, optional {pca_annulus, pca_annular}
+        Post-processing algorithm used.
+    delta_rot: float, optional
+        If algo is set to pca_annular, delta_rot is the angular threshold used
+        to select frames in the PCA library (see description of pca_annular).
     fmerit : {'sum', 'stddev'}, string optional
         Chooses the figure of merit to be used. stddev works better for close in
         companions sitting on top of speckle noise.
@@ -135,7 +142,8 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
                                  aperture_radius*fwhm, initial_state[0],
                                  initial_state[1], cube_ref=cube_ref,
                                  svd_mode=svd_mode, scaling=scaling,
-                                 imlib=imlib, interpolation=interpolation,
+                                 algo=algo, delta_rot=delta_rot, imlib=imlib, 
+                                 interpolation=interpolation,
                                  collapse=collapse)
     
     # Function of merit

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -86,7 +86,7 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
     psf_norm: numpy.array
         The scaled psf expressed as a numpy.array.
     annulus_width: float
-        The width of the annulus of interest in terms of the FWHM.
+        The width of the annulus of interest in pixels.
     ncomp: int
         The number of principal components.
     fwhm : float
@@ -138,8 +138,8 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
                                         verbose=False)
                                   
     # Perform PCA and extract the zone of interest
-    values = get_values_optimize(cube_negfc, angs, ncomp, annulus_width*fwhm,
-                                 aperture_radius*fwhm, initial_state[0],
+    values = get_values_optimize(cube_negfc, angs, ncomp, annulus_width,
+                                 aperture_radius, initial_state[0],
                                  initial_state[1], cube_ref=cube_ref,
                                  svd_mode=svd_mode, scaling=scaling,
                                  algo=algo, delta_rot=delta_rot, imlib=imlib, 
@@ -190,7 +190,7 @@ def lnprob(param,bounds, cube, angs, plsc, psf_norm, fwhm,
     ncomp: int
         The number of principal components.
     aperture_radius: float
-        The radius of the circular aperture.
+        The radius of the circular aperture in FWHM.
     initial_state: numpy.array
         The initial guess for the position and the flux of the planet.
     cube_ref : numpy ndarray, 3d, optional

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -503,8 +503,8 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     stop = np.inf
 
     if bounds is None:
-        bounds = [(initial_state[0] - annulus_width*fwhm/2.,
-                   initial_state[0] + annulus_width*fwhm/2.),  # radius
+        bounds = [(initial_state[0] - annulus_width/2.,
+                   initial_state[0] + annulus_width/2.),  # radius
                   (initial_state[1] - 10, initial_state[1] + 10),   # angle
                   (0, 2 * initial_state[2])]   # flux
     

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -139,7 +139,7 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
                                   
     # Perform PCA and extract the zone of interest
     values = get_values_optimize(cube_negfc, angs, ncomp, annulus_width,
-                                 aperture_radius, initial_state[0],
+                                 aperture_radius, fwhm, initial_state[0],
                                  initial_state[1], cube_ref=cube_ref,
                                  svd_mode=svd_mode, scaling=scaling,
                                  algo=algo, delta_rot=delta_rot, imlib=imlib, 
@@ -524,7 +524,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     if verbosity == 2:
         print('\nStart of the MCMC run ...')
         print('Step  |  Duration/step (sec)  |  Remaining Estimated Time (sec)')
-                             
+    
     for k, res in enumerate(sampler.sample(pos, iterations=nIterations,
                                            storechain=True)):
         elapsed = (datetime.datetime.now()-start).total_seconds()

--- a/vip_hci/negfc/nested_sampling.py
+++ b/vip_hci/negfc/nested_sampling.py
@@ -221,7 +221,7 @@ def nested_sampling_results(ns_object, burnin=0.4, bins=None):
     """
     res = ns_object
     nsamples = res.samples.shape[0]
-    indburnin = np.percentile(np.array(range(nsamples)), burnin * 100)
+    indburnin = int(np.percentile(np.array(range(nsamples)), burnin * 100))
 
     print(res.summary())
 

--- a/vip_hci/negfc/nested_sampling.py
+++ b/vip_hci/negfc/nested_sampling.py
@@ -52,7 +52,7 @@ def nested_negfc_sampling(init, cube, angs, plsc, psf, fwhm, annulus_width=2,
     annulus_width: float, optional
         The width in pixel of the annulus on which the PCA is performed.
     aperture_radius: float, optional
-        The radius of the circular aperture.
+        The radius of the circular aperture in FWHM.
     ncomp: int optional
         The number of principal components.
     scaling : {'temp-mean', 'temp-standard'} or None, optional

--- a/vip_hci/negfc/simplex_fmerit.py
+++ b/vip_hci/negfc/simplex_fmerit.py
@@ -42,7 +42,7 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
     fwhm : float
         The FHWM in pixels.
     annulus_width: int, optional
-        The width in terms of the FWHM of the annulus on which the PCA is done.       
+        The width in pixels of the annulus on which the PCA is done.       
     aperture_radius: int, optional
         The radius of the circular aperture in terms of the FWHM.
     initialState: numpy.array
@@ -135,7 +135,7 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
     ncomp: int
         The number of principal component.
     annulus_width: float
-        The width in fwhm of the annulus on which the PCA is performed.
+        The width in pixels of the annulus on which the PCA is performed.
     aperture_radius: float
         The radius in fwhm of the circular aperture.
     fwhm: float
@@ -183,7 +183,7 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
     centy_fr, centx_fr = frame_center(cube[0])
     posy = r_guess * np.sin(np.deg2rad(theta_guess)) + centy_fr
     posx = r_guess * np.cos(np.deg2rad(theta_guess)) + centx_fr
-    halfw = max(aperture_radius*fwhm, annulus_width*fwhm/2)
+    halfw = max(aperture_radius*fwhm, annulus_width/2)
 
     # Checking annulus/aperture sizes. Assuming square frames
     msg = 'The annulus and/or the circular aperture used by the NegFC falls '
@@ -193,13 +193,13 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
         raise RuntimeError(msg)
                           
     if algo == pca_annulus:
-        pca_res = pca_annulus(cube, angs, ncomp, annulus_width*fwhm, r_guess, cube_ref,
+        pca_res = pca_annulus(cube, angs, ncomp, annulus_width, r_guess, cube_ref,
                           svd_mode, scaling, imlib=imlib,
                           interpolation=interpolation, collapse=collapse)
     elif algo == pca_annular:
-        radius_int = int(np.floor(r_guess-annulus_width*fwhm/2))
+        radius_int = int(np.floor(r_guess-annulus_width/2))
         # crop cube to just be larger than annulus => FASTER PCA
-        crop_sz = int(np.ceil(r_guess+annulus_width*fwhm))
+        crop_sz = int(np.ceil(r_guess+annulus_width))
         if not crop_sz %2:
             crop_sz+=1
         if crop_sz < cube.shape[1] and crop_sz < cube.shape[2]:

--- a/vip_hci/negfc/simplex_fmerit.py
+++ b/vip_hci/negfc/simplex_fmerit.py
@@ -12,13 +12,15 @@ from hciplot import plot_frames
 from skimage.draw import circle
 from ..metrics import cube_inject_companions
 from ..var import frame_center
-from ..pca.utils_pca import pca_annulus
+from ..pca import pca_annulus, pca_annular
+from ..preproc import cube_crop_frames
 
 
 def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,  
               aperture_radius, initialState, ncomp, cube_ref=None, 
               svd_mode='lapack', scaling=None, fmerit='sum', collapse='median',
-              imlib='opencv', interpolation='lanczos4', debug=False):
+              algo=pca_annulus, delta_rot=1, imlib='opencv', 
+              interpolation='lanczos4', debug=False):
     """
     Calculate the reduced chi2:
     \chi^2_r = \frac{1}{N-3}\sum_{j=1}^{N} |I_j|,
@@ -63,6 +65,11 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
         Sets the way of collapsing the frames for producing a final image. If
         None then the cube of residuals is used when measuring the function of
         merit (instead of a single final frame).
+    algo: vip function, optional {pca_annulus, pca_annular}
+        Post-processing algorithm used.
+    delta_rot: float, optional
+        If algo is set to pca_annular, delta_rot is the angular threshold used
+        to select frames in the PCA library (see description of pca_annular).
     imlib : str, optional
         See the documentation of the ``vip_hci.preproc.frame_shift`` function.
     interpolation : str, optional
@@ -87,11 +94,12 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
                                         interpolation=interpolation)
                                       
     # Perform PCA and extract the zone of interest
-    res = get_values_optimize(cube_negfc, angs, ncomp, annulus_width*fwhm,
-                              aperture_radius*fwhm, initialState[0],
+    res = get_values_optimize(cube_negfc, angs, ncomp, annulus_width,
+                              aperture_radius, fwhm, initialState[0],
                               initialState[1], cube_ref=cube_ref,
-                              svd_mode=svd_mode, scaling=scaling,
-                              collapse=collapse, debug=debug)
+                              svd_mode=svd_mode, scaling=scaling, algo=algo,
+                              delta_rot=delta_rot, collapse=collapse, 
+                              debug=debug)
     if debug and collapse is not None:
         values, frpca = res
         plot_frames(frpca)
@@ -111,8 +119,9 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
 
 
 def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius, 
-                        r_guess, theta_guess, cube_ref=None, svd_mode='lapack',
-                        scaling=None, imlib='opencv', interpolation='lanczos4',
+                        fwhm, r_guess, theta_guess, cube_ref=None, 
+                        svd_mode='lapack', scaling=None, algo=pca_annulus, 
+                        delta_rot=1, imlib='opencv', interpolation='lanczos4',
                         collapse='median', debug=False):
     """ Extracts a PCA-ed annulus from the cube and returns the flux values of
     the pixels included in a circular aperture centered at a given position.
@@ -126,9 +135,11 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
     ncomp: int
         The number of principal component.
     annulus_width: float
-        The width in pixels of the annulus on which the PCA is performed.
+        The width in fwhm of the annulus on which the PCA is performed.
     aperture_radius: float
-        The radius in pixels of the circular aperture.
+        The radius in fwhm of the circular aperture.
+    fwhm: float
+        Value of the FWHM of the PSF.
     r_guess: float
         The radial position of the center of the circular aperture. This 
         parameter is NOT the radial position of the candidate associated to the 
@@ -146,6 +157,11 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
         "temp-mean" then temporal px-wise mean subtraction is done and with 
         "temp-standard" temporal mean centering plus scaling to unit variance 
         is done.
+    algo: vip function, optional {pca_annulus, pca_annular}
+        Post-processing algorithm used.
+    delta_rot: float, optional
+        If algo is set to pca_annular, delta_rot is the angular threshold used
+        to select frames in the PCA library (see description of pca_annular).
     imlib : str, optional
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
     interpolation : str, optional
@@ -167,7 +183,7 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
     centy_fr, centx_fr = frame_center(cube[0])
     posy = r_guess * np.sin(np.deg2rad(theta_guess)) + centy_fr
     posx = r_guess * np.cos(np.deg2rad(theta_guess)) + centx_fr
-    halfw = max(aperture_radius, annulus_width/2)
+    halfw = max(aperture_radius*fwhm, annulus_width*fwhm/2)
 
     # Checking annulus/aperture sizes. Assuming square frames
     msg = 'The annulus and/or the circular aperture used by the NegFC falls '
@@ -175,11 +191,34 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
     msg += 'decreasing the annulus or aperture size'
     if r_guess > centx_fr-halfw or r_guess <= halfw:
         raise RuntimeError(msg)
-        
-    pca_res = pca_annulus(cube, angs, ncomp, annulus_width, r_guess, cube_ref,
+                          
+    if algo == pca_annulus:
+        pca_res = pca_annulus(cube, angs, ncomp, annulus_width*fwhm, r_guess, cube_ref,
                           svd_mode, scaling, imlib=imlib,
                           interpolation=interpolation, collapse=collapse)
-    indices = circle(posy, posx, radius=aperture_radius)
+    elif algo == pca_annular:
+        radius_int = int(np.floor(r_guess-annulus_width*fwhm/2))
+        # crop cube to just be larger than annulus => FASTER PCA
+        crop_sz = int(np.ceil(r_guess+annulus_width*fwhm))
+        if not crop_sz %2:
+            crop_sz+=1
+        if crop_sz < cube.shape[1] and crop_sz < cube.shape[2]:
+            pad = int((cube.shape[1]-crop_sz)/2)
+            crop_cube = cube_crop_frames(cube, crop_sz, verbose=False)
+        else:
+            crop_cube = cube
+
+        pca_res_tmp = pca_annular(crop_cube, angs, radius_int=radius_int, fwhm=fwhm, 
+                              asize=annulus_width, delta_rot=delta_rot, 
+                              ncomp=ncomp, svd_mode=svd_mode, scaling=scaling, 
+                              imlib=imlib, interpolation=interpolation,
+                              collapse=collapse, full_output=False, 
+                              verbose=False)
+        # pad again now                      
+        pca_res = np.pad(pca_res_tmp,pad,mode='constant',constant_values=0)
+        
+                                  
+    indices = circle(posy, posx, radius=aperture_radius*fwhm)
     yy, xx = indices
 
     if collapse is None:

--- a/vip_hci/negfc/simplex_optim.py
+++ b/vip_hci/negfc/simplex_optim.py
@@ -46,7 +46,7 @@ def firstguess_from_coord(planet, center, cube, angs, PLSC, psf, fwhm,
     fwhm : float
         The FHWM in pixels.           
     annulus_width: int, optional
-        The width in terms of the FWHM of the annulus on which the PCA is done.       
+        The width in pixels of the annulus on which the PCA is done.       
     aperture_radius: int, optional
         The radius of the circular aperture in terms of the FWHM.
     ncomp: int
@@ -169,7 +169,7 @@ def firstguess_simplex(p, cube, angs, psf, plsc, ncomp, fwhm, annulus_width,
     fwhm : float
         The FHWM in pixels.   
     annulus_width: int, optional
-        The width in terms of the FWHM of the annulus on which the PCA is done.       
+        The width in pixels of the annulus on which the PCA is done.       
     aperture_radius: int, optional
         The radius of the circular aperture in terms of the FWHM.
     cube_ref : numpy ndarray, 3d, optional
@@ -229,7 +229,7 @@ def firstguess_simplex(p, cube, angs, psf, plsc, ncomp, fwhm, annulus_width,
     
 
 def firstguess(cube, angs, psfn, ncomp, plsc, planets_xy_coord, fwhm=4, 
-               annulus_width=3, aperture_radius=4, cube_ref=None, 
+               annulus_width=4, aperture_radius=1, cube_ref=None, 
                svd_mode='lapack', scaling=None, fmerit='sum', imlib='opencv',
                interpolation='lanczos4', collapse='median', algo=pca_annulus,
                delta_rot=1, p_ini=None, f_range=None, simplex=True, 
@@ -268,7 +268,7 @@ def firstguess(cube, angs, psfn, ncomp, plsc, planets_xy_coord, fwhm=4,
     fwhm : float, optional
         The FHWM in pixels.
     annulus_width: int, optional
-        The width in terms of the FWHM of the annulus on which the PCA is done.       
+        The width in pixels of the annulus on which the PCA is done.       
     aperture_radius: int, optional
         The radius of the circular aperture in terms of the FWHM.
     cube_ref : numpy ndarray, 3d, optional

--- a/vip_hci/negfc/simplex_optim.py
+++ b/vip_hci/negfc/simplex_optim.py
@@ -10,7 +10,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from scipy.optimize import minimize
 from .simplex_fmerit import chisquare
-from ..pca import pca_annulus, pca_annular
+from ..pca import pca_annulus
 from ..var import frame_center
 from ..conf import time_ini, timing
 from ..conf.utils_conf import sep

--- a/vip_hci/pca/pca_fullfr.py
+++ b/vip_hci/pca/pca_fullfr.py
@@ -149,7 +149,7 @@ def pca(cube, angle_list, cube_ref=None, scale_list=None, ncomp=1,
         ``spat-mean``: spatial mean is subtracted.
 
         ``temp-standard``: temporal mean centering plus scaling pixel values
-        to unit variance.
+        to unit variance. HIGHLY RECOMMENDED FOR ASDI AND RDI CASES!
 
         ``spat-standard``: spatial mean centering plus scaling pixel values
         to unit variance.
@@ -525,10 +525,10 @@ def _adimsdi_singlepca(cube, angle_list, scale_list, ncomp, fwhm, source_xy,
     """
     z, n, y_in, x_in = cube.shape
 
-    if not scaling == 'temp-standard':
-        scaling = 'temp-standard'
-        if verbose:
-            print("Pixel-wise scaling set to `temp-standard`")
+#    if not scaling == 'temp-standard':
+#        scaling = 'temp-standard'
+#        if verbose:
+#            print("Pixel-wise scaling set to `temp-standard`")
 
     angle_list = check_pa_vector(angle_list)
     if not angle_list.shape[0] == n:
@@ -642,10 +642,10 @@ def _adimsdi_doublepca(cube, angle_list, scale_list, ncomp, scaling,
     else:
         ncomp_ifs, ncomp_adi = ncomp
 
-    if not scaling == 'temp-standard':
-        scaling = 'temp-standard'
-        if verbose:
-            print("Pixel-wise scaling set to `temp-standard`")
+#    if not scaling == 'temp-standard':
+#        scaling = 'temp-standard'
+#        if verbose:
+#            print("Pixel-wise scaling set to `temp-standard`")
 
     angle_list = check_pa_vector(angle_list)
     if not angle_list.shape[0] == n:
@@ -756,10 +756,10 @@ def _adi_rdi_pca(cube, cube_ref, angle_list, ncomp, scaling, mask_center_px,
     n, y, x = cube.shape
 
     # forcing the 'temp-standard' scaling
-    if scaling != 'temp-standard':
-        scaling = 'temp-standard'
-        if verbose:
-            print("Pixel-wise scaling set to `temp-standard`")
+#    if scaling != 'temp-standard':
+#        scaling = 'temp-standard'
+#        if verbose:
+#            print("Pixel-wise scaling set to `temp-standard`")
 
     angle_list = check_pa_vector(angle_list)
     if not isinstance(ncomp, int):

--- a/vip_hci/pca/pca_local.py
+++ b/vip_hci/pca/pca_local.py
@@ -150,7 +150,7 @@ def pca_annular(cube, angle_list, cube_ref=None, scale_list=None, radius_int=0,
         ``spat-mean``: spatial mean is subtracted.
 
         ``temp-standard``: temporal mean centering plus scaling pixel values
-        to unit variance.
+        to unit variance. HIGHLY RECOMMENDED FOR ASDI AND RDI CASES.
 
         ``spat-standard``: spatial mean centering plus scaling pixel values
         to unit variance.
@@ -376,11 +376,11 @@ def _pca_adi_rdi(cube, angle_list, radius_int=0, fwhm=4, asize=2, n_segments=1,
         delta_rot = [delta_rot] * n_annuli
 
     # forcing the 'temp-standard' scaling
-    if cube_ref is not None:
-        if not scaling == 'temp-standard':
-            scaling = 'temp-standard'
-            if verbose:
-                print("Pixel-wise scaling set to `temp-standard`")
+#    if cube_ref is not None:
+#        if not scaling == 'temp-standard':
+#            scaling = 'temp-standard'
+#            if verbose:
+#                print("Pixel-wise scaling set to `temp-standard`")
 
     if isinstance(n_segments, int):
         n_segments = [n_segments for _ in range(n_annuli)]

--- a/vip_hci/pca/utils_pca.py
+++ b/vip_hci/pca/utils_pca.py
@@ -5,7 +5,7 @@ Module with helping functions for PCA.
 """
 
 __author__ = 'Carlos Alberto Gomez Gonzalez'
-__all__ = []
+__all__ = ['pca_annulus']
 
 import numpy as np
 from sklearn.decomposition import IncrementalPCA

--- a/vip_hci/pca/utils_pca.py
+++ b/vip_hci/pca/utils_pca.py
@@ -200,7 +200,7 @@ def pca_grid(cube, angle_list, fwhm=None, range_pcs=None, source_xy=None,
 
             for i in range(n_adi):
                 frame_i = scwave(residuals_res[i*z+idx_ini:i*z+idx_fin, :, :],
-                                 scale_list[idx_ini,idx_fin], full_output=False, 
+                                 scale_list[idx_ini:idx_fin], full_output=False, 
                                  inverse=True, y_in=y_in, x_in=x_in, 
                                  collapse=collapse)
                 residuals_reshaped[i] = frame_i

--- a/vip_hci/var/shapes.py
+++ b/vip_hci/var/shapes.py
@@ -248,13 +248,15 @@ def get_square(array, size, y, x, position=False, force=False, verbose=True):
         [position=True] Coordinates of the bottom-left vertex.
 
     """
-    size_init = array.shape[0]  # assuming square frames
-
+    size_init_y = array.shape[0]
+    size_init_x = array.shape[1]
+    size_init = array.shape[0] # "force" cases assume square input frame
+    
     if array.ndim != 2:
         raise TypeError('Input array is not a 2d array.')
     if not isinstance(size, int):
         raise TypeError('`Size` must be integer')
-    if size >= size_init:  # assuming square frames
+    if size >= size_init_y and size >= size_init_x:  # assuming square frames
         msg = "`Size` is equal to or bigger than the initial frame size"
         raise ValueError(msg)
 
@@ -297,7 +299,7 @@ def get_square(array, size, y, x, position=False, force=False, verbose=True):
     x0 = int(x - wing)
     x1 = int(x + wing + 1)
 
-    if y0 < 0 or x0 < 0 or y1 > size_init or x1 > size_init:
+    if y0 < 0 or x0 < 0 or y1 > size_init_y or x1 > size_init_x:
         # assuming square frames
         raise RuntimeError('square cannot be obtained with size={}, y={}, x={}'
                            ''.format(size, y, x))


### PR DESCRIPTION
- PCA-ASDI contrast curves were not reliable due to a combination of (1) enforcing the scaling in the PCA functions and (2) the flux normalization before the contrast curve calculation not being properly taken into account due to the scaling.  This is now solved by not enforcing the scaling to be used in the PCA function and by computing noise levels in the final images obtained with and without scaling in the contrast curve function.

- Bugs related to python 2 syntaxes still present in the MCMC_smapling and nested_sampling modules are now corrected. 

- Bugs related to the way the aperture and annulus sizes are defined for NEGFC are also corrected. Now the definition is uniform throughout all NEGFC functions (simplex and MCMC), match the description, and propagates well down to the PCA function used in the the NEGFC core function. The input radius is now to be expressed in terms of FWHM, while the annulus width should be in pixels (this is for consistence with the input format of the PCA_annular function). A new option was added to be able to use PCA_annular (i.e. with a PA threshold) instead of PCA_annulus with NEGFC.

- Bad pixel correction algorithm cube_fix_badpix_isolated() is now adapted to work better, in particular to correct for cosmic rays throughout the cube. The bad pixel identification was previously based on the mean frame of the cube, hence cosmic rays were not picked up. I have now added an option to do the bpix correction frame by frame.

- Finally the get_square() function is now compatible with a rectangular input array.