### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,10 +37,15 @@ def resource(*args):
 
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
 reqs = parse_requirements(resource('requirements.txt'), session=False)
-reqs = [str(ir.req) for ir in reqs]
+try:
+    reqs = [str(ir.req) for ir in reqs]
+except:
+    reqs = [str(ir.requirement) for ir in reqs]
 reqs_dev = parse_requirements(resource('requirements-dev.txt'), session=False)
-reqs_dev = [str(ir.req) for ir in reqs_dev]
-
+try:
+    reqs_dev = [str(ir.req) for ir in reqs_dev]
+except:
+    reqs_dev = [str(ir.requirement) for ir in reqs_dev]    
 
 with open(resource('README.rst')) as readme_file:
     README = readme_file.read()


### PR DESCRIPTION
Update to make it compatible with the latest pip release (>=20.1.1) which generates an error while installing vip_hci:

The command python setup.py develop
returned the following error:

Traceback (most recent call last):
  File "setup.py", line 40, in <module>
    reqs = [str(ir.req) for ir in reqs]
  File "setup.py", line 40, in <listcomp>
    reqs = [str(ir.req) for ir in reqs]
AttributeError: 'ParsedRequirement' object has no attribute 'req'

The 'ParsedRequirement' object has now an attribute called requirement. The proposed change is retro-compatible.