### PR TITLE
Amendments to write_fits

### DIFF
--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -145,7 +145,7 @@ def verify_fits(fitsfilename):
             f.verify()
 
 
-def write_fits(fitsfilename, array, header=None, precision=np.float32,
+def write_fits(fitsfilename, array, header=None, output_verify='exception', precision=np.float32,
                verbose=True):
     """
     Write array and header into FTIS file.
@@ -160,6 +160,8 @@ def write_fits(fitsfilename, array, header=None, precision=np.float32,
         Array to be written into a fits file.
     header : numpy ndarray, optional
         Array with header.
+    output_verify : fix silentfix ignore warn exception, optional
+        Verification options
     precision : numpy dtype, optional
         Float precision, by default np.float32 or single precision float.
     verbose : bool, optional
@@ -172,10 +174,10 @@ def write_fits(fitsfilename, array, header=None, precision=np.float32,
 
     if os.path.exists(fitsfilename):
         os.remove(fitsfilename)
-        ap_fits.writeto(fitsfilename, array, header)
+        ap_fits.writeto(fitsfilename, array, header, output_verify)
         if verbose:
             print("Fits file successfully overwritten")
     else:
-        ap_fits.writeto(fitsfilename, array, header)
+        ap_fits.writeto(fitsfilename, array, header, output_verify)
         if verbose:
             print("Fits file successfully saved")

--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -145,8 +145,8 @@ def verify_fits(fitsfilename):
             f.verify()
 
 
-def write_fits(fitsfilename, array, header=None, output_verify='exception', precision=np.float32,
-               verbose=True):
+def write_fits(fitsfilename, array, header=None, output_verify='exception',
+               precision=np.float32, verbose=True):
     """
     Write array and header into FTIS file.
 
@@ -160,8 +160,10 @@ def write_fits(fitsfilename, array, header=None, output_verify='exception', prec
         Array to be written into a fits file.
     header : numpy ndarray, optional
         Array with header.
-    output_verify : fix silentfix ignore warn exception, optional
-        Verification options
+    output_verify : str, optional
+        {"fix", "silentfix", "ignore", "warn", "exception"} 
+        Verification options:
+        https://docs.astropy.org/en/stable/io/fits/api/verification.html
     precision : numpy dtype, optional
         Float precision, by default np.float32 or single precision float.
     verbose : bool, optional


### PR DESCRIPTION
write_fits now includes an argument for 'output_verify' this will give the user the choice to ignore/fix any issues with the headers of NACO data