### PR TITLE
Problem with max distances in cube_inject_companions 

### DIFF
--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -804,7 +804,7 @@ def noise_per_annulus(array, separation, fwhm, init_rad=None, wedge=(0, 360),
 
     if init_rad is None:
         init_rad = fwhm
-
+        
     if debug:
         _, ax = plt.subplots(figsize=(6, 6))
         ax.imshow(array, origin='lower', interpolation='nearest',
@@ -817,7 +817,7 @@ def noise_per_annulus(array, separation, fwhm, init_rad=None, wedge=(0, 360),
         yy += centery
         xx += centerx
 
-        apertures = photutils.CircularAperture((xx, yy), fwhm/2)
+        apertures = photutils.CircularAperture(np.array((xx, yy)).T, fwhm/2)
         fluxes = photutils.aperture_photometry(array, apertures)
         fluxes = np.array(fluxes['aperture_sum'])
 

--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -744,6 +744,9 @@ def noise_per_annulus(array, separation, fwhm, init_rad=None, wedge=(0, 360),
                       verbose=False, debug=False):
     """ Measures the noise as the standard deviation of apertures defined in
     each annulus with a given separation.
+    
+    The annuli start at init_rad (== fwhm by default) and stop 2*separation
+    before the edge of the frame.
 
     Parameters
     ----------
@@ -799,7 +802,7 @@ def noise_per_annulus(array, separation, fwhm, init_rad=None, wedge=(0, 360),
 
     init_angle, fin_angle = wedge
     centery, centerx = frame_center(array)
-    n_annuli = int(np.floor((centery - init_rad)/separation))
+    n_annuli = int(np.floor((centery - init_rad)/separation)) - 1
     noise = []
     vector_radd = []
     if verbose:

--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -794,17 +794,17 @@ def noise_per_annulus(array, separation, fwhm, init_rad=None, wedge=(0, 360),
         raise TypeError('Wedge must be a tuple with the initial and final '
                         'angles')
 
+    if init_rad is None:
+        init_rad = fwhm
+
     init_angle, fin_angle = wedge
     centery, centerx = frame_center(array)
-    n_annuli = int(np.floor((centery)/separation)) - 1
+    n_annuli = int(np.floor((centery - init_rad)/separation))
     noise = []
     vector_radd = []
     if verbose:
         print('{} annuli'.format(n_annuli))
 
-    if init_rad is None:
-        init_rad = fwhm
-        
     if debug:
         _, ax = plt.subplots(figsize=(6, 6))
         ax.imshow(array, origin='lower', interpolation='nearest',

--- a/vip_hci/metrics/fakecomp.py
+++ b/vip_hci/metrics/fakecomp.py
@@ -87,7 +87,7 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
     if array.ndim == 3:
         ceny, cenx = frame_center(array[0])
 
-        if not rad_dists[-1] < min(ceny, cenx) - 5:
+        if not rad_dists[-1] < array[0].shape[0] / 2:
             raise ValueError('rad_dists last location is at the border (or '
                              'outside) of the field')
         size_fc = psf_template.shape[0]
@@ -138,7 +138,7 @@ def cube_inject_companions(array, psf_template, angle_list, flevel, plsc,
     if array.ndim == 4 and psf_template.ndim == 3:
         ceny, cenx = frame_center(array[0, 0])
 
-        if not rad_dists[-1] < min(ceny, cenx) - 5:
+        if not rad_dists[-1] < array[0].shape[0] / 2:
             raise ValueError('rad_dists last location is at the border (or '
                              'outside) of the field')
 


### PR DESCRIPTION
See #429 for previous discussion.
It turns out that only modifying `noise_per_annulus` is required to makes sure we are not too close from the edge of a frames, where "too close" is here 2*separation and the given separation is `fwhm_med` in `throughput`.

As commented in the function: The annuli start at init_rad (== fwhm by default) and stop 2 x separation before the edge of the frame.
Factor 2*sep is ensured by the -1 line 805 and by the range() function in the for-loop.