### PR TITLE
Transformed Priors for Nested Sampling

### DIFF
--- a/vip_hci/negfc/nested_sampling.py
+++ b/vip_hci/negfc/nested_sampling.py
@@ -317,5 +317,5 @@ def nested_sampling_results(ns_object, burnin=0.4, bins=None, save=False,
 
     final_res = np.array([[mean[0], np.sqrt(cov[0, 0])],
                           [mean[1], np.sqrt(cov[1, 1])],
-                          [mean[2], np.sqrt(cov[1, 1])]])
+                          [mean[2], np.sqrt(cov[2, 2])]])
     return final_res                     

--- a/vip_hci/negfc/nested_sampling.py
+++ b/vip_hci/negfc/nested_sampling.py
@@ -202,7 +202,7 @@ def nested_negfc_sampling(init, cube, angs, plsc, psf, fwhm, annulus_width=8,
 
         fmin = init[2] - w[2]
         fmax = init[2] + w[2]
-        f = (x[2] * (np.sqrt(fmax) - np.sqrt(fmin)) + fmin)**2
+        f = (x[2] * (np.sqrt(fmax) - np.sqrt(fmin)) + np.sqrt(fmin))**2
 
         return np.array([r, t, f])
 


### PR DESCRIPTION
This PR changes the `prior_transform` from the `negfc` module's nested sampling routine to more statistically correct priors. 

Basically, it changes the prior for `r` and `f`-

## Radial Uniform prior

If we want uniform position priors (`r` and `theta`) we need to consider that the prior is _acutally_ uniform over `x` and `y`, and therefore the distribution needs to undergo a change of variables before being applied in polar coordinates. I'm happy to write out the math, but this causes the distribution for `r` to become `p(r) ~ r` (where `~` means proportional to here). It has no effect on the prior for `theta`, though.

## Poisson invariant scale prior

For the "amplitude", we might consider either a Poisson invariant scale prior or a Gaussian invariant scale prior as derivations of Jeffrey's priors for the underlying data. The Gaussian prior goes `p(f) ~ 1/f` and the Poisson prior goes `p(f) ~ 1/sqrt(f)`. For this PR I've chose the Poisson variant. Again, the derivation from the Fisher information matrix is in my notes if you want them.

I've also edited the docstring for `prior_transform` to be extra clear in what is happening.

