### PR TITLE
Major VIP update to v1.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -205,17 +205,17 @@ and/or updates).
 
 Attribution
 -----------
-Please cite `Gomez Gonzalez et al. (2017) <https://ui.adsabs.harvard.edu/abs/2017AJ....154....7G/abstract>`_whenever 
-you publish data reduced with ``VIP``. Astrophysics Source Code Library reference [ascl:1603.003].
+Please cite `Gomez Gonzalez et al. (2017) <https://ui.adsabs.harvard.edu/abs/2017AJ....154....7G/abstract>`_ whenever 
+you publish data reduced with ``VIP`` . Astrophysics Source Code Library reference [ascl:1603.003].
 In addition, if you use one of the following modules, please also cite:
 
 - andromeda: `Cantalloube et al. (2015) <https://ui.adsabs.harvard.edu/abs/2015A%26A...582A..89C/abstract>`_;
 - leastsq: `Lafrenière et al. (2007) <https://ui.adsabs.harvard.edu/abs/2007ApJ...660..770L/abstract>`_;
 - llsg: `Gomez Gonzalez et al. (2016) <https://ui.adsabs.harvard.edu/abs/2016A%26A...589A..54G/abstract>`_;
-- medsub: `Marois et al. (2006) <https://ui.adsabs.harvard.edu/abs/2006ApJ...641..556M/abstract>`_for
- ADI and `Sparks and Ford (2002) <https://ui.adsabs.harvard.edu/abs/2002ApJ...578..543S/abstract>`_for SDI;
+- medsub: `Marois et al. (2006) <https://ui.adsabs.harvard.edu/abs/2006ApJ...641..556M/abstract>`_ for
+ ADI and `Sparks and Ford (2002) <https://ui.adsabs.harvard.edu/abs/2002ApJ...578..543S/abstract>`_ for SDI;
 - negfc: `Wertz et al. (2017) <https://ui.adsabs.harvard.edu/abs/2017A%26A...598A..83W/abstract>`_;
 - nmf: `Ren et al. (2018) <https://ui.adsabs.harvard.edu/abs/2018ApJ...852..104R/abstract>`_;
-- pca: `Amara and Quanz (2012) <https://ui.adsabs.harvard.edu/abs/2012MNRAS.427..948A/abstract>`_and
+- pca: `Amara and Quanz (2012) <https://ui.adsabs.harvard.edu/abs/2012MNRAS.427..948A/abstract>`_ and
  `Soummer et al. (2012) <https://ui.adsabs.harvard.edu/abs/2012ApJ...755L..28S/abstract>`_;
 - specfit: `Christiaens et al. (2021) <https://ui.adsabs.harvard.edu/abs/2021arXiv210210288C/abstract>`_;

--- a/README.rst
+++ b/README.rst
@@ -212,10 +212,8 @@ In addition, if you use one of the following modules, please also cite:
 - andromeda: `Cantalloube et al. (2015) <https://ui.adsabs.harvard.edu/abs/2015A%26A...582A..89C/abstract>`_;
 - leastsq: `Lafrenière et al. (2007) <https://ui.adsabs.harvard.edu/abs/2007ApJ...660..770L/abstract>`_;
 - llsg: `Gomez Gonzalez et al. (2016) <https://ui.adsabs.harvard.edu/abs/2016A%26A...589A..54G/abstract>`_;
-- medsub: `Marois et al. (2006) <https://ui.adsabs.harvard.edu/abs/2006ApJ...641..556M/abstract>`_ for
- ADI and `Sparks and Ford (2002) <https://ui.adsabs.harvard.edu/abs/2002ApJ...578..543S/abstract>`_ for SDI;
+- medsub: `Marois et al. (2006) <https://ui.adsabs.harvard.edu/abs/2006ApJ...641..556M/abstract>`_ for ADI and `Sparks and Ford (2002) <https://ui.adsabs.harvard.edu/abs/2002ApJ...578..543S/abstract>`_ for SDI;
 - negfc: `Wertz et al. (2017) <https://ui.adsabs.harvard.edu/abs/2017A%26A...598A..83W/abstract>`_;
 - nmf: `Ren et al. (2018) <https://ui.adsabs.harvard.edu/abs/2018ApJ...852..104R/abstract>`_;
-- pca: `Amara and Quanz (2012) <https://ui.adsabs.harvard.edu/abs/2012MNRAS.427..948A/abstract>`_ and
- `Soummer et al. (2012) <https://ui.adsabs.harvard.edu/abs/2012ApJ...755L..28S/abstract>`_;
+- pca: `Amara and Quanz (2012) <https://ui.adsabs.harvard.edu/abs/2012MNRAS.427..948A/abstract>`_ and `Soummer et al. (2012) <https://ui.adsabs.harvard.edu/abs/2012ApJ...755L..28S/abstract>`_;
 - specfit: `Christiaens et al. (2021) <https://ui.adsabs.harvard.edu/abs/2021arXiv210210288C/abstract>`_;

--- a/README.rst
+++ b/README.rst
@@ -56,9 +56,11 @@ open source code distribution, using Git as a version control system.
 
 ``VIP`` started as the effort of `Carlos Alberto Gomez Gonzalez <https://carlgogo.github.io/>`_,
 a former PhD student of the `VORTEX team <http://www.vortex.ulg.ac.be/>`_
-(ULiege, Belgium). ``VIP``'s development is led by Dr. Gomez with contributions
-made by collaborators from several teams (take a look at the `contributors tab <https://github.com/vortex-exoplanet/VIP/graphs/contributors>`_ on
-``VIP``'s GitHub repository). Most of ``VIP``'s functionalities are mature but
+(ULiege, Belgium). ``VIP``'s development has been led by Dr. Gomez with contributions
+made by collaborators from several teams (take a look at the 
+`contributors tab <https://github.com/vortex-exoplanet/VIP/graphs/contributors>`_ on
+``VIP``'s GitHub repository). It is now maintained by Dr. Valentin Christiaens.
+Most of ``VIP``'s functionalities are mature but
 it doesn't mean it's free from bugs. The code is continuously evolving and
 therefore feedback/contributions are greatly appreciated. If you want to report
 a bug or suggest a functionality please create an issue on GitHub. Pull
@@ -72,8 +74,14 @@ The documentation for ``VIP`` can be found here: http://vip.readthedocs.io.
 
 Jupyter notebook tutorial
 -------------------------
-Tutorials, in the form of Jupyter notebooks, showcasing ``VIP``'s usage and other resources such as test/dummy datasets are available on the ``VIP-extras`` `repository <https://github.com/carlgogo/VIP_extras>`_. Alternatively, you can execute this repository on `Binder <https://mybinder.org/v2/gh/carlgogo/VIP_extras/master>`_. The notebook for ADI processing can be visualized online with
-`nbviewer <http://nbviewer.jupyter.org/github/carlgogo/VIP_extras/blob/master/tutorials/01_adi_pre-postproc_fluxpos_ccs.ipynb>`_. If you are new to the Jupyter notebook application check out the `beginner's guide
+Tutorials, in the form of Jupyter notebooks, showcasing ``VIP``'s usage and 
+other resources such as test/dummy datasets are available on the 
+``VIP-extras`` `repository <https://github.com/carlgogo/VIP_extras>`_. 
+Alternatively, you can execute this repository on 
+`Binder <https://mybinder.org/v2/gh/carlgogo/VIP_extras/master>`_. The notebook 
+for ADI processing can be visualized online with
+`nbviewer <http://nbviewer.jupyter.org/github/carlgogo/VIP_extras/blob/master/tutorials/01_adi_pre-postproc_fluxpos_ccs.ipynb>`_. 
+If you are new to the Jupyter notebook application check out the `beginner's guide
 <https://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/what_is_jupyter.html>`_.
 
 
@@ -90,7 +98,8 @@ The benefits of using a Python package manager (distribution), such as
 (ana)conda or Canopy, are many. Mainly, it brings easy and robust package
 management and avoids messing up with your system's default python. An
 alternative is to use package managers like apt-get for Ubuntu or
-Homebrew/MacPorts/Fink for macOS. I personally recommend using `Miniconda <https://conda.io/miniconda>`_.
+Homebrew/MacPorts/Fink for macOS. We recommend using 
+`Miniconda <https://conda.io/miniconda>`_.
 
 ``VIP`` depends on existing packages from the Python ecosystem, such as
 ``numpy``, ``scipy``, ``matplotlib``, ``pandas``, ``astropy``, ``scikit-learn``,
@@ -130,6 +139,7 @@ root folder and run:
 
   $ python setup.py install
 
+
 Using Git
 ^^^^^^^^^
 If you want to benefit from the ``git`` functionalities, you need to clone the
@@ -143,19 +153,10 @@ Then you can install the package by following the previous steps, using the
 setup.py file. Creating a fork with GitHub is recommended to developers or to
 users who want to experiment with the code.
 
-Other dependencies
-^^^^^^^^^^^^^^^^^^
-``OpenCV`` (Open source Computer Vision) provides fast C++ image processing
-operations and is used by ``VIP`` for basic image transformations. If you don't
-have/want the ``OpenCV`` python bindings (``OpenCV`` is optional since ``VIP``
-v0.5.2), ``VIP`` will use the much slower ``ndimage``/``scikit-image`` libraries
-transparently. Fortunately, installing ``OpenCV`` library is nowadays and easy
-process that is done automatically with the ``VIP`` installation. Alternatively,
-you could use ``conda``:
-
-.. code-block:: bash
-
-  $ conda install opencv
+Optional dependencies
+^^^^^^^^^^^^^^^^^^^^^
+The following dependencies are are not automatically installed upon installation
+of ``VIP`` but may significantly improve your experience:
 
 ``VIP`` contains a class ``vip_hci.fits.ds9`` that enables, through ``pyds9``,
 the interaction with a DS9 window (displaying numpy arrays, controlling the
@@ -166,7 +167,7 @@ installed from the latest development version:
 
     $ pip install git+git://github.com/ericmandel/pyds9.git#egg=pyds9
 
-Also, you can install the Intel Math Kernel Library (MKL) optimizations
+Also, you can install the Intel Math Kernel Library (``mkl``) optimizations
 (provided that you have a recent version of ``conda``) or ``openblas``
 libraries. Either of them can be installed with ``conda install``. This is
 recommended along with ``OpenCV`` for maximum speed on ``VIP`` computations.
@@ -175,6 +176,12 @@ recommended along with ``OpenCV`` for maximum speed on ``VIP`` computations.
 (starting from version 0.8.0) or ``PyTorch`` (from version 0.9.2). These remain
 as optional requirements, to be installed by the user, as well as a proper CUDA
 environment (and a decent GPU card).
+
+Finally, bad pixel correction routines can be optimised with ``Numba``, which 
+converts some Python code, particularly ``NumPy``, into fast machine code. A 
+factor up to ~50x times speed improvement can be obtained on large images 
+compared to NumPy. Numba can be installed with ``conda install numba``.
+
 
 Loading VIP
 ^^^^^^^^^^^
@@ -198,7 +205,17 @@ and/or updates).
 
 Attribution
 -----------
-Please cite Gomez Gonzalez et al. 2017 (http://iopscience.iop.org/article/10.3847/1538-3881/aa73d7/)
-whenever you publish data reduced with ``VIP``. Astrophysics Source Code Library
-reference [ascl:1603.003].
+Please cite `Gomez Gonzalez et al. (2017) <https://ui.adsabs.harvard.edu/abs/2017AJ....154....7G/abstract>`_whenever 
+you publish data reduced with ``VIP``. Astrophysics Source Code Library reference [ascl:1603.003].
+In addition, if you use one of the following modules, please also cite:
 
+- andromeda: `Cantalloube et al. (2015) <https://ui.adsabs.harvard.edu/abs/2015A%26A...582A..89C/abstract>`_;
+- leastsq: `Lafrenière et al. (2007) <https://ui.adsabs.harvard.edu/abs/2007ApJ...660..770L/abstract>`_;
+- llsg: `Gomez Gonzalez et al. (2016) <https://ui.adsabs.harvard.edu/abs/2016A%26A...589A..54G/abstract>`_;
+- medsub: `Marois et al. (2006) <https://ui.adsabs.harvard.edu/abs/2006ApJ...641..556M/abstract>`_for
+ ADI and `Sparks and Ford (2002) <https://ui.adsabs.harvard.edu/abs/2002ApJ...578..543S/abstract>`_for SDI;
+- negfc: `Wertz et al. (2017) <https://ui.adsabs.harvard.edu/abs/2017A%26A...598A..83W/abstract>`_;
+- nmf: `Ren et al. (2018) <https://ui.adsabs.harvard.edu/abs/2018ApJ...852..104R/abstract>`_;
+- pca: `Amara and Quanz (2012) <https://ui.adsabs.harvard.edu/abs/2012MNRAS.427..948A/abstract>`_and
+ `Soummer et al. (2012) <https://ui.adsabs.harvard.edu/abs/2012ApJ...755L..28S/abstract>`_;
+- specfit: `Christiaens et al. (2021) <https://ui.adsabs.harvard.edu/abs/2021arXiv210210288C/abstract>`_;

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,7 @@ PACKAGES = ['vip_hci',
             'vip_hci.nmf',
             'vip_hci.pca',
             'vip_hci.preproc',
+            'vip_hci.specfit',
             'vip_hci.stats',
             'vip_hci.var']
 

--- a/tests/test_hcidataset.py
+++ b/tests/test_hcidataset.py
@@ -27,7 +27,7 @@ def test_saveable_dataset():
     ds.save(fn)
 
     # restore
-    ds2 = Dataset.load(fn)
+    ds2 = Dataset.load(fn, allow_pickle=True)
 
     # compare
     aarc(ds2.cube, cube)

--- a/tests/test_preproc_recentering.py
+++ b/tests/test_preproc_recentering.py
@@ -111,8 +111,11 @@ def do_recenter(method, cube, shiftx, shifty, errormsg, mse=1e-2,
             ", ".join("{}={}".format(k, v) for k, v in kwargs.items())))
 
     #===== recentering
-    recentered_cube, unshifty, unshiftx = method(shifted_cube, debug=debug,
-                                                 **kwargs)
+    rec_res = method(shifted_cube, debug=debug, **kwargs)
+    
+    recentered_cube= rec_res[0]
+    unshifty= rec_res[1]
+    unshiftx= rec_res[2]
 
     if debug:
         vip.var.pp_subplots(cube, title="input cube")
@@ -134,7 +137,7 @@ def do_recenter(method, cube, shiftx, shifty, errormsg, mse=1e-2,
     if debug:
         try:
             import pandas as pd
-            from IPython.display import display, HTML
+            from IPython.display import display
             p = pd.DataFrame(np.array([
                 shiftx,
                 -unshiftx,

--- a/vip_hci/__init__.py
+++ b/vip_hci/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.9.11"
+__version__ = "1.0.0"
 
 from . import andromeda
 from . import preproc
@@ -12,6 +12,7 @@ from . import negfc
 from . import nmf
 from . import pca
 from . import metrics
+from . import specfit
 from . import stats
 from . import var
 from .hci_dataset import *

--- a/vip_hci/andromeda/andromeda.py
+++ b/vip_hci/andromeda/andromeda.py
@@ -38,11 +38,9 @@ global CUBE
 
 def andromeda(cube, oversampling_fact, angles, psf, filtering_fraction=.25,
               min_sep=.5, annuli_width=1., roa=2, opt_method='lsq',
-              nsmooth_snr=18, iwa=None, owa=None, precision=50,
-              fast=False,
+              nsmooth_snr=18, iwa=None, owa=None, precision=50, fast=False, 
               homogeneous_variance=True, ditimg=1.0, ditpsf=None, tnd=1.0,
-              total=False,
-              multiply_gamma=True, nproc=1, verbose=False):
+              total=False, multiply_gamma=True, nproc=1, verbose=False):
     """
     Exoplanet detection in ADI sequences by maximum-likelihood approach.
 

--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -19,7 +19,8 @@ from astropy.io import fits as ap_fits
 
 
 def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
-              precision=np.float32, return_memmap=False, verbose=True):
+              precision=np.float32, return_memmap=False, verbose=True, 
+              **kwargs):
     """
     Load a fits file into a memory as numpy array.
 
@@ -36,14 +37,17 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
     ignore_missing_end : bool optional
         Allows to open fits files with a header missing END card.
     return_memmap : bool, optional
-        If True, the functinor returns the handle to the FITS file opened by
+        If True, the function returns the handle to the FITS file opened by
         mmap. With the hdulist, array data of each HDU to be accessed with mmap,
         rather than being read into memory all at once. This is particularly
         useful for working with very large arrays that cannot fit entirely into
         physical memory.
     verbose : bool, optional
         If True prints message of completion.
-
+    **kwargs: optional
+        Optional arguments to the astropy.io.fits.open() function. E.g. 
+        "output_verify" can be set to ignore, in case of non-standard header.
+        
     Returns
     -------
     hdulist : hdulist
@@ -59,7 +63,7 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
         fitsfilename += '.fits'
 
     hdulist = ap_fits.open(fitsfilename, ignore_missing_end=ignore_missing_end,
-                           memmap=True)
+                           memmap=True, **kwargs)
 
     if return_memmap:
         return hdulist[n]
@@ -112,7 +116,7 @@ def byteswap_array(array):
     return array_out
 
 
-def info_fits(fitsfilename):
+def info_fits(fitsfilename, **kwargs):
     """
     Print the information about a fits file.
 
@@ -120,9 +124,12 @@ def info_fits(fitsfilename):
     ----------
     fitsfilename : str
         Path to the fits file.
-
+    **kwargs: optional
+        Optional arguments to the astropy.io.fits.open() function. E.g. 
+        "output_verify" can be set to ignore, in case of non-standard header.
+        
     """
-    with ap_fits.open(fitsfilename, memmap=True) as hdulist:
+    with ap_fits.open(fitsfilename, memmap=True, **kwargs) as hdulist:
         hdulist.info()
 
 

--- a/vip_hci/leastsq/leastsq.py
+++ b/vip_hci/leastsq/leastsq.py
@@ -25,7 +25,7 @@ from ..conf.utils_conf import pool_map, iterable, Progressbar
 def xloci(cube, angle_list, scale_list=None, fwhm=4, metric='manhattan',
           dist_threshold=100, delta_rot=(0.1, 1), delta_sep=(0.1, 1),
           radius_int=0, asize=4, n_segments=4, nproc=1, solver='lstsq',
-          tol=1e-3, optim_scale_fact=2, adimsdi='skipadi', imlib='opencv',
+          tol=1e-2, optim_scale_fact=2, adimsdi='skipadi', imlib='opencv',
           interpolation='lanczos4', collapse='median', verbose=True,
           full_output=False):
     """ LOCI style algorithm that models a PSF (for ADI and ADI+mSDI) with a
@@ -48,7 +48,7 @@ def xloci(cube, angle_list, scale_list=None, fwhm=4, metric='manhattan',
         documentation).
     dist_threshold : int, optional
         Indices with a distance larger than ``dist_threshold`` percentile will
-        initially discarded. 90 by default.
+        initially discarded. 100 by default.
     delta_rot : float or tuple of floats, optional
         Factor for adjusting the parallactic angle threshold, expressed in
         FWHM. Default is 1 (excludes 1 FHWM on each side of the considered
@@ -237,7 +237,7 @@ def xloci(cube, angle_list, scale_list=None, fwhm=4, metric='manhattan',
 
 def _leastsq_adi(cube, angle_list, fwhm=4, metric='manhattan',
                  dist_threshold=50, delta_rot=0.5, radius_int=0, asize=4,
-                 n_segments=4, nproc=1, solver='lstsq', tol=1e-3,
+                 n_segments=4, nproc=1, solver='lstsq', tol=1e-2,
                  optim_scale_fact=1, imlib='opencv', interpolation='lanczos4',
                  collapse='median', verbose=True, full_output=False):
     """ Least-squares model PSF subtraction for ADI.
@@ -296,7 +296,7 @@ def _leastsq_adi(cube, angle_list, fwhm=4, metric='manhattan',
 
         # store segment data for multiprocessing
         ayxyx += [(ann, indices[nseg][0], indices[nseg][1],
-                   ind_opt[nseg][0], ind_opt[nseg][0]) for nseg in
+                   ind_opt[nseg][0], ind_opt[nseg][1]) for nseg in
                   range(n_segments_ann)]
 
         pa_thresholds.append(pa_threshold)

--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -183,7 +183,7 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
                             **algo_dict)
     vector_radd = res_throug[3]
     if res_throug[0].shape[0] > 1:
-        thruput_mean = np.mean(res_throug[0], axis=0)
+        thruput_mean = np.nanmean(res_throug[0], axis=0)
     else:
         thruput_mean = res_throug[0][0]
     frame_fc_all = res_throug[4]

--- a/vip_hci/metrics/detection.py
+++ b/vip_hci/metrics/detection.py
@@ -4,9 +4,10 @@
 Module with detection algorithms.
 """
 
-__author__ = 'Carlos Alberto Gomez Gonzalez'
+__author__ = 'Carlos Alberto Gomez Gonzalez, Valentin Christiaens'
 __all__ = ['detection',
            'mask_source_centers',
+           'mask_sources',
            'peak_coordinates']
 
 import numpy as np
@@ -19,7 +20,7 @@ from astropy.stats import gaussian_fwhm_to_sigma, gaussian_sigma_to_fwhm
 from astropy.modeling import models, fitting
 from skimage.feature import peak_local_max
 from ..var import (mask_circle, get_square, frame_center, fit_2dgaussian,
-                   frame_filter_lowpass)
+                   frame_filter_lowpass, dist_matrix)
 from ..conf.utils_conf import sep
 from .snr_source import snr, snrmap, frame_report
 
@@ -395,7 +396,7 @@ def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
         used as the standard deviation for Gaussian kernel of the Gaussian
         filtering. Can be a 1d array if obj_tmp is a 3D cube.
     approx_peak: 2 components list or array, opt
-        Gives the approximate coordinates of the peak.
+        Gives the approximate yx coordinates of the peak.
     search_box: float or 2 components list or array, opt
         Gives the half-size in pixels of a box in which the peak is searched,
         around approx_peak. If float, it is assumed the same box size is wanted
@@ -403,7 +404,7 @@ def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
         approx_peak is provided.
     channels_peak: bool, {False, True}, opt
         Whether returns the indices of the peak in each channel in addition to
-        the global indices of the peak in the cube. If True, it would hence also
+        the global indices of the peak in the cube. If True, it would hence
         return two 1d-arrays. (note: only available if the input is a 3d cube)
 
     Returns
@@ -434,12 +435,13 @@ def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
             sbox = np.zeros([n_z,2*sbox_y+1,2*sbox_x+1])
 
     if ndims == 2:
-        gauss_filt_tmp = frame_filter_lowpass(obj_tmp, 'gauss', fwhm_size=fwhm)
+        med_filt_tmp = frame_filter_lowpass(obj_tmp, 'median', 
+                                            median_size=int(fwhm))
         if approx_peak is None:
-            ind_max = np.unravel_index(gauss_filt_tmp.argmax(),
-                                       gauss_filt_tmp.shape)
+            ind_max = np.unravel_index(med_filt_tmp.argmax(),
+                                       med_filt_tmp.shape)
         else:
-            sbox = gauss_filt_tmp[approx_peak[0]-sbox_y:approx_peak[0]+sbox_y+1,
+            sbox = med_filt_tmp[approx_peak[0]-sbox_y:approx_peak[0]+sbox_y+1,
                                   approx_peak[1]-sbox_x:approx_peak[1]+sbox_x+1]
             ind_max_sbox = np.unravel_index(sbox.argmax(), sbox.shape)
             ind_max = (approx_peak[0]-sbox_y+ind_max_sbox[0],
@@ -449,19 +451,19 @@ def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
 
     if ndims == 3:
         n_z = obj_tmp.shape[0]
-        gauss_filt_tmp = np.zeros_like(obj_tmp)
+        med_filt_tmp = np.zeros_like(obj_tmp)
         ind_ch_max = np.zeros([n_z,2])
         if isinstance(fwhm, float) or isinstance(fwhm, int):
             fwhm = [fwhm]*n_z
 
         for zz in range(n_z):
-            gauss_filt_tmp[zz] = frame_filter_lowpass(obj_tmp[zz], 'gauss',
-                                                      fwhm_size=fwhm[zz])
+            med_filt_tmp[zz] = frame_filter_lowpass(obj_tmp[zz], 'median', 
+                                                    median_size=int(fwhm[zz]))
             if approx_peak is None:
-                ind_ch_max[zz] = np.unravel_index(gauss_filt_tmp[zz].argmax(),
-                                                  gauss_filt_tmp[zz].shape)
+                ind_ch_max[zz] = np.unravel_index(med_filt_tmp[zz].argmax(),
+                                                  med_filt_tmp[zz].shape)
             else:
-                sbox[zz] = gauss_filt_tmp[zz, approx_peak[0]-sbox_y:\
+                sbox[zz] = med_filt_tmp[zz, approx_peak[0]-sbox_y:\
                                           approx_peak[0]+sbox_y+1,
                                           approx_peak[1]-sbox_x:\
                                           approx_peak[1]+sbox_x+1]
@@ -471,8 +473,8 @@ def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
                                   approx_peak[1]-sbox_x+ind_max_sbox[1])
 
         if approx_peak is None:
-            ind_max = np.unravel_index(gauss_filt_tmp.argmax(),
-                                       gauss_filt_tmp.shape)
+            ind_max = np.unravel_index(med_filt_tmp.argmax(),
+                                       med_filt_tmp.shape)
         else:
             ind_max_tmp = np.unravel_index(sbox.argmax(),
                                            sbox.shape)
@@ -485,9 +487,11 @@ def peak_coordinates(obj_tmp, fwhm, approx_peak=None, search_box=None,
             return ind_max
 
 
-def mask_source_centers(array, fwhm, y, x):
+def mask_source_centers(array, fwhm, y=None, x=None):
     """ Creates a mask of ones with the size of the input frame and zeros at
     the center of the sources (planets) with coordinates x, y.
+    If y and x are not provided, the sources will be found automatically using
+    'detection()' ('log' mode).
 
     Parameters
     ----------
@@ -495,7 +499,7 @@ def mask_source_centers(array, fwhm, y, x):
         Input frame.
     fwhm : float
         Size in pixels of the FWHM.
-    y, x : tuples of int
+    y, x : tuples of int (optional)
         Coordinates of the center of the sources.
 
     Returns
@@ -508,7 +512,7 @@ def mask_source_centers(array, fwhm, y, x):
         raise TypeError('Wrong input array shape.')
 
     frame = array.copy()
-    if not y and x:
+    if y is None or x is None:
         frame = mask_circle(frame, radius=2*fwhm)
         yy, xx = detection(frame, fwhm, plot=False, mode='log')
     else:
@@ -520,3 +524,40 @@ def mask_source_centers(array, fwhm, y, x):
     return mask
 
 
+
+def mask_sources(mask, ap_rad):
+    """ Given an input mask with zeros only at the *center* of source locations
+    (ones elsewhere), returns a mask with zeros within a radius ap_rad of all 
+    sources.
+
+    Parameters
+    ----------
+    mask : numpy ndarray
+        Input mask with zeros at sources center. Mask has to be square.
+    ap_rad : float
+        Size in pixels of the apertures that should be filled with zeros 
+        around each source in the mask.
+
+    Returns
+    -------
+    mask_out : numpy ndarray
+        Output mask frame.
+
+    """
+    if mask.ndim != 2:
+        raise TypeError('Wrong input array shape.')
+    mask[np.where(mask>1)] = 1
+
+    ny, nx = mask.shape
+    n_s = int(ny*nx - np.sum(mask))
+    mask_out = np.ones([ny,nx])
+    
+    if n_s == 0:
+        return mask_out
+    else:
+        s_coords = np.where(mask==0)
+        for s in range(n_s):
+            rad_arr = dist_matrix(ny, cx=s_coords[1][s], cy=s_coords[0][s]) 
+            mask_out[np.where(rad_arr<ap_rad)] = 0
+
+        return mask_out

--- a/vip_hci/metrics/snr_source.py
+++ b/vip_hci/metrics/snr_source.py
@@ -6,7 +6,7 @@ We strongly recommend users to read Mawet et al. (2014) before using routines
 of this module: https://ui.adsabs.harvard.edu/abs/2014ApJ...792...97M/abstract
 """
 
-__author__ = 'Carlos Alberto Gomez Gonzalez, O. Absil @ ULg'
+__author__ = 'Carlos Alberto Gomez Gonzalez, O. Absil @ ULg, V. Christiaens'
 __all__ = ['snr',
            'snrmap',
            'significance',
@@ -27,7 +27,8 @@ from ..var import get_annulus_segments, frame_center, dist
 
 
 def snrmap(array, fwhm, approximated=False, plot=False, known_sources=None,
-           nproc=None, array2=None, use2alone=False, verbose=True, **kwargs):
+           nproc=None, array2=None, use2alone=False, 
+           exclude_negative_lobes=False, verbose=True, **kwargs):
     """Parallel implementation of the S/N map generation function. Applies the
     S/N function (small samples penalty) at each pixel.
     
@@ -116,7 +117,7 @@ def snrmap(array, fwhm, approximated=False, plot=False, known_sources=None,
         # computing s/n map with Mawet+14 definition
         else:
             res = pool_map(nproc, snr, array, iterable(coords), fwhm, True,
-                           array2, use2alone)
+                           array2, use2alone, exclude_negative_lobes)
             res = np.array(res)
             yy = res[:, 0]
             xx = res[:, 1]
@@ -169,7 +170,8 @@ def snrmap(array, fwhm, approximated=False, plot=False, known_sources=None,
             coor_ann = [(x, y) for (x, y) in zip(annx, anny) if (x, y) not in
                         zip(cirx, ciry)]
             res = pool_map(nproc, snr, arr_masked_sources, iterable(coor_ann),
-                           fwhm, True, array2, use2alone)
+                           fwhm, True, array2, use2alone, 
+                           exclude_negative_lobes)
             res = np.array(res)
             yy_res = res[:, 0]
             xx_res = res[:, 1]
@@ -180,7 +182,7 @@ def snrmap(array, fwhm, approximated=False, plot=False, known_sources=None,
         # S/Ns of the rest of the frame without the annulus
         coor_rest = [(x, y) for (x, y) in zip(xx, yy) if (x, y) not in coor_ann]
         res = pool_map(nproc, snr, array, iterable(coor_rest), fwhm, True,
-                       array2, use2alone)
+                       array2, use2alone, exclude_negative_lobes)
         res = np.array(res)
         yy_res = res[:, 0]
         xx_res = res[:, 1]

--- a/vip_hci/metrics/stim.py
+++ b/vip_hci/metrics/stim.py
@@ -10,7 +10,7 @@ Implementation of the STIM map from [PAI18]
 
 
 import numpy as np
-import vip_hci as vip
+from ..preproc import cube_derotate
 from ..var import get_circle
 
 
@@ -55,10 +55,6 @@ def compute_inverse_stim_map(cube, angle_list):
         Inverse STIM detection map.
     """
     t, n, _ = cube.shape
-    cube_inv_der = vip.preproc.cube_derotate(cube, -angle_list)
+    cube_inv_der = cube_derotate(cube, -angle_list)
     inverse_stim_map = compute_stim_map(cube_inv_der)
     return inverse_stim_map
-
-
-
-

--- a/vip_hci/negfc/__init__.py
+++ b/vip_hci/negfc/__init__.py
@@ -25,4 +25,6 @@ from .simplex_fmerit import *
 from .mcmc_sampling import *
 from .nested_sampling import *
 from .simplex_optim import *
+from .speckle_noise import *
+from .utils_mcmc import *
 from .utils_negfc import *

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -5,13 +5,12 @@ Module with the MCMC (``emcee``) sampling for NEGFC parameter estimation.
 """
 
 
-__author__ = 'O. Wertz, Carlos Alberto Gomez Gonzalez'
+__author__ = 'O. Wertz, Carlos Alberto Gomez Gonzalez, V. Christiaens'
 __all__ = ['mcmc_negfc_sampling',
            'chain_zero_truncated',
            'show_corner_plot',
            'show_walk_plot',
            'confidence']
-
 import numpy as np
 import os
 import emcee
@@ -20,15 +19,17 @@ import datetime
 import corner
 from matplotlib import pyplot as plt
 from matplotlib.ticker import MaxNLocator
+import pickle
 from scipy.stats import norm
 from ..metrics import cube_inject_companions
 from ..conf import time_ini, timing
 from ..conf.utils_conf import sep
 from ..pca import pca_annulus
-from .simplex_fmerit import get_values_optimize
+from .simplex_fmerit import get_values_optimize, get_mu_and_sigma
+from .utils_mcmc import gelman_rubin, autocorr_test
 import warnings
 warnings.filterwarnings("ignore", category=DeprecationWarning)
-
+from ..fits import write_fits
 
 def lnprior(param, bounds):
     """ Define the prior log-function.
@@ -69,8 +70,9 @@ def lnprior(param, bounds):
 def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
            ncomp, aperture_radius, initial_state, cube_ref=None,
            svd_mode='lapack', scaling='temp-mean', algo=pca_annulus,
-           delta_rot=1, fmerit='sum', imlib='opencv',
-           interpolation='lanczos4', collapse='median', debug=False):
+           delta_rot=1, fmerit='sum', imlib='opencv', interpolation='lanczos4', 
+           collapse='median', algo_options={}, weights=None, transmission=None, 
+           mu_sigma=True, debug=False):
     """ Define the likelihood log-function.
     
     Parameters
@@ -87,8 +89,8 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
         The scaled psf expressed as a numpy.array.
     annulus_width: float
         The width of the annulus of interest in pixels.
-    ncomp: int
-        The number of principal components.
+    ncomp: int or None
+        The number of principal components for PCA-based algorithms.
     fwhm : float
         The FHWM in pixels.
     aperture_radius: float
@@ -120,6 +122,34 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
         Sets the way of collapsing the frames for producing a final image. If
         None then the cube of residuals is used when measuring the function of
         merit (instead of a single final frame).
+    algo_options: dict, opt
+        Dictionary with additional parameters related to the algorithm 
+        (e.g. tol, min_frames_lib, max_frames_lib). If 'algo' is not a vip
+        routine, this dict should contain all necessary arguments apart from
+        the cube and derotation angles. Note: arguments such as ncomp, svd_mode,
+        scaling, imlib, interpolation or collapse can also be included in this
+        dict (the latter are also kept as function arguments for consistency
+        with older versions of vip). 
+    weights : 1d array, optional
+        If provided, the negative fake companion fluxes will be scaled according
+        to these weights before injection in the cube. Can reflect changes in 
+        the observing conditions throughout the sequence.
+    transmission: numpy array, optional
+        Array with 2 columns. First column is the radial separation in pixels. 
+        Second column is the off-axis transmission (between 0 and 1) at the 
+        radial separation given in column 1.
+    mu_sigma: tuple of 2 floats or None, opt
+        If set to None: not used, and falls back to original version of the 
+        algorithm, using fmerit. Otherwise, should be a tuple of 2 elements,
+        containing the mean and standard deviation of pixel intensities in an 
+        annulus centered on the location of the companion, excluding the area 
+        directly adjacent to the companion.
+    scale_fac: float
+        Factor by which the intensities in the cube are scaled up, to 
+        increase the residuals. This operation is needed for very low companion 
+        fluxes. The probability exp(lnprob) would otherwise be ~1 for all flux 
+        values less or similar to the true value. In practice, for companion 
+        fluxes > 100, letting scale_fac to 1 should be fine.
     debug: boolean
         If True, the cube is returned along with the likelihood log-function.
         
@@ -130,31 +160,45 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
         
     """
     # Create the cube with the negative fake companion injected
-    cube_negfc = cube_inject_companions(cube, psf_norm, angs, flevel=-param[2],
+    if weights is None:   
+        flux = -param[2]
+        norm_weights=weights
+    else:
+        flux = -param[2]*weights
+        norm_weights = weights/np.sum(weights)
+    cube_negfc = cube_inject_companions(cube, psf_norm, angs, flevel=flux,
                                         plsc=plsc, rad_dists=[param[0]],
                                         n_branches=1, theta=param[1],
-                                        imlib=imlib,
+                                        imlib=imlib, 
                                         interpolation=interpolation,
+                                        transmission=transmission,
                                         verbose=False)
-                                  
+#    if scale_fac > 1:
+#        cube_negfc*=scale_fac                            
     # Perform PCA and extract the zone of interest
     values = get_values_optimize(cube_negfc, angs, ncomp, annulus_width,
                                  aperture_radius, fwhm, initial_state[0],
                                  initial_state[1], cube_ref=cube_ref,
                                  svd_mode=svd_mode, scaling=scaling,
                                  algo=algo, delta_rot=delta_rot, imlib=imlib, 
-                                 interpolation=interpolation,
-                                 collapse=collapse)
+                                 interpolation=interpolation, collapse=collapse, 
+                                 algo_options=algo_options, 
+                                 weights=norm_weights)
     
-    # Function of merit
-    if fmerit == 'sum':
-        lnlikelihood = -0.5 * np.sum(np.abs(values))
-    elif fmerit == 'stddev':
-        values = values[values != 0]
-        lnlikelihood = -np.std(np.abs(values))
+    if isinstance(mu_sigma, tuple):
+        mu = mu_sigma[0]
+        sigma = mu_sigma[1]
+        lnlikelihood = -0.5 * np.sum(np.power(mu-values,2)/sigma**2)
     else:
-        raise RuntimeError('fmerit choice not recognized.')
-    
+        # old version - delete?
+        if fmerit == 'sum':
+            lnlikelihood = -0.5 * np.sum(np.abs(values))
+        elif fmerit == 'stddev':
+            values = values[values != 0]
+            lnlikelihood = -np.std(values)*values.size
+        else:
+            raise RuntimeError('fmerit choice not recognized.')
+   
     if debug:
         return lnlikelihood, cube_negfc
     else:
@@ -164,8 +208,9 @@ def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
 def lnprob(param,bounds, cube, angs, plsc, psf_norm, fwhm,
            annulus_width, ncomp, aperture_radius, initial_state, cube_ref=None,
            svd_mode='lapack', scaling='temp-mean', algo=pca_annulus,
-           delta_rot=1, fmerit='sum', imlib='opencv',
-           interpolation='lanczos4', collapse='median', display=False):
+           delta_rot=1, fmerit='sum', imlib='opencv', interpolation='lanczos4', 
+           collapse='median', algo_options={}, weights=None, transmission=None, 
+           mu_sigma=True, display=False):
     """ Define the probability log-function as the sum between the prior and
     likelihood log-funtions.
     
@@ -188,8 +233,8 @@ def lnprob(param,bounds, cube, angs, plsc, psf_norm, fwhm,
         The FHWM in pixels.
     annulus_width: float
         The width in pixel of the annulus on wich the PCA is performed.
-    ncomp: int
-        The number of principal components.
+    ncomp: int or None
+        The number of principal components for PCA-based algorithms.
     aperture_radius: float
         The radius of the circular aperture in FWHM.
     initial_state: numpy.array
@@ -210,10 +255,38 @@ def lnprob(param,bounds, cube, angs, plsc, psf_norm, fwhm,
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
     interpolation : str, optional
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    algo_options, : dict, opt
+        Dictionary with additional parameters related to the algorithm 
+        (e.g. tol, min_frames_lib, max_frames_lib). If 'algo' is not a vip
+        routine, this dict should contain all necessary arguments apart from
+        the cube and derotation angles. Note: arguments such as ncomp, svd_mode,
+        scaling, imlib, interpolation or collapse can also be included in this
+        dict (the latter are also kept as function arguments for consistency
+        with older versions of vip). 
     collapse : {'median', 'mean', 'sum', 'trimmean', None}, str or None, optional
         Sets the way of collapsing the frames for producing a final image. If
         None then the cube of residuals is used when measuring the function of
         merit (instead of a single final frame).
+    weights : 1d array, optional
+        If provided, the negative fake companion fluxes will be scaled according
+        to these weights before injection in the cube. Can reflect changes in 
+        the observing conditions throughout the sequence.
+    transmission: numpy array, optional
+        Array with 2 columns. First column is the radial separation in pixels. 
+        Second column is the off-axis transmission (between 0 and 1) at the 
+        radial separation given in column 1.
+    mu_sigma: tuple of 2 floats or None, opt
+        If set to None: not used, and falls back to original version of the 
+        algorithm, using fmerit. Otherwise, should be a tuple of 2 elements,
+        containing the mean and standard deviation of pixel intensities in an 
+        annulus centered on the location of the companion, excluding the area 
+        directly adjacent to the companion.
+    scale_fac: float
+        Factor by which the intensities in the cube are scaled up, to 
+        increase the residuals. This operation is needed for very low companion 
+        fluxes. The probability exp(lnprob) would otherwise be ~1 for all flux 
+        values less or similar to the true value. In practice, for companion 
+        fluxes > 100, letting scale_fac to 1 should be fine.
     display: boolean
         If True, the cube is displayed with ds9.
         
@@ -229,100 +302,13 @@ def lnprob(param,bounds, cube, angs, plsc, psf_norm, fwhm,
     lp = lnprior(param, bounds)
     
     if np.isinf(lp):
-        return -np.inf       
+        return -np.inf
     
-    return lp + lnlike(param, cube, angs, plsc, psf_norm, fwhm,
-                       annulus_width, ncomp, aperture_radius, initial_state,
-                       cube_ref, svd_mode, scaling, algo,
-                       delta_rot, fmerit, imlib,
-                       interpolation, collapse, display)
-
-
-def gelman_rubin(x):
-    """
-    Determine the Gelman-Rubin \hat{R} statistical test between Markov chains.
-    
-    Parameters
-    ----------
-    x: numpy.array
-        The numpy.array on which the Gelman-Rubin test is applied. This array
-        should contain at least 2 set of data, i.e. x.shape >= (2,).
-        
-    Returns
-    -------
-    out: float
-        The Gelman-Rubin \hat{R}.
-
-    Example
-    -------
-    >>> x1 = np.random.normal(0.0,1.0,(1,100))
-    >>> x2 = np.random.normal(0.1,1.3,(1,100))
-    >>> x = np.vstack((x1,x2))
-    >>> gelman_rubin(x)
-    1.0366629898991262
-    >>> gelman_rubin(np.vstack((x1,x1)))
-    0.99
-        
-    """
-    if np.shape(x) < (2,):
-        msg = 'Gelman-Rubin diagnostic requires multiple chains of the same '
-        msg += 'length'
-        raise ValueError(msg)
-
-    try:
-        m, n = np.shape(x)
-    except ValueError:
-        print("Bad shape for the chains")
-        return
-
-    # Calculate between-chain variance
-    B_over_n = np.sum((np.mean(x, 1) - np.mean(x)) ** 2) / (m - 1)
-
-    # Calculate within-chain variances
-    W = np.sum([(x[i] - xbar) ** 2 for i, xbar in
-                enumerate(np.mean(x, 1))]) / (m * (n - 1))
-    # (over) estimate of variance
-    s2 = W * (n - 1) / n + B_over_n
-
-    # Pooled posterior variance estimate
-    V = s2 + B_over_n / m
-
-    # Calculate PSRF
-    R = V / W
-
-    return R
-
-
-def gelman_rubin_from_chain(chain, burnin):
-    """ Pack the MCMC chain and determine the Gelman-Rubin \hat{R} statistical
-    test. In other words, two sub-sets are extracted from the chain (burnin
-    parts are taken into account) and the Gelman-Rubin statistical test is
-    performed.
-    
-    Parameters
-    ----------
-    chain: numpy.array
-        The MCMC chain with the shape walkers x steps x model_parameters
-    burnin: float \in [0,1]
-        The fraction of a walker which is discarded.
-        
-    Returns
-    -------
-    out: float
-        The Gelman-Rubin \hat{R}.
-        
-    """
-    dim = chain.shape[2]
-    k = chain.shape[1]
-    thr0 = int(np.floor(burnin*k))
-    thr1 = int(np.floor((1-burnin) * k * 0.25))
-    rhat = np.zeros(dim)
-    for j in range(dim):
-        part1 = chain[:, thr0:thr0+thr1, j].reshape((-1))
-        part2 = chain[:, thr0+3*thr1:thr0+4*thr1, j].reshape((-1))
-        series = np.vstack((part1, part2))
-        rhat[j] = gelman_rubin(series)
-    return rhat
+    return lp + lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width, 
+                       ncomp, aperture_radius, initial_state, cube_ref, 
+                       svd_mode, scaling, algo, delta_rot, fmerit, imlib,
+                       interpolation, collapse, algo_options, weights, 
+                       transmission, mu_sigma)
 
 
 def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
@@ -330,12 +316,15 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
                         svd_mode='lapack', scaling='temp-mean', 
                         algo=pca_annulus, delta_rot=1, fmerit='sum',
                         imlib='opencv', interpolation='lanczos4',
-                        collapse='median', nwalkers=1000, bounds=None, a=2.0,
-                        burnin=0.3, rhat_threshold=1.01, rhat_count_threshold=1,
-                        niteration_min=0, niteration_limit=1e2,
-                        niteration_supp=0, check_maxgap=1e4, nproc=1,
-                        output_dir='results/', output_file=None, display=False, 
-                        verbosity=0, save=False):
+                        collapse='median', algo_options={}, wedge=None, 
+                        weights=None, transmission=None, mu_sigma=None, 
+                        nwalkers=100, bounds=None, a=2.0, burnin=0.3, 
+                        rhat_threshold=1.01, rhat_count_threshold=1, 
+                        niteration_min=10, niteration_limit=10000, 
+                        niteration_supp=0, check_maxgap=20, conv_test='gb',
+                        ac_c=50, ac_count_thr=3, nproc=1, output_dir='results/', 
+                        output_file=None, display=False, verbosity=0, 
+                        save=False):
     r""" Runs an affine invariant mcmc sampling algorithm in order to determine
     the position and the flux of the planet using the 'Negative Fake Companion'
     technique. The result of this procedure is a chain with the samples from the
@@ -360,11 +349,15 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
         ADI fits cube.
     angs: numpy.array
         The parallactic angle vector.
-    psfn: numpy.array
-        PSF array. The PSF must be centered and the flux in a 1*FWHM aperture
-        must equal 1 (use ``vip_hci.phot.psf_norm``).
-    ncomp: int
-        The number of principal components.
+    psfn: numpy 2D or 3D array
+        Normalised PSF template used for negative fake companion injection. 
+        The PSF must be centered and the flux in a 1*FWHM aperture must equal 1 
+        (use ``vip_hci.metrics.normalize_psf``).
+        If a 3D array is provided, it must match the number of frames of ADI 
+        cube. This can be useful if the cube was unsaturated and conditions 
+        were variable.s
+    ncomp: int or None
+        The number of principal components for PCA-based algorithms.
     plsc: float
         The platescale, in arcsec per pixel.
     annulus_width: float, optional
@@ -381,6 +374,10 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     svd_mode : {'lapack', 'randsvd', 'eigen', 'arpack'}, str optional
         Switch for different ways of computing the SVD and selected PCs.
         'randsvd' is not recommended for the negative fake companion technique.
+    algo : python routine
+        Post-processing algorithm used to model and subtract the star. First
+        2 arguments must be input cube and derotation angles. Must return a
+        post-processed 2d frame.
     scaling : {'temp-mean', 'temp-standard'} or None, optional
         With None, no scaling is performed on the input data before SVD. With
         "temp-mean" then temporal px-wise mean subtraction is done and with
@@ -397,18 +394,68 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
         Sets the way of collapsing the frames for producing a final image. If
         None then the cube of residuals is used when measuring the function of
         merit (instead of a single final frame).
+    algo_options: dict, opt
+        Dictionary with additional parameters related to the algorithm 
+        (e.g. tol, min_frames_lib, max_frames_lib). If 'algo' is not a vip
+        routine, this dict should contain all necessary arguments apart from
+        the cube and derotation angles. Note: arguments such as ncomp, svd_mode,
+        scaling, imlib, interpolation or collapse can also be included in this
+        dict (the latter are also kept as function arguments for consistency
+        with older versions of vip). 
+    wedge: tuple, opt
+        Range in theta where the mean and standard deviation are computed in an 
+        annulus defined in the PCA image. If None, it will be calculated 
+        automatically based on initial guess and derotation angles to avoid.
+        If some disc signal is present elsewhere in the annulus, it is 
+        recommended to provide wedge manually. The provided range should be 
+        continuous and >0. E.g. provide (270, 370) to consider a PA range 
+        between [-90,+10].
+    weights : 1d array, optional
+        If provided, the negative fake companion fluxes will be scaled according
+        to these weights before injection in the cube. Can reflect changes in 
+        the observing conditions throughout the sequence.
+    transmission: numpy array, optional
+        Array with 2 columns. First column is the radial separation in pixels. 
+        Second column is the off-axis transmission (between 0 and 1) at the 
+        radial separation given in column 1.
+    mu_sigma: tuple of 2 floats or bool, opt
+        If set to None: not used, and falls back to original version of the 
+        algorithm, using fmerit.
+        If a tuple of 2 elements: should be the mean and standard deviation of 
+        pixel intensities in an annulus centered on the lcoation of the 
+        companion candidate, excluding the area directly adjacent to the CC.
+        If set to anything else, but None/False/tuple: will compute said mean 
+        and standard deviation automatically.
+        These values will then be used in the log-probability of the MCMC.
     bounds: numpy.array or list, default=None, optional
         The prior knowledge on the model parameters. If None, large bounds will
         be automatically estimated from the initial state.
     a: float, default=2.0
         The proposal scale parameter. See notes.
     burnin: float, default=0.3
-        The fraction of a walker which is discarded.
+        The fraction of a walker chain which is discarded. NOTE: only used for
+        Gelman-Rubin convergence test - the chains are returned full. 
     rhat_threshold: float, default=0.01
         The Gelman-Rubin threshold used for the test for nonconvergence.
     rhat_count_threshold: int, optional
         The Gelman-Rubin test must be satisfied 'rhat_count_threshold' times in
         a row before claiming that the chain has converged.
+    conv_test: str, optional {'gb','ac'}
+        Method to check for convergence: 
+        - 'gb' for gelman-rubin test
+        (http://digitalassets.lib.berkeley.edu/sdtr/ucb/text/305.pdf)
+        - 'ac' for autocorrelation analysis 
+        (https://emcee.readthedocs.io/en/stable/tutorials/autocorr/)
+    ac_c: float, optional
+        If the convergence test is made using the auto-correlation, this is the
+        value of C such that tau/N < 1/C is the condition required for tau to be
+        considered a reliable auto-correlation time estimate (for N number of 
+        samples). Recommended: C>50.
+        More details here: 
+        https://emcee.readthedocs.io/en/stable/tutorials/autocorr/
+    ac_c_thr: int, optional
+        The auto-correlation test must be satisfied ac_c_thr times in a row 
+        before claiming that the chain has converged.
     niteration_min: int, optional
         Steps per walker lower bound. The simulation will run at least this
         number of steps per walker.
@@ -431,8 +478,11 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     display: bool, optional
         If True, the walk plot is displayed at each evaluation of the Gelman-
         Rubin test.
-    verbosity: 0, 1 or 2, optional
-        Verbosity level. 0 for no output and 2 for full information.
+    verbosity: 0, 1, 2 or 3, optional
+        Verbosity level. 0 for no output and 3 for full information.
+        (only difference between 2 and 3 is that 3 also writes intermediate
+        pickles containing the state of the chain at convergence tests; these 
+        can end up taking a lot of space).
     save: bool, optional
         If True, the MCMC results are pickled.
                     
@@ -450,7 +500,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     The parameter 'rhat_threshold' can be a numpy.array with individual
     threshold value for each model parameter.
     """
-    if verbosity == 1 or verbosity == 2:
+    if verbosity >0:
         start_time = time_ini()
         print("        MCMC sampler for the NEGFC technique       ")
         print(sep)
@@ -478,7 +528,18 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     if cube_ref is not None:
         if not isinstance(cube_ref, np.ndarray) or cube_ref.ndim != 3:
             raise ValueError('`cube_ref` must be a 3D numpy array')
-    
+    if weights is not None:
+        if not len(weights)==cube.shape[0]:
+            raise TypeError("Weights should have same length as cube axis 0")
+        norm_weights = weights/np.sum(weights)
+    else:
+        norm_weights=weights
+        
+    if psfn.ndim==3:
+        if psfn.shape[0] != cube.shape[0]:
+            msg = "If PSF is 3D, number of frames must match cube length"
+            raise TypeError(msg)
+        
     # #########################################################################
     # Initialization of the variables
     # #########################################################################
@@ -488,7 +549,37 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     supp = niteration_supp
     maxgap = check_maxgap
     initial_state = np.array(initial_state)
+
+    # Measure mu and sigma once in the annulus (instead of each MCMC step)
+    if isinstance(mu_sigma, tuple):
+        if len(mu_sigma) != 2:
+            raise TypeError("if a tuple, mu_sigma should have 2 elements")
+    elif mu_sigma:
+        mu_sigma = get_mu_and_sigma(cube, angs, ncomp, annulus_width, 
+                                     aperture_radius, fwhm, initial_state[0], 
+                                     initial_state[1], cube_ref=cube_ref, 
+                                     wedge=wedge, svd_mode=svd_mode, 
+                                     scaling=scaling, algo=algo, 
+                                     delta_rot=delta_rot, imlib=imlib, 
+                                     interpolation=interpolation,
+                                     collapse=collapse, weights=norm_weights, 
+                                     algo_options=algo_options)
+        if verbosity >0:
+            msg = "The mean and stddev in the annulus at the radius of the "
+            msg+= "companion (excluding the PA area directly adjacent to it)"
+            msg+=" are {:.2f} and {:.2f} respectively."
+            print(msg.format(mu_sigma[0],mu_sigma[1]))
+#    pca_args['mu']=mu
+#    pca_args['sigma']=sigma
+    # if does not work, activate scale fac
     
+    # If companion flux is too low MCMC will not converge. Solution: scale up 
+    # the intensities in the cube after injecting the negfc.
+#    if initial_state[2] < 100:
+#        scale_fac = 100./initial_state[2]
+#    else:
+    #scale_fac = 1
+        
     if itermin > limit:
         itermin = 0
 
@@ -497,9 +588,10 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     lastcheck = 0
     konvergence = np.inf
     rhat_count = 0
+    ac_count = 0
     chain = np.empty([nwalkers, 1, dim])
     isamples = np.empty(0)
-    pos = initial_state + np.random.normal(0, 1e-1, (nwalkers, 3))
+    pos = initial_state*(1+np.random.normal(0, 0.01, (nwalkers, 3)))
     nIterations = limit + supp
     rhat = np.zeros(dim)
     stop = np.inf
@@ -508,7 +600,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
         bounds = [(initial_state[0] - annulus_width/2.,
                    initial_state[0] + annulus_width/2.),  # radius
                   (initial_state[1] - 10, initial_state[1] + 10),   # angle
-                  (0, 2 * initial_state[2])]   # flux
+                  (0.1* initial_state[2], 2 * initial_state[2])]   # flux
     
     sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob, a,
                                     args=([bounds, cube, angs, plsc, psfn,
@@ -516,21 +608,23 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
                                            aperture_radius, initial_state,
                                            cube_ref, svd_mode, scaling, algo,
                                            delta_rot, fmerit, imlib, 
-                                           interpolation, collapse]),
+                                           interpolation, collapse, algo_options, 
+                                           weights, transmission, mu_sigma]),
                                     threads=nproc)
+                                    
     start = datetime.datetime.now()
 
     # #########################################################################
     # Affine Invariant MCMC run
     # #########################################################################
-    if verbosity == 2:
+    if verbosity > 1:
         print('\nStart of the MCMC run ...')
         print('Step  |  Duration/step (sec)  |  Remaining Estimated Time (sec)')
     
     for k, res in enumerate(sampler.sample(pos, iterations=nIterations,
                                            storechain=True)):
         elapsed = (datetime.datetime.now()-start).total_seconds()
-        if verbosity == 2:
+        if verbosity > 1:
             if k == 0:
                 q = 0.5
             else:
@@ -554,19 +648,18 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
         # ---------------------------------------------------------------------
         # If k meets the criterion, one tests the non-convergence.
         # ---------------------------------------------------------------------
-        criterion = np.amin([np.ceil(itermin*(1+fraction)**geom),
-                             lastcheck+np.floor(maxgap)])
+        criterion = int(np.amin([np.ceil(itermin*(1+fraction)**geom),
+                             lastcheck+np.floor(maxgap)]))
         if k == criterion:
-            if verbosity == 2:
-                print('\n   Gelman-Rubin statistic test in progress ...')
+            if verbosity > 1:
+                print('\n {} convergence test in progress...'.format(conv_test))
             
             geom += 1
             lastcheck = k
             if display:
                 show_walk_plot(chain)
                 
-            if save:
-                import pickle
+            if save and verbosity == 3:
                 fname = '{d}/{f}_temp_k{k}'.format(d=output_dir,f=output_file_tmp, k=k)
                 data = {'chain': sampler.chain,
                         'lnprob': sampler.lnprobability,
@@ -576,43 +669,67 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
                 
             # We only test the rhat if we have reached the min # of steps
             if (k+1) >= itermin and konvergence == np.inf:
-                thr0 = int(np.floor(burnin*k))
-                thr1 = int(np.floor((1-burnin)*k*0.25))
-
-                # We calculate the rhat for each model parameter.
-                for j in range(dim):
-                    part1 = chain[:, thr0:thr0 + thr1, j].reshape(-1)
-                    part2 = chain[:, thr0 + 3 * thr1:thr0 + 4 * thr1, j
-                                 ].reshape(-1)
-                    series = np.vstack((part1, part2))
-                    rhat[j] = gelman_rubin(series)
-                if verbosity == 1 or verbosity == 2:
-                    print('   r_hat = {}'.format(rhat))
-                    cond = rhat <= rhat_threshold
-                    print('   r_hat <= threshold = {} \n'.format(cond))
-                # We test the rhat.
-                if (rhat <= rhat_threshold).all():
-                    rhat_count += 1
-                    if rhat_count < rhat_count_threshold:
-                        if verbosity == 1 or verbosity == 2:
-                            msg = "Gelman-Rubin test OK {}/{}"
-                            print(msg.format(rhat_count, rhat_count_threshold))
-                    elif rhat_count >= rhat_count_threshold:
-                        if verbosity == 1 or verbosity == 2:
-                            print('... ==> convergence reached')
-                        konvergence = k
-                        stop = konvergence + supp
+                if conv_test == 'gb':
+                    thr0 = int(np.floor(burnin*k))
+                    thr1 = int(np.floor((1-burnin)*k*0.25))
+    
+                    # We calculate the rhat for each model parameter.
+                    for j in range(dim):
+                        part1 = chain[:, thr0:thr0 + thr1, j].reshape(-1)
+                        part2 = chain[:, thr0 + 3 * thr1:thr0 + 4 * thr1, j
+                                     ].reshape(-1)
+                        series = np.vstack((part1, part2))
+                        rhat[j] = gelman_rubin(series)
+                    if verbosity > 0:
+                        print('   r_hat = {}'.format(rhat))
+                        cond = rhat <= rhat_threshold
+                        print('   r_hat <= threshold = {} \n'.format(cond))
+                    # We test the rhat.
+                    if (rhat <= rhat_threshold).all():
+                        rhat_count += 1
+                        if rhat_count < rhat_count_threshold:
+                            if verbosity > 0:
+                                msg = "Gelman-Rubin test OK {}/{}"
+                                print(msg.format(rhat_count, rhat_count_threshold))
+                        elif rhat_count >= rhat_count_threshold:
+                            if verbosity > 0 :
+                                print('... ==> convergence reached')
+                            konvergence = k
+                            stop = konvergence + supp
+                    else:
+                        rhat_count = 0
+                elif conv_test == 'ac':
+                    # We calculate the auto-corr test for each model parameter.
+                    if save:
+                        write_fits(output_dir+"/TMP_test_chain{:.0f}.fits".format(k),chain[:,:k])
+                    for j in range(dim):
+                        rhat[j] = autocorr_test(chain[:,:k,j])
+                    thr = 1./ac_c
+                    if verbosity > 0:
+                        print('Auto-corr tau/N = {}'.format(rhat))
+                        print('tau/N <= {} = {} \n'.format(thr, rhat<thr))
+                    if (rhat <= thr).all():
+                        ac_count+=1
+                        if verbosity > 0:
+                            msg = "Auto-correlation test passed for all params!"
+                            msg+= "{}/{}".format(ac_count,ac_count_thr)
+                            print(msg)
+                        if ac_count >= ac_count_thr:
+                            msg='\n ... ==> convergence reached'
+                            print(msg)
+                            stop = k
+                    else:
+                        ac_count = 0
                 else:
-                    rhat_count = 0
-
+                    raise ValueError('conv_test value not recognized')
         # We have reached the maximum number of steps for our Markov chain.
         if k+1 >= stop:
-            if verbosity == 1 or verbosity == 2:
+            if verbosity > 0:
                 print('We break the loop because we have reached convergence')
             break
       
     if k == nIterations-1:
-        if verbosity == 1 or verbosity == 2:
+        if verbosity > 0:
             print("We have reached the limit # of steps without convergence")
             
     # #########################################################################
@@ -624,14 +741,17 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     else:
         idxzero = chain.shape[1]
     
-    idx = int(np.amin([np.floor(2e5/nwalkers), np.floor(0.1*idxzero)]))
+    # commented due to arbitrary cutoffs, rather tweak "burnin":
+    # idx = int(np.amin([np.floor(2e5/nwalkers), np.floor(0.1*idxzero)]))
+    
+    idx=0
+        
     if idx == 0:
         isamples = chain[:, 0:idxzero, :]
     else:
         isamples = chain[:, idxzero-idx:idxzero, :]
 
     if save:
-        import pickle
         frame = inspect.currentframe()
         args, _, _, values = inspect.getargvalues(frame)
         input_parameters = {j: values[j] for j in args[1:]}
@@ -650,7 +770,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
         msg = "\nThe file MCMC_results has been stored in the folder {}"
         print(msg.format(output_dir+'/'))
 
-    if verbosity == 1 or verbosity == 2:
+    if verbosity > 0:
         timing(start_time)
                                     
     return chain_zero_truncated(chain)
@@ -734,7 +854,7 @@ def show_corner_plot(chain, burnin=0.5, save=False, output_dir='', **kwargs):
         If a part of the chain is filled with zero values, the method will
         discard these steps.
     burnin: float, default: 0
-        The fraction of a walker we want to discard.
+        The fraction of a walker chain we want to discard.
     save: boolean, default: False
         If True, a pdf file is created.
      
@@ -774,7 +894,7 @@ def show_corner_plot(chain, burnin=0.5, save=False, output_dir='', **kwargs):
 
 
 def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
-               verbose=True, save=False, output_dir='', **kwargs):
+               verbose=True, save=False, output_dir='', force=False, **kwargs):
     """
     Determine the highly probable value for each model parameter, as well as
     the 1-sigma confidence interval.
@@ -796,14 +916,24 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
     save: boolean, optional
         If "True", a txt file with the results is saved in the output
         repository.
+    output_dir: str, optional
+        If save is True, this is the full path to a directory where the results
+        are saved.
+    force: bool, optional
+        If set to True, to force the confidence interval estimate even if too
+        many samples fall in a single bin (unreliable CI estimates). If False, 
+        an error message is raised if the percentile of samples falling in a 
+        single bin is larger than cfd, suggesting to increase number of bins.
     kwargs: optional
         Additional attributes are passed to the matplotlib hist() method.
         
     Returns
     -------
     out: tuple
-        A 2 elements tuple with the highly probable solution and the confidence
-        interval.
+        A 2 elements tuple with either 1) the highly probable solution and the 
+        confidence interval; or 2) (if gaussian_fit is True) the center of the 
+        best-fit 1d gaussian distribution and its standard deviation, for each
+        planet parameter.
         
     """
 
@@ -814,12 +944,26 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
         
     try:
         l = isamples.shape[1]
+        if l == 1:
+            isamples = isamples[:,0]
+            pKey = ['f']
+            label_file = ['flux']
+            label = [r'$\Delta f$']
+        elif l == 3:
+            pKey = ['r', 'theta', 'f']
+            label_file = ['r', 'theta', 'flux']
+            label = [r'$\Delta r$', r'$\Delta \theta$', r'$\Delta f$']
+        else:
+            raise TypeError("input shape of isamples not recognized")
     except:
         l = 1
+        pKey = ['f']
+        label_file = ['flux']
+        label = [r'$\Delta f$']
      
     confidenceInterval = {}
     val_max = {}
-    pKey = ['r', 'theta', 'f']
+    
     
     if cfd == 100:
         cfd = 99.9
@@ -828,26 +972,33 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
     ##  Determine the confidence interval  ##
     #########################################
     if gaussian_fit:
-        mu = np.zeros(3)
+        mu = np.zeros(l)
         sigma = np.zeros_like(mu)
     
     if gaussian_fit:
-        fig, ax = plt.subplots(2, 3, figsize=(12,8))
+        fig, ax = plt.subplots(2, l, figsize=(int(l*4),8))
     else:
-        fig, ax = plt.subplots(1, 3, figsize=(12,4))
+        fig, ax = plt.subplots(1, l, figsize=(int(l*4),4))
     
     for j in range(l):
-        label_file = ['r', 'theta', 'flux']
-        label = [r'$\Delta r$', r'$\Delta \theta$', r'$\Delta f$']
-        
-        if gaussian_fit:
-            n, bin_vertices, _ = ax[0][j].hist(isamples[:,j], bins=bins,
-                                               weights=weights, histtype='step',
-                                               edgecolor='gray')
+        if l>1:
+            if gaussian_fit:
+                n, bin_vertices, _ = ax[0][j].hist(isamples[:,j], bins=bins,
+                                                   weights=weights, histtype='step',
+                                                   edgecolor='gray')
+            else:
+                n, bin_vertices, _ = ax[j].hist(isamples[:,j], bins=bins,
+                                                weights=weights, histtype='step',
+                                                edgecolor='gray')
         else:
-            n, bin_vertices, _ = ax[j].hist(isamples[:,j], bins=bins,
-                                            weights=weights, histtype='step',
-                                            edgecolor='gray')
+            if gaussian_fit:
+                n, bin_vertices, _ = ax[0].hist(isamples[:], bins=bins,
+                                                   weights=weights, histtype='step',
+                                                   edgecolor='gray')
+            else:
+                n, bin_vertices, _ = ax.hist(isamples[:], bins=bins,
+                                                weights=weights, histtype='step',
+                                                edgecolor='gray')                
         bins_width = np.mean(np.diff(bin_vertices))
         surface_total = np.sum(np.ones_like(n)*bins_width * n)
         n_arg_sort = np.argsort(n)[::-1]
@@ -862,9 +1013,18 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
                     msg = 'percentage for {}: {}%'
                     print(msg.format(label_file[j], pourcentage))
                 break
-        n_arg_min = int(n_arg_sort[:k].min())
+        if k ==0:
+            msg = "WARNING: Percentile reached in a single bin. "
+            msg += "This may be due to outliers or a small sample."
+            msg += "Uncertainties will be unreliable. Try one of these:"
+            msg += "increase bins, or trim outliers, or decrease cfd."
+            if force:
+                raise ValueError(msg)
+            else:
+                print(msg)               
+        n_arg_min = int(n_arg_sort[:k+1].min())
         n_arg_max = int(n_arg_sort[:k+1].max())
-        
+
         if n_arg_min == 0:
             n_arg_min += 1
         if n_arg_max == bins:
@@ -874,49 +1034,100 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
         confidenceInterval[pKey[j]] = np.array([bin_vertices[n_arg_min-1],
                                                bin_vertices[n_arg_max+1]]
                                                - val_max[pKey[j]])
-                        
-        arg = (isamples[:, j] >= bin_vertices[n_arg_min - 1]) * \
-              (isamples[:, j] <= bin_vertices[n_arg_max + 1])
-        if gaussian_fit:
-            ax[0][j].hist(isamples[arg,j], bins=bin_vertices,
-                          facecolor='gray', edgecolor='darkgray',
-                          histtype='stepfilled', alpha=0.5)
-            ax[0][j].vlines(val_max[pKey[j]], 0, n[int(n_arg_sort[0])],
-                            linestyles='dashed', color='red')
-            ax[0][j].set_xlabel(label[j])
-            if j == 0:
-                ax[0][j].set_ylabel('Counts')
-
-            mu[j], sigma[j] = norm.fit(isamples[:, j])
-            n_fit, bins_fit = np.histogram(isamples[:, j], bins, normed=1,
-                                           weights=weights)
-            ax[1][j].hist(isamples[:, j], bins, normed=1, weights=weights,
-                          facecolor='gray', edgecolor='darkgray',
-                          histtype='step')
-            y = norm.pdf(bins_fit, mu[j], sigma[j])
-            ax[1][j].plot(bins_fit, y, 'r--', linewidth=2, alpha=0.7)
-
-            ax[1][j].set_xlabel(label[j])
-            if j == 0:
-                ax[1][j].set_ylabel('Counts')
-
-            if title is not None:
-                msg = r"{}   $\mu$ = {:.4f}, $\sigma$ = {:.4f}"
-                ax[1][j].set_title(msg.format(title, mu[j], sigma[j]),
-                                   fontsize=10)
-
+        if l>1:                
+            arg = (isamples[:, j] >= bin_vertices[n_arg_min - 1]) * \
+                  (isamples[:, j] <= bin_vertices[n_arg_max + 1])            
+            if gaussian_fit:
+                ax[0][j].hist(isamples[arg,j], bins=bin_vertices,
+                              facecolor='gray', edgecolor='darkgray',
+                              histtype='stepfilled', alpha=0.5)
+                ax[0][j].vlines(val_max[pKey[j]], 0, n[int(n_arg_sort[0])],
+                                linestyles='dashed', color='red')
+                ax[0][j].set_xlabel(label[j])
+                if j == 0:
+                    ax[0][j].set_ylabel('Counts')
+    
+                mu[j], sigma[j] = norm.fit(isamples[:, j])
+                n_fit, bins_fit = np.histogram(isamples[:, j], bins, normed=1,
+                                               weights=weights)
+                ax[1][j].hist(isamples[:, j], bins, density=1, weights=weights,
+                              facecolor='gray', edgecolor='darkgray',
+                              histtype='step')
+                y = norm.pdf(bins_fit, mu[j], sigma[j])
+                ax[1][j].plot(bins_fit, y, 'r--', linewidth=2, alpha=0.7)
+    
+                ax[1][j].set_xlabel(label[j])
+                if j == 0:
+                    ax[1][j].set_ylabel('Counts')
+    
+                if title is not None:
+                    msg = r"{}   $\mu$ = {:.4f}, $\sigma$ = {:.4f}"
+                    ax[1][j].set_title(msg.format(title, mu[j], sigma[j]),
+                                       fontsize=10)
+    
+            else:            
+                ax[j].hist(isamples[arg,j],bins=bin_vertices, facecolor='gray',
+                           edgecolor='darkgray', histtype='stepfilled',
+                           alpha=0.5)
+                ax[j].vlines(val_max[pKey[j]], 0, n[int(n_arg_sort[0])],
+                             linestyles='dashed', color='red')
+                ax[j].set_xlabel(label[j])
+                if j == 0:
+                    ax[j].set_ylabel('Counts')
+    
+                if title is not None:
+                    msg = r"{} - {:.3f} {:.3f} +{:.3f}"
+                    ax[1].set_title(msg.format(title, val_max[pKey[j]], 
+                                               confidenceInterval[pKey[j]][0], 
+                                               confidenceInterval[pKey[j]][1]),
+                                    fontsize=10)
         else:
-            ax[j].hist(isamples[arg,j],bins=bin_vertices, facecolor='gray',
-                       edgecolor='darkgray', histtype='stepfilled',
-                       alpha=0.5)
-            ax[j].vlines(val_max[pKey[j]], 0, n[int(n_arg_sort[0])],
-                         linestyles='dashed', color='red')
-            ax[j].set_xlabel(label[j])
-            if j == 0:
-                ax[j].set_ylabel('Counts')
-
-            if title is not None:
-                ax[1].set_title(title, fontsize=10)
+            arg = (isamples[:] >= bin_vertices[n_arg_min - 1]) * \
+                      (isamples[:] <= bin_vertices[n_arg_max + 1])
+            if gaussian_fit:
+                ax[0].hist(isamples[arg], bins=bin_vertices,
+                              facecolor='gray', edgecolor='darkgray',
+                              histtype='stepfilled', alpha=0.5)
+                ax[0].vlines(val_max[pKey[j]], 0, n[int(n_arg_sort[0])],
+                                linestyles='dashed', color='red')
+                ax[0].set_xlabel(label[j])
+                if j == 0:
+                    ax[0].set_ylabel('Counts')
+    
+                mu[j], sigma[j] = norm.fit(isamples[:])
+                n_fit, bins_fit = np.histogram(isamples[:], bins, normed=1,
+                                               weights=weights)
+                ax[1].hist(isamples[:], bins, density=1, weights=weights,
+                              facecolor='gray', edgecolor='darkgray',
+                              histtype='step')
+                y = norm.pdf(bins_fit, mu[j], sigma[j])
+                ax[1].plot(bins_fit, y, 'r--', linewidth=2, alpha=0.7)
+    
+                ax[1].set_xlabel(label[j])
+                if j == 0:
+                    ax[1].set_ylabel('Counts')
+    
+                if title is not None:
+                    msg = r"{}   $\mu$ = {:.4f}, $\sigma$ = {:.4f}"
+                    ax[1].set_title(msg.format(title, mu[j], sigma[j]),
+                                       fontsize=10)
+    
+            else:
+                ax.hist(isamples[arg],bins=bin_vertices, facecolor='gray',
+                           edgecolor='darkgray', histtype='stepfilled',
+                           alpha=0.5)
+                ax.vlines(val_max[pKey[j]], 0, n[int(n_arg_sort[0])],
+                             linestyles='dashed', color='red')
+                ax.set_xlabel(label[j])
+                if j == 0:
+                    ax.set_ylabel('Counts')
+    
+                if title is not None:
+                    msg = r"{} - {:.3f} {:.3f} +{:.3f}"
+                    ax.set_title(msg.format(title, val_max[pKey[j]], 
+                                               confidenceInterval[pKey[j]][0], 
+                                               confidenceInterval[pKey[j]][1]),
+                                    fontsize=10)            
 
         plt.tight_layout(w_pad=0.1)
 
@@ -928,22 +1139,26 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
 
     if verbose:
         print('\n\nConfidence intervals:')
-        print('r: {} [{},{}]'.format(val_max['r'],
-                                     confidenceInterval['r'][0],
-                                     confidenceInterval['r'][1]))
-        print('theta: {} [{},{}]'.format(val_max['theta'],
-                                         confidenceInterval['theta'][0],
-                                         confidenceInterval['theta'][1]))
+        if l>1:
+            print('r: {} [{},{}]'.format(val_max['r'],
+                                         confidenceInterval['r'][0],
+                                         confidenceInterval['r'][1]))
+            print('theta: {} [{},{}]'.format(val_max['theta'],
+                                             confidenceInterval['theta'][0],
+                                             confidenceInterval['theta'][1]))
         print('flux: {} [{},{}]'.format(val_max['f'],
                                         confidenceInterval['f'][0],
                                         confidenceInterval['f'][1]))
         if gaussian_fit:
             print()
             print('Gaussian fit results:')
-            print('r: {} +-{}'.format(mu[0], sigma[0]))
-            print('theta: {} +-{}'.format(mu[1], sigma[1]))
-            print('f: {} +-{}'.format(mu[2], sigma[2]))
-
+            if l>1:
+                print('r: {} +-{}'.format(mu[0], sigma[0]))
+                print('theta: {} +-{}'.format(mu[1], sigma[1]))
+                print('f: {} +-{}'.format(mu[2], sigma[2]))
+            else:
+                print('f: {} +-{}'.format(mu[0], sigma[0]))
+                
     ##############################################
     ##  Write inference results in a text file  ##
     ##############################################
@@ -960,23 +1175,23 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
             f.write('{} % confidence interval\n'.format(cfd))
             f.write(' \n')
 
-            for i in range(3):
+            for i in range(l):
                 confidenceMax = confidenceInterval[pKey[i]][1]
                 confidenceMin = -confidenceInterval[pKey[i]][0]
-                if i == 2:
+                if i == 2 or l==1:
                     text = '{}: \t\t\t{:.3f} \t-{:.3f} \t+{:.3f}\n'
                 else:
                     text = '{}: \t\t\t{:.3f} \t\t-{:.3f} \t\t+{:.3f}\n'
                     
                 f.write(text.format(pKey[i], val_max[pKey[i]],
                                     confidenceMin, confidenceMax))
-            
-            f.write(' ')
-            f.write('Platescale = {} mas\n'.format(plsc*1000))
-            f.write('r (mas): \t\t{:.2f} \t\t-{:.2f} \t\t+{:.2f}\n'.format(
-                        val_max[pKey[0]]*plsc*1000,
-                        -confidenceInterval[pKey[0]][0]*plsc*1000,
-                        confidenceInterval[pKey[0]][1]*plsc*1000))
+            if l>1:
+                f.write(' ')
+                f.write('Platescale = {} mas\n'.format(plsc*1000))
+                f.write('r (mas): \t\t{:.2f} \t\t-{:.2f} \t\t+{:.2f}\n'.format(
+                            val_max[pKey[0]]*plsc*1000,
+                            -confidenceInterval[pKey[0]][0]*plsc*1000,
+                            confidenceInterval[pKey[0]][1]*plsc*1000))
 
     if gaussian_fit:
         return mu, sigma

--- a/vip_hci/negfc/simplex_fmerit.py
+++ b/vip_hci/negfc/simplex_fmerit.py
@@ -4,15 +4,15 @@
 Module with the function of merit definitions for the NEGFC optimization.
 """
 
-
+__author__ = 'O. Wertz, Carlos Alberto Gomez Gonzalez, Valentin Christiaens'
 __all__ = []
 
 import numpy as np
 from hciplot import plot_frames
 from skimage.draw import circle
 from ..metrics import cube_inject_companions
-from ..var import frame_center
-from ..pca import pca_annulus, pca_annular
+from ..var import frame_center, get_annular_wedge, cube_filter_highpass
+from ..pca import pca_annulus, pca_annular, pca
 from ..preproc import cube_crop_frames
 
 
@@ -20,7 +20,8 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
               aperture_radius, initialState, ncomp, cube_ref=None, 
               svd_mode='lapack', scaling=None, fmerit='sum', collapse='median',
               algo=pca_annulus, delta_rot=1, imlib='opencv', 
-              interpolation='lanczos4', debug=False):
+              interpolation='lanczos4', algo_options={}, transmission=None, 
+              mu_sigma=None, weights=None, force_rPA=False, debug=False):
     """
     Calculate the reduced chi2:
     \chi^2_r = \frac{1}{N-3}\sum_{j=1}^{N} |I_j|,
@@ -47,8 +48,8 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
         The radius of the circular aperture in terms of the FWHM.
     initialState: numpy.array
         Position (r, theta) of the circular aperture center.
-    ncomp: int
-        The number of principal components.
+    ncomp: int or None
+        The number of principal components for PCA-based algorithms.
     cube_ref : numpy ndarray, 3d, optional
         Reference library cube. For Reference Star Differential Imaging.
     svd_mode : {'lapack', 'randsvd', 'eigen', 'arpack'}, str optional
@@ -65,8 +66,10 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
         Sets the way of collapsing the frames for producing a final image. If
         None then the cube of residuals is used when measuring the function of
         merit (instead of a single final frame).
-    algo: vip function, optional {pca_annulus, pca_annular}
-        Post-processing algorithm used.
+    algo: python routine, opt {pca_annulus, pca_annular, pca, custom}
+        Routine to be used to model and subtract the stellar PSF. From an input
+        cube, derotation angles, and optional arguments, it should return a 
+        post-processed frame.
     delta_rot: float, optional
         If algo is set to pca_annular, delta_rot is the angular threshold used
         to select frames in the PCA library (see description of pca_annular).
@@ -74,24 +77,63 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
         See the documentation of the ``vip_hci.preproc.frame_shift`` function.
     interpolation : str, optional
         See the documentation of the ``vip_hci.preproc.frame_shift`` function.
+    algo_options: dict, opt
+        Dictionary with additional parameters related to the algorithm 
+        (e.g. tol, min_frames_lib, max_frames_lib). If 'algo' is not a vip
+        routine, this dict should contain all necessary arguments apart from
+        the cube and derotation angles. Note: arguments such as ncomp, svd_mode,
+        scaling, imlib, interpolation or collapse can also be included in this
+        dict (the latter are also kept as function arguments for consistency
+        with older versions of vip). 
+    transmission: numpy array, optional
+        Array with 2 columns. First column is the radial separation in pixels. 
+        Second column is the off-axis transmission (between 0 and 1) at the 
+        radial separation given in column 1.
+    mu_sigma: tuple of 2 floats or None, opt
+        If set to None: not used, and falls back to original version of the 
+        algorithm, using fmerit.
+        If set to anything but None: will compute the mean and standard 
+        deviation of pixel intensities in an annulus centered on the location 
+        of the companion, excluding the area directly adjacent to the companion.
+    weights : 1d array, optional
+        If provided, the negative fake companion fluxes will be scaled according
+        to these weights before injection in the cube. Can reflect changes in 
+        the observing conditions throughout the sequence.
+    force_rPA: bool, optional
+        Whether to only search for optimal flux, provided (r,PA).
+    debug: bool, opt
+        Whether to debug and plot the post-processed frame after injection of 
+        the negative fake companion.
         
     Returns
     -------
     out: float
         The reduced chi squared.
         
-    """    
-    try:
-        r, theta, flux = modelParameters
-    except TypeError:
-        msg = 'modelParameters must be a tuple, {} was given'
-        print(msg.format(type(modelParameters)))
+    """
+    if force_rPA:
+        r, theta = initialState
+        flux_tmp = modelParameters[0]
+    else:
+        try:
+            r, theta, flux_tmp = modelParameters
+        except TypeError:
+            msg = 'modelParameters must be a tuple, {} was given'
+            print(msg.format(type(modelParameters)))
+
+    if weights is None:   
+        flux = -flux_tmp
+        norm_weights=weights
+    else:
+        flux = -flux_tmp*weights
+        norm_weights = weights/np.sum(weights)
 
     # Create the cube with the negative fake companion injected
-    cube_negfc = cube_inject_companions(cube, psfs_norm, angs, flevel=-flux,
+    cube_negfc = cube_inject_companions(cube, psfs_norm, angs, flevel=flux,
                                         plsc=plsc, rad_dists=[r], n_branches=1,
                                         theta=theta, imlib=imlib, verbose=False,
-                                        interpolation=interpolation)
+                                        interpolation=interpolation, 
+                                        transmission=transmission)
                                       
     # Perform PCA and extract the zone of interest
     res = get_values_optimize(cube_negfc, angs, ncomp, annulus_width,
@@ -99,7 +141,9 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
                               initialState[1], cube_ref=cube_ref,
                               svd_mode=svd_mode, scaling=scaling, algo=algo,
                               delta_rot=delta_rot, collapse=collapse, 
+                              algo_options=algo_options, weights=norm_weights, 
                               debug=debug)
+    
     if debug and collapse is not None:
         values, frpca = res
         plot_frames(frpca)
@@ -107,22 +151,30 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
         values = res
     
     # Function of merit
-    if fmerit == 'sum':
-        values = np.abs(values)
-        chi2 = np.sum(values[values > 0])
-        N = len(values[values > 0])
-        return chi2 / (N-3)
-    elif fmerit == 'stddev':
-        return np.std(values[values != 0])
+    if mu_sigma is None:
+        # old version - delete?
+        if fmerit == 'sum':
+            chi = np.sum(np.abs(values))
+        elif fmerit == 'stddev':
+            values = values[values != 0]
+            chi = np.std(values)*values.size
+        else:
+            raise RuntimeError('fmerit choice not recognized.')
     else:
-        raise RuntimeError('`fmerit` choice not recognized')
+        # true expression of a gaussian log probability
+        mu = mu_sigma[0]
+        sigma = mu_sigma[1]
+        chi = np.sum(np.power(mu-values,2)/sigma**2)   
+        
+    return chi
 
 
 def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius, 
                         fwhm, r_guess, theta_guess, cube_ref=None, 
                         svd_mode='lapack', scaling=None, algo=pca_annulus, 
                         delta_rot=1, imlib='opencv', interpolation='lanczos4',
-                        collapse='median', debug=False):
+                        collapse='median', algo_options={}, weights=None, 
+                        debug=False):
     """ Extracts a PCA-ed annulus from the cube and returns the flux values of
     the pixels included in a circular aperture centered at a given position.
     
@@ -132,8 +184,8 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
         The cube of fits images expressed as a numpy.array.
     angs: numpy.array
         The parallactic angle fits image expressed as a numpy.array.
-    ncomp: int
-        The number of principal component.
+    ncomp: int or None
+        The number of principal components for PCA-based algorithms.
     annulus_width: float
         The width in pixels of the annulus on which the PCA is performed.
     aperture_radius: float
@@ -157,8 +209,10 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
         "temp-mean" then temporal px-wise mean subtraction is done and with 
         "temp-standard" temporal mean centering plus scaling to unit variance 
         is done.
-    algo: vip function, optional {pca_annulus, pca_annular}
-        Post-processing algorithm used.
+    algo: python routine, opt {pca_annulus, pca_annular, pca, custom}
+        Routine to be used to model and subtract the stellar PSF. From an input
+        cube, derotation angles, and optional arguments, it should return a 
+        post-processed frame.
     delta_rot: float, optional
         If algo is set to pca_annular, delta_rot is the angular threshold used
         to select frames in the PCA library (see description of pca_annular).
@@ -169,6 +223,18 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
     collapse : {'median', 'mean', 'sum', 'trimmean', None}, str or None, optional
         Sets the way of collapsing the frames for producing a final image. If
         None then the cube of residuals is returned.
+    algo_options: dict, opt
+        Dictionary with additional parameters related to the algorithm 
+        (e.g. tol, min_frames_lib, max_frames_lib). If 'algo' is not a vip
+        routine, this dict should contain all necessary arguments apart from
+        the cube and derotation angles. Note: arguments such as ncomp, svd_mode,
+        scaling, imlib, interpolation or collapse can also be included in this
+        dict (the latter are also kept as function arguments for consistency
+        with older versions of vip). 
+    weights : 1d array, optional
+        If provided, the negative fake companion fluxes will be scaled according
+        to these weights before injection in the cube. Can reflect changes in 
+        the observing conditions throughout the sequence.
     debug: boolean
         If True, the cube is returned along with the values.        
         
@@ -177,7 +243,7 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
     values: numpy.array
         The pixel values in the circular aperture after the PCA process.
 
-    If debug is True the PCA frame is returned (in case when collapse is not None)
+    If debug is True and collapse non-None, the PCA frame is also returned.
         
     """
     centy_fr, centx_fr = frame_center(cube[0])
@@ -191,17 +257,30 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
     msg += 'decreasing the annulus or aperture size.'
     msg += 'rguess: {:.0f}px; centx_fr: {:.0f}px'.format(r_guess,centx_fr)
     msg += 'halfw: {:.0f}px'.format(halfw)
-    if r_guess > centx_fr-halfw or r_guess <= halfw:
+    if r_guess > centx_fr-halfw:# or r_guess <= halfw:
         raise RuntimeError(msg)
-                          
+
+    ncomp = algo_options.get('ncomp',ncomp)
+    svd_mode = algo_options.get('svd_mode',svd_mode)
+    scaling = algo_options.get('scaling',scaling)
+    imlib = algo_options.get('imlib',imlib)
+    interpolation = algo_options.get('interpolation',interpolation)
+    collapse = algo_options.get('collapse',collapse)
+        
     if algo == pca_annulus:
-        pca_res = pca_annulus(cube, angs, ncomp, annulus_width, r_guess, cube_ref,
-                              svd_mode, scaling, imlib=imlib,
-                              interpolation=interpolation, collapse=collapse)
+        pca_res = pca_annulus(cube, angs, ncomp, annulus_width, r_guess, 
+                              cube_ref, svd_mode, scaling, imlib=imlib,
+                              interpolation=interpolation, collapse=collapse,
+                              weights=weights)
     elif algo == pca_annular:
-        radius_int = int(np.floor(r_guess-annulus_width/2))
+                
+        tol = algo_options.get('tol',1e-1)
+        min_frames_lib=algo_options.get('min_frames_lib',2)
+        max_frames_lib=algo_options.get('max_frames_lib',200)
+        radius_int = max(1,int(np.floor(r_guess-annulus_width/2)))
+        radius_int = algo_options.get('radius_int', radius_int)
         # crop cube to just be larger than annulus => FASTER PCA
-        crop_sz = int(np.ceil(r_guess+annulus_width))
+        crop_sz = int(2*np.ceil(radius_int+annulus_width+1))
         if not crop_sz %2:
             crop_sz+=1
         if crop_sz < cube.shape[1] and crop_sz < cube.shape[2]:
@@ -210,15 +289,46 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
         else:
             crop_cube = cube
 
-        pca_res_tmp = pca_annular(crop_cube, angs, radius_int=radius_int, fwhm=fwhm, 
-                                  asize=annulus_width, delta_rot=delta_rot, 
-                                  ncomp=ncomp, svd_mode=svd_mode, scaling=scaling, 
+
+        pca_res_tmp = pca_annular(crop_cube, angs, radius_int=radius_int, 
+                                  fwhm=fwhm, asize=annulus_width, 
+                                  delta_rot=delta_rot, ncomp=ncomp, 
+                                  svd_mode=svd_mode, scaling=scaling, 
                                   imlib=imlib, interpolation=interpolation,
-                                  collapse=collapse, full_output=False, 
-                                  verbose=False)
+                                  collapse=collapse, weights=weights, tol=tol, 
+                                  min_frames_lib=min_frames_lib, 
+                                  max_frames_lib=max_frames_lib, 
+                                  full_output=False, verbose=False)
         # pad again now                      
         pca_res = np.pad(pca_res_tmp,pad,mode='constant',constant_values=0)
         
+    elif algo == pca:
+        hp_filter = algo_options.get('hp_filter',None)
+        hp_kernel = algo_options.get('hp_kernel',None)
+        scale_list = algo_options.get('scale_list',None)
+        ifs_collapse_range = algo_options.get('ifs_collapse_range','all')
+        nproc = algo_options.get('nproc','all')
+        
+        # not recommended, except if large-scale residual sky present (NIRC2-L')
+        if hp_filter is not None:
+            if 'median' in hp_filter:
+                cube = cube_filter_highpass(cube, mode=hp_filter, 
+                                            median_size=hp_kernel)
+            elif "gauss" in hp_filter:
+                cube = cube_filter_highpass(cube, mode=hp_filter, 
+                                            fwhm_size=hp_kernel)
+            else:
+                cube = cube_filter_highpass(cube, mode=hp_filter, 
+                                            kernel_size=hp_kernel)
+        
+        pca_res = pca(cube, angs, cube_ref, scale_list, ncomp, 
+                      svd_mode=svd_mode, scaling=scaling, imlib=imlib,
+                      interpolation=interpolation, collapse=collapse,
+                      ifs_collapse_range=ifs_collapse_range, nproc=nproc,
+                      weights=weights, verbose=False)
+    else:
+        algo_args = algo_options
+        pca_res = algo(cube, angs, **algo_args)
                                   
     indices = circle(posy, posx, radius=aperture_radius*fwhm)
     yy, xx = indices
@@ -233,3 +343,189 @@ def get_values_optimize(cube, angs, ncomp, annulus_width, aperture_radius,
     else:
         return values
 
+
+def get_mu_and_sigma(cube, angs, ncomp, annulus_width, aperture_radius, 
+                     fwhm, r_guess, theta_guess, cube_ref=None, wedge=None,
+                     svd_mode='lapack', scaling=None, algo=pca_annulus, 
+                     delta_rot=1, imlib='opencv', interpolation='lanczos4',
+                     collapse='median', weights=None, algo_options={}):
+    """ Extracts the mean and standard deviation of pixel intensities in an
+    annulus of the PCA-ADI image obtained with 'algo', in the part of a defined 
+    wedge that is not overlapping with PA_pl+-delta_PA.
+    
+    Parameters
+    ----------
+    cube: numpy.array
+        The cube of fits images expressed as a numpy.array.
+    angs: numpy.array
+        The parallactic angle fits image expressed as a numpy.array.
+    ncomp: int or None
+        The number of principal components for PCA-based algorithms.
+    annulus_width: float
+        The width in pixels of the annulus on which the PCA is performed.
+    aperture_radius: float
+        The radius in fwhm of the circular aperture.
+    fwhm: float
+        Value of the FWHM of the PSF.
+    r_guess: float
+        The radial position of the center of the circular aperture. This 
+        parameter is NOT the radial position of the candidate associated to the 
+        Markov chain, but should be the fixed initial guess.
+    theta_guess: float
+        The angular position of the center of the circular aperture. This 
+        parameter is NOT the angular position of the candidate associated to the 
+        Markov chain, but should be the fixed initial guess.  
+    cube_ref : numpy ndarray, 3d, optional
+        Reference library cube. For Reference Star Differential Imaging.
+    wedge: tuple, opt
+        Range in theta where the mean and standard deviation are computed in an 
+        annulus defined in the PCA image. If None, it will be calculated 
+        automatically based on initial guess and derotation angles to avoid.
+        If some disc signal is present elsewhere in the annulus, it is 
+        recommended to provide wedge manually. The provided range should be 
+        continuous and >0. E.g. provide (270, 370) to consider a PA range 
+        between [-90,+10].
+    svd_mode : {'lapack', 'randsvd', 'eigen', 'arpack'}, str optional
+        Switch for different ways of computing the SVD and selected PCs.
+    scaling : {None, 'temp-mean', 'temp-standard'}
+        With None, no scaling is performed on the input data before SVD. With 
+        "temp-mean" then temporal px-wise mean subtraction is done and with 
+        "temp-standard" temporal mean centering plus scaling to unit variance 
+        is done.
+    algo: python routine, opt {pca_annulus, pca_annular, pca, custom}
+        Routine to be used to model and subtract the stellar PSF. From an input
+        cube, derotation angles, and optional arguments, it should return a 
+        post-processed frame.
+    delta_rot: float, optional
+        If algo is set to pca_annular, delta_rot is the angular threshold used
+        to select frames in the PCA library (see description of pca_annular).
+    imlib : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    interpolation : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
+    collapse : {'median', 'mean', 'sum', 'trimmean', None}, str or None, optional
+        Sets the way of collapsing the frames for producing a final image. If
+        None then the cube of residuals is returned.
+    weights: 1d numpy array or list, optional
+        Weights to be applied for a weighted mean. Need to be provided if 
+        collapse mode is 'wmean'.
+    algo_options: dict, opt
+        Dictionary with additional parameters related to the algorithm 
+        (e.g. tol, min_frames_lib, max_frames_lib). If 'algo' is not a vip
+        routine, this dict should contain all necessary arguments apart from
+        the cube and derotation angles. Note: arguments such as ncomp, svd_mode,
+        scaling, imlib, interpolation or collapse can also be included in this
+        dict (the latter are also kept as function arguments for consistency
+        with older versions of vip). 
+        
+    Returns
+    -------
+    values: numpy.array
+        The pixel values in the circular aperture after the PCA process.
+        
+    """
+    centy_fr, centx_fr = frame_center(cube[0])
+    halfw = max(aperture_radius*fwhm, annulus_width/2)
+
+    # Checking annulus/aperture sizes. Assuming square frames
+    msg = 'The annulus and/or the circular aperture used by the NegFC falls '
+    msg += 'outside the FOV. Try increasing the size of your frames or '
+    msg += 'decreasing the annulus or aperture size.'
+    msg += 'rguess: {:.0f}px; centx_fr: {:.0f}px'.format(r_guess,centx_fr)
+    msg += 'halfw: {:.0f}px'.format(halfw)
+    if r_guess > centx_fr-halfw:# or r_guess <= halfw:
+        raise RuntimeError(msg)
+
+    ncomp = algo_options.get('ncomp',ncomp)                       
+    svd_mode = algo_options.get('svd_mode',svd_mode)
+    scaling = algo_options.get('scaling',scaling)
+    imlib = algo_options.get('imlib',imlib)
+    interpolation = algo_options.get('interpolation',interpolation)
+    collapse = algo_options.get('collapse',collapse)
+
+    radius_int = max(1,int(np.floor(r_guess-annulus_width/2)))
+    radius_int = algo_options.get('radius_int', radius_int)
+    
+    if algo == pca_annulus:
+        pca_res = pca_annulus(cube, angs, ncomp, annulus_width, r_guess, 
+                              cube_ref, svd_mode, scaling, imlib=imlib,
+                              interpolation=interpolation, collapse=collapse, 
+                              weights=weights)
+    elif algo == pca_annular:                
+        tol = algo_options.get('tol',1e-1)
+        min_frames_lib=algo_options.get('min_frames_lib',2)
+        max_frames_lib=algo_options.get('max_frames_lib',200)       
+        # crop cube to just be larger than annulus => FASTER PCA
+        crop_sz = int(2*np.ceil(radius_int+annulus_width+1))
+        if not crop_sz %2:
+            crop_sz+=1
+        if crop_sz < cube.shape[1] and crop_sz < cube.shape[2]:
+            pad = int((cube.shape[1]-crop_sz)/2)
+            crop_cube = cube_crop_frames(cube, crop_sz, verbose=False)
+        else:
+            crop_cube = cube
+
+
+        pca_res_tmp = pca_annular(crop_cube, angs, radius_int=radius_int, 
+                                  fwhm=fwhm, asize=annulus_width, 
+                                  delta_rot=delta_rot, ncomp=ncomp, 
+                                  svd_mode=svd_mode, scaling=scaling, 
+                                  imlib=imlib, interpolation=interpolation,
+                                  collapse=collapse, tol=tol, 
+                                  min_frames_lib=min_frames_lib, 
+                                  max_frames_lib=max_frames_lib, 
+                                  full_output=False, verbose=False, 
+                                  weights=weights)
+        # pad again now                      
+        pca_res = np.pad(pca_res_tmp,pad,mode='constant',constant_values=0)
+    elif algo == pca:
+        hp_filter = algo_options.get('hp_filter',None)
+        hp_kernel = algo_options.get('hp_kernel',None)
+        scale_list = algo_options.get('scale_list',None)
+        ifs_collapse_range = algo_options.get('ifs_collapse_range','all')
+        nproc = algo_options.get('nproc','all')
+        
+        # not recommended, except if large-scale residual sky present (NIRC2-L')
+        if hp_filter is not None:
+            if 'median' in hp_filter:
+                cube = cube_filter_highpass(cube, mode=hp_filter, 
+                                            median_size=hp_kernel)
+            elif "gauss" in hp_filter:
+                cube = cube_filter_highpass(cube, mode=hp_filter, 
+                                            fwhm_size=hp_kernel)
+            else:
+                cube = cube_filter_highpass(cube, mode=hp_filter, 
+                                            kernel_size=hp_kernel)
+        
+        pca_res = pca(cube, angs, cube_ref, scale_list, ncomp, 
+                      svd_mode=svd_mode, scaling=scaling, imlib=imlib,
+                      interpolation=interpolation, collapse=collapse,
+                      ifs_collapse_range=ifs_collapse_range, nproc=nproc,
+                      weights=weights, verbose=False)
+    else:
+        algo_args = algo_options
+        pca_res = algo(cube, angs, **algo_args)
+        
+    if wedge is None:
+        delta_theta = np.amax(angs)-np.amin(angs)
+        if delta_theta>150:
+            delta_theta = 150 # if too much rotation, be less conservative
+            
+        theta_ini = (theta_guess+delta_theta)%360
+        theta_fin = theta_ini+delta_theta
+        wedge = (theta_ini,theta_fin)
+    elif len(wedge)==2:
+        if wedge[0]>wedge[1]:
+            msg = '2nd value of wedge smaller than first one => 360 was added'
+            print(msg)
+            wedge = (wedge[0],wedge[1]+360)
+    else:
+        raise TypeError("Wedge should have exactly 2 values")
+        
+    indices = get_annular_wedge(pca_res, radius_int, annulus_width, wedge=wedge)
+    
+    yy, xx = indices
+    mu = np.mean(pca_res[yy, xx])
+    sigma = np.std(pca_res[yy, xx])
+
+    return mu, sigma

--- a/vip_hci/negfc/speckle_noise.py
+++ b/vip_hci/negfc/speckle_noise.py
@@ -1,0 +1,286 @@
+#! /usr/bin/env python
+
+"""
+Module with routines allowing for the estimation of the uncertainty on the 
+parameters of an imaged companion associated to residual speckle noise.
+"""
+
+__author__ = 'O. Wertz, C. A. Gomez Gonzalez, V. Christiaens'
+__all__ = ['speckle_noise_uncertainty']
+
+#import itertools as itt
+from multiprocessing import cpu_count
+import numpy as np
+import matplotlib.pyplot as plt
+
+from ..conf.utils_conf import pool_map, iterable #eval_func_tuple
+from ..metrics import cube_inject_companions 
+from .simplex_optim import firstguess_simplex
+from .simplex_fmerit import get_mu_and_sigma
+from .utils_negfc import cube_planet_free
+from .mcmc_sampling import confidence
+
+
+def speckle_noise_uncertainty(cube, p_true, angle_range, derot_angles, algo, 
+                              psfn, plsc, fwhm, aperture_radius, cube_ref=None, 
+                              fmerit='sum', algo_options={}, transmission=None, 
+                              mu_sigma=None, wedge=None, weights=None, 
+                              force_rPA=False, nproc=None, simplex_options=None, 
+                              bins=None, save=False, output=None, verbose=True, 
+                              full_output=True, plot=False):
+    """
+    Step-by-step procedure used to determine the speckle noise uncertainty 
+    associated to the parameters of a companion candidate.
+
+      __ 
+     |   The steps 1 to 3 need to be performed for each angle.
+     | 
+     | - 1 - At the true planet radial distance and for a given angle, we 
+     |       inject a fake companion in our planet-free cube.
+     |   
+     | - 2 - Then, using the negative fake companion method, we determine the 
+     |       position and flux of the fake companion thanks to a Simplex  
+     |       Nelder-Mead minimization.
+     |
+     | - 3 - We calculate the offset between the true values of the position 
+     |       and the flux of the fake companion, and those obtained from the 
+     |       minimization. The results will be dependent on the angular 
+     |       position of the fake companion. 
+     |__
+     
+    The resulting distribution of deviations is then used to infer the 
+    1-sigma uncertainty on each parameter by fitting a 1d-gaussian.
+     
+    Parameters
+    ----------
+    cube: numpy array
+        The original ADI cube.    
+    p_true: tuple or numpy array with 3 elements
+        The radial separation, position angle (from x=0 axis) and flux 
+        associated to a given companion candidate for which the speckle 
+        uncertainty is to be evaluated. The planet will first 
+        be subtracted from the cube, then used for test injections.
+    angle_range: 1d numpy array
+        Range of angles (counted from x=0 axis, counter-clockwise) at which the 
+        fake companions will be injected, in [0,360[.
+    derot_angles: 1d numpy array
+        Derotation angles for ADI. Length should match input cube.
+    algo: python routine
+        Routine to be used to model and subtract the stellar PSF. From an input
+        cube, derotation angles, and optional arguments, it should return a 
+        post-processed frame.
+    psfn: 2d numpy array
+        2d array with the normalized PSF template. The PSF image must be 
+        centered wrt to the array. Therefore, it is recommended to run the 
+        function ``metrics/normalize_psf()`` to generate a centered and 
+        flux-normalized PSF template. 
+    plsc : float
+        Value of the plsc in arcsec/px. Only used for printing debug output when
+        ``verbose=True``.
+    algo_options: dict
+        Options for algo. To be provided as a dictionary. Can include ncomp 
+        (for PCA), svd_mode, collapse, imlib, interpolation, scaling, delta_rot
+    transmission: numpy array, optional
+        Array with 2 columns. First column is the radial separation in pixels. 
+        Second column is the off-axis transmission (between 0 and 1) at the 
+        radial separation given in column 1.
+    mu_sigma: tuple of 2 floats, bool or None, opt
+        If set to None: not used, and falls back to original version of the 
+        algorithm, using fmerit.
+        If a tuple of 2 elements: should be the mean and standard deviation of 
+        pixel intensities in an annulus centered on the lcoation of the 
+        companion candidate, excluding the area directly adjacent to the CC.
+        If set to anything else, but None/False/tuple: will compute said mean 
+        and standard deviation automatically.
+    force_rPA: bool, optional
+        Whether to only search for optimal flux, provided (r,PA).
+    fmerit: None
+        Figure of merit to use, if mu_sigma is None.
+    simplex_options: dict
+        All the required simplex parameters, for instance {'tol':1e-08, 
+        'max_iter':200}
+    bins: int or None, opt
+        Number of bins for histogram of parameter deviations. If None, will be
+        determined automatically based on number of injected fake companions.
+    full_output: bool, optional
+        Whether to return more outputs.
+    output: str, optional
+        The name of the output file (if save is True)    
+    save: bool, optional
+        If True, the result are pickled.
+    verbose: bool, optional
+        If True, informations are displayed in the shell.
+    plot: bool, optional
+        Whether to plot the gaussian fit to the distributions of parameter 
+        deviations (between retrieved and injected).
+     
+    Returns:
+    --------
+    sp_unc: numpy ndarray of 3 elements
+        Uncertainties on the radius, position angle and flux of the companion,
+        respectively, associated to residual speckle noise. Only 1 element if
+        force_rPA is set to True.
+    If full_output, also returns:
+        mean_dev: numpy ndarray of 3 elements
+            Mean deviation for each of the 3 parameters
+        p_simplex: numpy ndarray n_fc x 3
+            Parameters retrieved by the simplex for the injected fake 
+            companions; n_fc is the number of injected  
+        offset: numpy ndarray n_fc x 3
+            Deviations with respect to the values used for injection of the 
+            fake companions.
+        chi2, nit, success: numpy ndarray of length n_fc 
+            Outputs from the simplex function for the retrieval of the 
+            parameters of each injected companion: chi square value, number of
+            iterations and whether the simplex converged, respectively.
+    """    
+    
+    if not nproc:   # Hyper-threading "duplicates" the cores -> cpu_count/2
+        nproc = (cpu_count()/2)
+    
+    if verbose:
+        print('')
+        print('#######################################################')
+        print('###            SPECKLE NOISE DETERMINATION          ###')
+        print('#######################################################')
+        print('')
+    
+    r_true, theta_true, f_true = p_true
+
+    if angle_range[0]%360 == angle_range[-1]%360:
+        angle_range = angle_range[:-1]
+                  
+    if verbose:              
+        print('Number of steps: {}'.format(angle_range.shape[0]))
+        print('')
+    
+    imlib = algo_options.get('imlib','opencv')
+    interpolation = algo_options.get('interpolation','lanczos4')
+    
+    # FIRST SUBTRACT THE TRUE COMPANION CANDIDATE
+    planet_parameter = np.array([[r_true, theta_true, f_true]])
+    cube_pf = cube_planet_free(planet_parameter, cube, derot_angles, psfn, plsc, 
+                               imlib=imlib, interpolation=interpolation,
+                               transmission=transmission)
+
+    # Measure mu and sigma once in the annulus (instead of each MCMC step)
+    if isinstance(mu_sigma,tuple):
+        if len(mu_sigma)!=2:
+            raise TypeError("If a tuple, mu_sigma must have 2 elements")
+    elif mu_sigma is not None:
+        ncomp = algo_options.get('ncomp', None)
+        annulus_width = algo_options.get('annulus_width', int(fwhm))
+        if weights is not None:
+            if not len(weights)==cube.shape[0]:
+                raise TypeError("Weights should have same length as cube axis 0")
+            norm_weights = weights/np.sum(weights)
+        else:
+            norm_weights=weights
+        mu_sigma = get_mu_and_sigma(cube, derot_angles, ncomp, annulus_width, 
+                                    aperture_radius, fwhm, r_true, theta_true, 
+                                    cube_ref=cube_ref, wedge=wedge, algo=algo, 
+                                    weights=norm_weights, 
+                                    algo_options=algo_options)
+      
+    res = pool_map(nproc, _estimate_speckle_one_angle, iterable(angle_range), 
+                   cube_pf, psfn, derot_angles, r_true, f_true, plsc, fwhm,
+                   aperture_radius, cube_ref, fmerit, algo, algo_options, 
+                   transmission, mu_sigma, weights, force_rPA, simplex_options, 
+                   verbose=verbose)
+    residuals = np.array(res)
+ 
+    if verbose:  
+        print("residuals (offsets): ", residuals[:,3],residuals[:,4],
+              residuals[:,5])
+
+    p_simplex = np.transpose(np.vstack((residuals[:,0],residuals[:,1],
+                                        residuals[:,2])))
+    offset = np.transpose(np.vstack((residuals[:,3],residuals[:,4],
+                            residuals[:,5])))
+    print(offset)
+    chi2 = residuals[:,6]
+    nit = residuals[:,7]
+    success = residuals[:,8]
+
+    if save:
+        speckles = {'r_true':r_true,
+                    'angle_range': angle_range,
+                    'f_true':f_true,
+                    'r_simplex':residuals[:,0],
+                    'theta_simplex':residuals[:,1],
+                    'f_simplex':residuals[:,2],
+                    'offset': offset,
+                    'chi2': chi2,
+                    'nit': nit,
+                    'success': success}
+        
+        if output is None:
+            output = 'speckles_noise_result'
+
+        from pickle import Pickler
+        with open(output,'wb') as fileSave:
+            myPickler = Pickler(fileSave)
+            myPickler.dump(speckles)
+
+
+    # Calculate 1 sigma of distribution of deviations
+    print(offset.shape)
+    if force_rPA:
+        offset = offset[:,2]
+        print(offset.shape)
+    if bins is None:
+        bins = offset.shape[0]
+    mean_dev, sp_unc = confidence(offset, cfd=68.27, bins=bins, 
+                                  gaussian_fit=True, verbose=True, save=False, 
+                                  output_dir='', force=True)
+    if plot:
+        plt.show()
+
+    if full_output:
+        return sp_unc, mean_dev, p_simplex, offset, chi2, nit, success
+    else:
+        return sp_unc
+
+
+def _estimate_speckle_one_angle(angle, cube_pf, psfn, angs, r_true, f_true, 
+                                plsc, fwhm, aperture_radius, cube_ref, fmerit, 
+                                algo, algo_options, transmission, mu_sigma, 
+                                weights, force_rPA, simplex_options, 
+                                verbose=True):
+                         
+    if verbose:
+        print('Process is running for angle: {:.2f}'.format(angle))
+
+    cube_fc = cube_inject_companions(cube_pf, psfn, angs, flevel=f_true, 
+                                     plsc=plsc, rad_dists=[r_true], 
+                                     n_branches=1, theta=angle, 
+                                     transmission=transmission, verbose=False)
+    
+    ncomp = algo_options.get('ncomp', None)
+    annulus_width = algo_options.get('annulus_width', int(fwhm))
+    
+    res_simplex = firstguess_simplex((r_true,angle,f_true), cube_fc, angs, psfn, 
+                                     plsc, ncomp, fwhm, annulus_width, 
+                                     aperture_radius, cube_ref=cube_ref,
+                                     fmerit=fmerit, algo=algo, 
+                                     algo_options=algo_options,
+                                     transmission=transmission, 
+                                     mu_sigma=mu_sigma, weights=weights, 
+                                     force_rPA=force_rPA, 
+                                     options=simplex_options, 
+                                     verbose=False)
+
+    if force_rPA:
+        simplex_res_f, = res_simplex.x
+        simplex_res_r, simplex_res_PA = r_true, angle
+    else:
+        simplex_res_r, simplex_res_PA, simplex_res_f = res_simplex.x
+    offset_r = simplex_res_r - r_true
+    offset_PA = simplex_res_PA - angle
+    offset_f = simplex_res_f - f_true       
+    chi2 = res_simplex.fun
+    nit = res_simplex.nit
+    success = res_simplex.success    
+    
+    return (simplex_res_r, simplex_res_PA, simplex_res_f, offset_r, offset_PA, 
+            offset_f, chi2, nit, success)

--- a/vip_hci/negfc/utils_mcmc.py
+++ b/vip_hci/negfc/utils_mcmc.py
@@ -1,0 +1,154 @@
+#! /usr/bin/env python
+
+"""
+Module with utility functions to the MCMC (``emcee``) sampling for NEGFC 
+parameter estimation.
+"""
+
+
+__author__ = 'V. Christiaens, O. Wertz, Carlos Alberto Gomez Gonzalez'
+__all__ = ['gelman_rubin',
+           'gelman_rubin_from_chain',
+           'autocorr_func_1d',
+           'auto_window',
+           'autocorr',
+           'autocorr_test']
+
+import numpy as np
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+def gelman_rubin(x):
+    """
+    Determine the Gelman-Rubin \hat{R} statistical test between Markov chains.
+    
+    Parameters
+    ----------
+    x: numpy.array
+        The numpy.array on which the Gelman-Rubin test is applied. This array
+        should contain at least 2 set of data, i.e. x.shape >= (2,).
+        
+    Returns
+    -------
+    out: float
+        The Gelman-Rubin \hat{R}.
+
+    Example
+    -------
+    >>> x1 = np.random.normal(0.0,1.0,(1,100))
+    >>> x2 = np.random.normal(0.1,1.3,(1,100))
+    >>> x = np.vstack((x1,x2))
+    >>> gelman_rubin(x)
+    1.0366629898991262
+    >>> gelman_rubin(np.vstack((x1,x1)))
+    0.99
+        
+    """
+    if np.shape(x) < (2,):
+        msg = 'Gelman-Rubin diagnostic requires multiple chains of the same '
+        msg += 'length'
+        raise ValueError(msg)
+
+    try:
+        m, n = np.shape(x)
+    except ValueError:
+        print("Bad shape for the chains")
+        return
+
+    # Calculate between-chain variance
+    B_over_n = np.sum((np.mean(x, 1) - np.mean(x)) ** 2) / (m - 1)
+
+    # Calculate within-chain variances
+    W = np.sum([(x[i] - xbar) ** 2 for i, xbar in
+                enumerate(np.mean(x, 1))]) / (m * (n - 1))
+    # (over) estimate of variance
+    s2 = W * (n - 1) / n + B_over_n
+
+    # Pooled posterior variance estimate
+    V = s2 + B_over_n / m
+
+    # Calculate PSRF
+    R = V / W
+
+    return R
+
+
+def gelman_rubin_from_chain(chain, burnin):
+    """ Pack the MCMC chain and determine the Gelman-Rubin \hat{R} statistical
+    test. In other words, two sub-sets are extracted from the chain (burnin
+    parts are taken into account) and the Gelman-Rubin statistical test is
+    performed.
+    
+    Parameters
+    ----------
+    chain: numpy.array
+        The MCMC chain with the shape walkers x steps x model_parameters
+    burnin: float \in [0,1]
+        The fraction of a walker which is discarded.
+        
+    Returns
+    -------
+    out: float
+        The Gelman-Rubin \hat{R}.
+        
+    """
+    dim = chain.shape[2]
+    k = chain.shape[1]
+    thr0 = int(np.floor(burnin*k))
+    thr1 = int(np.floor((1-burnin) * k * 0.25))
+    rhat = np.zeros(dim)
+    for j in range(dim):
+        part1 = chain[:, thr0:thr0+thr1, j].reshape((-1))
+        part2 = chain[:, thr0+3*thr1:thr0+4*thr1, j].reshape((-1))
+        series = np.vstack((part1, part2))
+        rhat[j] = gelman_rubin(series)
+    return rhat
+
+
+def next_pow_two(n):
+    i = 1
+    while i < n:
+        i = i << 1
+    return i
+
+
+def autocorr_func_1d(x, norm=True):
+    x = np.atleast_1d(x)
+    if len(x.shape) != 1:
+        raise ValueError("invalid dimensions for 1D autocorrelation function")
+    n = next_pow_two(len(x))
+
+    # Compute the FFT and then (from that) the auto-correlation function
+    f = np.fft.fft(x - np.mean(x), n=2 * n)
+    acf = np.fft.ifft(f * np.conjugate(f))[: len(x)].real
+    acf /= 4 * n
+
+    # Optionally normalize
+    if norm:
+        acf /= acf[0]
+
+    return acf
+
+
+def auto_window(taus, c):
+    m = np.arange(len(taus)) < c * taus
+    if np.any(m):
+        return np.argmin(m)
+    return len(taus) - 1
+
+
+def autocorr(y, c=5.0):
+    f = np.zeros(y.shape[1])
+    for yy in y:
+        f += autocorr_func_1d(yy)
+    f /= len(y)
+    taus = 2.0 * np.cumsum(f) - 1.0
+    window = auto_window(taus, c)
+    return taus[window]
+
+
+def autocorr_test(chain):
+    N = chain.shape[1]
+    tau = autocorr(chain)
+    return tau/N

--- a/vip_hci/negfc/utils_negfc.py
+++ b/vip_hci/negfc/utils_negfc.py
@@ -5,6 +5,7 @@ Module with post-processing related functions called from within the NFC
 algorithm.
 """
 
+__author__ = 'Carlos Alberto Gomez Gonzalez'
 __all__ = ['cube_planet_free']
 
 import numpy as np
@@ -14,7 +15,7 @@ from matplotlib.pyplot import plot, xlim, ylim, axes, gca, show
 
 
 def cube_planet_free(planet_parameter, cube, angs, psfn, plsc, imlib='opencv',
-                     interpolation='lanczos4'):
+                     interpolation='lanczos4',transmission=None):
     """
     Return a cube in which we have injected negative fake companion at the
     position/flux given by planet_parameter.
@@ -69,14 +70,15 @@ def cube_planet_free(planet_parameter, cube, angs, psfn, plsc, imlib='opencv',
                                                 theta=planet_parameter[i, 1, j],
                                                 imlib=imlib, 
                                                 interpolation=interpolation,
-                                                verbose=False)
-        else:    
+                                                verbose=False,
+                                                transmission=transmission)
+        else:
             cpf = cube_inject_companions(cube_temp, psfn, angs,
                                          flevel=-planet_parameter[i, 2], plsc=plsc,
                                          rad_dists=[planet_parameter[i, 0]],
                                          n_branches=1, theta=planet_parameter[i, 1],
                                          imlib=imlib, interpolation=interpolation,
-                                         verbose=False)
+                                         verbose=False, transmission=transmission)
     return cpf
 
 

--- a/vip_hci/pca/svd.py
+++ b/vip_hci/pca/svd.py
@@ -30,12 +30,10 @@ from numpy import linalg
 from matplotlib import pyplot as plt 
 from scipy.sparse.linalg import svds
 from sklearn.decomposition import randomized_svd
-from sklearn.metrics import mean_squared_error as MSE
-from sklearn.metrics import mean_absolute_error as MAE
 from sklearn.utils import check_random_state
 from pandas import DataFrame
 from ..conf import timing, time_ini, sep, Progressbar
-from ..var import matrix_scaling, prepare_matrix, matrix_scaling
+from ..var import matrix_scaling, prepare_matrix
 from ..preproc import check_scal_vector, cube_crop_frames
 from ..preproc import cube_rescaling_wavelengths as scwave
 from ..conf import vip_figsize, check_array

--- a/vip_hci/preproc/recentering.py
+++ b/vip_hci/preproc/recentering.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+ #! /usr/bin/env python
 
 """
 Module containing functions for cubes frame registration.
@@ -37,9 +37,10 @@ from . import frame_crop
 from ..conf import time_ini, timing, Progressbar
 from ..conf.utils_conf import vip_figsize, check_array
 from ..conf.utils_conf import pool_map, iterable
+from ..stats import frame_basic_stats
 from ..var import (get_square, frame_center, get_annulus_segments,
-                   fit_2dmoffat, fit_2dgaussian, cube_filter_lowpass,
-                   cube_filter_highpass)
+                   fit_2dmoffat, fit_2dgaussian, fit_2dairydisk,
+                   fit_2d2gaussian, cube_filter_lowpass, cube_filter_highpass)
 from ..preproc import cube_crop_frames
 
 
@@ -381,7 +382,7 @@ def frame_center_satspots(array, xy, subi_size=19, sigfactor=6, shift=False,
 
 
 def cube_recenter_satspots(array, xy, subi_size=19, sigfactor=6, plot=True,
-                           fit_type='moff', debug=False, verbose=True, 
+                           fit_type='moff', lbda=None, debug=False, verbose=True, 
                            full_output=False):
     """ Function analog to frame_center_satspots but for image sequences. It
     actually will call frame_center_satspots for each image in the cube. The
@@ -401,6 +402,10 @@ def cube_recenter_satspots(array, xy, subi_size=19, sigfactor=6, plot=True,
         in an X configuration, the order is the following: top-left, top-right,
         bottom-left and bottom-right. When the spots are in an + (cross-like)
         configuration, the order is the following: top, right, left, bottom.
+        If wavelength vector is not provided, assumes all sat spots of the cube
+        are at a similar location. If wavelength is provided, only coordinates 
+        of the sat spots in the first channel should be provided. The boxes
+        location in other channels will be scaled accordingly.
     subi_size : int, optional
         Size of subimage where the fitting is done.
     sigfactor : int, optional
@@ -412,6 +417,9 @@ def cube_recenter_satspots(array, xy, subi_size=19, sigfactor=6, plot=True,
         Whether to plot the shifts.
     fit_type: str, optional {'gaus','moff'}
         Type of 2d fit to infer the centroid of the satellite spots.
+    lbda: 1d array or list, opt
+        Wavelength vector. If provided, the subimages will be scaled accordingly 
+        to follow the motion of the satellite spots.
     debug : bool, optional
         If True debug information is printed and plotted (fit and residuals,
         intersections and shifts). This has to be used carefully as it can
@@ -444,10 +452,24 @@ def cube_recenter_satspots(array, xy, subi_size=19, sigfactor=6, plot=True,
     sat_x = np.zeros([n_frames,4])
     array_rec = []
 
+    if lbda is not None:
+        cy, cx = frame_center(array[0])
+        final_xy = []
+        rescal = lbda/lbda[0]
+        for i in range(n_frames):
+            xy_new = []
+            for s in range(4):
+                xy_new.append((cx+rescal[i]*(xy[s][0]-cx),cy+rescal[i]*(xy[s][1]-cy)))
+            xy_new = tuple(xy_new)
+            final_xy.append(xy_new)
+    else:
+        final_xy = [xy for i in range(n_frames)]
+
     if verbose:
+        print("Final xy positions for sat spots:", final_xy)
         print('Looping through the frames, fitting the intersections:')
     for i in Progressbar(range(n_frames), verbose=verbose):
-        res = frame_center_satspots(array[i], xy, debug=debug, shift=True,
+        res = frame_center_satspots(array[i], final_xy[i], debug=debug, shift=True,
                                     subi_size=subi_size, sigfactor=sigfactor,
                                     fit_type=fit_type, verbose=False)
         array_rec.append(res[0])
@@ -827,7 +849,7 @@ def cube_recenter_dft_upsampling(array, center_fr1=None, negative=False,
                   'the Gaussian 2d fit')
             cy_1, cx_1 = frame_center(array[0])
         else:
-            cx_1, cy_1 = center_fr1
+            cy_1, cx_1 = center_fr1
         if not isinstance(subi_size, int):
             raise ValueError('subi_size must be an integer or None')
         if subi_size < fwhm:
@@ -942,8 +964,9 @@ def _shift_dft(array_rec, array, frnum, upsample_factor, interpolation, imlib):
 
 def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
                         nproc=1, imlib='opencv', interpolation='lanczos4',
-                        offset=None, negative=False, threshold=False,
-                        save_shifts=False, full_output=False, verbose=True,
+                        offset=None, negative=False, threshold=False, 
+                        sigfactor=2, fix_neg=False, params_2g=None, 
+                        save_shifts=False, full_output=False, verbose=True, 
                         debug=False, plot=True):
     """ Recenters the frames of a cube. The shifts are found by fitting a 2d
     Gaussian or Moffat to a subimage centered at ``xy``. This assumes the frames
@@ -954,8 +977,12 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
     ----------
     array : numpy ndarray
         Input cube.
-    xy : tuple of int
-        Coordinates of the center of the subimage (wrt the original frame).
+    xy : tuple of integers or floats
+        Integer coordinates of the center of the subimage (wrt the original frame).
+        For the double gaussian fit with fixed negative gaussian, this should
+        correspond to the exact location of the center of the negative gaussiam
+        (e.g. the center of the coronagraph mask) - in that case a tuple of 
+        floats is also accepted.
     fwhm : float or numpy ndarray
         FWHM size in pixels, either one value (float) that will be the same for
         the whole cube, or an array of floats with the same dimension as the
@@ -964,8 +991,9 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
     subi_size : int, optional
         Size of the square subimage sides in pixels.
     model : str, optional
-        Sets the type of fit to be used. 'gauss' for a 2d Gaussian fit and
-        'moff' for a 2d Moffat fit.
+        Sets the type of fit to be used. 'gauss' for a 2d Gaussian fit,
+        'moff' for a 2d Moffat fit, 'airy' for a 2d Airy disk fit, and 
+        '2gauss' for a 2d double Gaussian (positive+negative) fit.
     nproc : int or None, optional
         Number of processes (>1) for parallel computing. If 1 then it runs in
         serial. If None the number of processes will be set to (cpu_count()/2).
@@ -979,9 +1007,27 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
         serves as the offset of the fitted area wrt the center of the 2d arrays.
     negative : bool, optional
         If True a negative 2d Gaussian/Moffat fit is performed.
+    fix_neg: bool, optional
+        In case of a double gaussian fit, whether to fix the parameters of the
+        megative gaussian. If True, they should be provided in params_2g.
+    params_2g: None or dictionary, optional
+        In case of a double gaussian fit, dictionary with either fixed or first 
+        guess parameters for the double gaussian. E.g.: 
+        params_2g = {'fwhm_neg': 3.5, 'fwhm_pos': (3.5,4.2), 'theta_neg': 48., 
+        'theta_pos':145., 'neg_amp': 0.5}
+        fwhm_neg: float or tuple with fwhm of neg gaussian  
+        fwhm_pos: can be a tuple for x and y axes of pos gaussian (replaces fwhm)    
+        theta_neg: trigonometric angle of the x axis of the neg gaussian (deg)
+        theta_pos: trigonometric angle of the x axis of the pos gaussian (deg)
+        neg_amp: amplitude of the neg gaussian wrt the amp of the positive one
+        Note: it is always recommended to provide theta_pos and theta_neg for a 
+        better fit.
     threshold : bool, optional
         If True the background pixels (estimated using sigma clipped statistics)
-        will be replaced by small random Gaussian noise.
+        will be replaced by small random Gaussian noise (recommended for 2g).
+    sigfactor: float, optional
+        If thresholding is performed, set the the threshold in terms of 
+        gaussian sigma in the subimage (will depend on your cropping size).
     save_shifts : bool, optional
         Whether to save the shifts to a file in disk.
     full_output : bool, optional
@@ -997,7 +1043,7 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
 
     Returns
     -------
-    array_recentered : numpy ndarray
+    array_rec: numpy ndarray
         The recentered cube.
     y : numpy ndarray
         [full_output=True] 1d array with the shifts in y.
@@ -1014,8 +1060,7 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
 
     if not isinstance(subi_size, int):
         raise ValueError('`subi_size` must be an integer')
-    if subi_size < fwhm:
-        raise ValueError('`subi_size` (value in pixels) is too small')
+        
     if sizey % 2 == 0:
         if subi_size % 2 != 0:
             subi_size += 1
@@ -1027,7 +1072,7 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
             print('`subi_size` is even (while frame size is odd)')
             print('Setting `subi_size` to {} pixels'.format(subi_size))
 
-    if isinstance(fwhm, (float, int)):
+    if isinstance(fwhm, (float, int, np.float32, np.float64)):
         fwhm = np.ones(n_frames) * fwhm
 
     if debug and array.shape[0] > 20:
@@ -1037,38 +1082,67 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
 
     if xy is not None:
         pos_x, pos_y = xy
-        if not isinstance(pos_x, int) or not isinstance(pos_y, int):
+        cond = model != '2gauss'
+        if (not isinstance(pos_x, int) or not isinstance(pos_y, int)) and cond:
             raise TypeError('`xy` must be a tuple of integers')
     else:
         pos_y, pos_x = frame_center(array[0])
 
     cy, cx = frame_center(array[0])
-    array_recentered = np.empty_like(array)
+    array_rec = np.empty_like(array)
 
     if model == 'gauss':
         func = _centroid_2dg_frame
     elif model == 'moff':
         func = _centroid_2dm_frame
+    elif model == 'airy':
+        func = _centroid_2da_frame
+    elif model == '2gauss':
+        func = _centroid_2d2g_frame
     else:
         raise ValueError('model not recognized')
 
     if nproc is None:
         nproc = cpu_count() // 2        # Hyper-threading doubles the # of cores
 
-    if nproc == 1:
+    if nproc == 1:                 
         res = []
-        print('2d Gauss-fitting')
+        print('2d {}-fitting'.format(model))
         for i in Progressbar(range(n_frames), desc="frames", verbose=verbose):
-            res.append(func(array, i, subi_size, pos_y, pos_x, negative, debug,
-                            fwhm[i], threshold))
+            if model == "2gauss":
+                args = [array, i, subi_size, pos_y, pos_x, debug, fwhm[i], 
+                        fix_neg, params_2g, threshold, sigfactor]
+            else:
+                args = [array, i, subi_size, pos_y, pos_x, negative, debug,
+                        fwhm[i], threshold, sigfactor]
+  
+            res.append(func(*args))
         res = np.array(res)
     elif nproc > 1:
-        res = pool_map(nproc, func, array, iterable(range(n_frames)), subi_size,
-                       pos_y, pos_x, negative, debug, iterable(fwhm), threshold)
+        if model == "2gauss":
+            args = [array, iterable(range(n_frames)), subi_size, pos_y, pos_x, 
+                    debug, iterable(fwhm), fix_neg, params_2g, threshold,
+                    sigfactor]
+        else:
+            args = [array, iterable(range(n_frames)), subi_size, pos_y, pos_x, 
+                    negative, debug, iterable(fwhm), threshold, sigfactor]
+        res = pool_map(nproc, func, *args)
         res = np.array(res)
     y = cy - res[:, 0]
     x = cx - res[:, 1]
-
+    
+    if model == "2gauss" and not fix_neg:
+        y_neg = res[:, 2]
+        x_neg = res[:, 3]
+        fwhm_x = res[:, 4]
+        fwhm_y = res[:, 5]
+        fwhm_neg_x = res[:, 6]
+        fwhm_neg_y = res[:, 7]
+        theta = res[:, 8]
+        theta_neg = res[:, 9]
+        amp_pos = res[:,10]
+        amp_neg = res[:, 11]
+        
     if offset is not None:
         offx, offy = offset
         y -= offy
@@ -1078,7 +1152,7 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
         if debug:
             print("\nShifts in X and Y")
             print(x[i], y[i])
-        array_recentered[i] = frame_shift(array[i], y[i], x[i], imlib=imlib,
+        array_rec[i] = frame_shift(array[i], y[i], x[i], imlib=imlib,
                                           interpolation=interpolation)
 
     if verbose:
@@ -1098,6 +1172,11 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
         la = 'Histogram'
         _ = plt.hist(x, bins=b, alpha=0.5, label=la + ' shifts X')
         _ = plt.hist(y, bins=b, alpha=0.5, label=la + ' shifts Y')
+        if model == "2gauss" and not fix_neg:
+            _ = plt.hist(cx-x_neg, bins=b, alpha=0.5, 
+                         label=la + ' shifts X (neg gaussian)')
+            _ = plt.hist(cy-y_neg, bins=b, alpha=0.5, 
+                         label=la + ' shifts Y (neg gaussian)')            
         plt.legend(loc='best')
         plt.ylabel('Bin counts')
         plt.xlabel('Pixels')
@@ -1105,13 +1184,17 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
     if save_shifts:
         np.savetxt('recent_gauss_shifts.txt', np.transpose([y, x]), fmt='%f')
     if full_output:
-        return array_recentered, y, x
+        if model == "2gauss" and not fix_neg:
+            return (array_rec, y, x, y_neg, x_neg, fwhm_x, fwhm_y, fwhm_neg_x, 
+                    fwhm_neg_y, theta, theta_neg, amp_pos, amp_neg)
+        
+        return array_rec, y, x
     else:
-        return array_recentered
+        return array_rec
 
 
 def _centroid_2dg_frame(cube, frnum, size, pos_y, pos_x, negative, debug,
-                        fwhm, threshold=False):
+                        fwhm, threshold=False, sigfactor=1):
     """ Finds the centroid by using a 2d gaussian fitting in one frame from a
     cube.
     """
@@ -1122,7 +1205,7 @@ def _centroid_2dg_frame(cube, frnum, size, pos_y, pos_x, negative, debug,
         sub_image = -sub_image + np.abs(np.min(-sub_image))
 
     y_i, x_i = fit_2dgaussian(sub_image, crop=False, fwhmx=fwhm, fwhmy=fwhm,
-                              threshold=threshold, sigfactor=1, debug=debug,
+                              threshold=threshold, sigfactor=sigfactor, debug=debug,
                               full_output=False)
     y_i = y1 + y_i
     x_i = x1 + x_i
@@ -1130,7 +1213,7 @@ def _centroid_2dg_frame(cube, frnum, size, pos_y, pos_x, negative, debug,
 
 
 def _centroid_2dm_frame(cube, frnum, size, pos_y, pos_x, negative, debug,
-                        fwhm, threshold=False):
+                        fwhm, threshold=False, sigfactor=1):
     """ Finds the centroid by using a 2d moffat fitting in one frame from a
     cube.
     """
@@ -1141,19 +1224,82 @@ def _centroid_2dm_frame(cube, frnum, size, pos_y, pos_x, negative, debug,
         sub_image = -sub_image + np.abs(np.min(-sub_image))
 
     y_i, x_i = fit_2dmoffat(sub_image, crop=False, fwhm=fwhm, debug=debug,
-                            threshold=threshold, full_output=False)
+                            threshold=threshold, sigfactor=sigfactor, 
+                            full_output=False)
     y_i = y1 + y_i
     x_i = x1 + x_i
     return y_i, x_i
 
 
+def _centroid_2da_frame(cube, frnum, size, pos_y, pos_x, negative, debug,
+                        fwhm, threshold=False, sigfactor=1):
+    """ Finds the centroid by using a 2d Airy disk fitting in one frame from a
+    cube.
+    """
+    sub_image, y1, x1 = get_square(cube[frnum], size=size, y=pos_y, x=pos_x,
+                                   position=True)
+    # negative fit
+    if negative:
+        sub_image = -sub_image + np.abs(np.min(-sub_image))
+
+    y_i, x_i = fit_2dairydisk(sub_image, crop=False, fwhm=fwhm, 
+                              threshold=threshold, sigfactor=sigfactor, 
+                              full_output=False, debug=debug)                   
+    y_i = y1 + y_i
+    x_i = x1 + x_i
+    return y_i, x_i
+    
+    
+def _centroid_2d2g_frame(cube, frnum, size, pos_y, pos_x, debug=False, fwhm=4, 
+                         fix_neg=True, params_2g=None, threshold=False,
+                         sigfactor=1):
+    """ Finds the centroid by using a 2d double gaussian (positive+negative) 
+    fitting in one frame from a cube. To be called from within 
+    cube_recenter_doublegauss2d_fit().
+    """
+
+    size = min(cube[frnum].shape[0],cube[frnum].shape[1],size)
+    #sub_image, y1, x1 = get_square_robust(cube[frnum], size=size, y=pos_y, 
+    #                                      x=pos_x, position=True)
+    if isinstance(params_2g,dict):
+        fwhm_neg = params_2g.get('fwhm_neg', 0.8*fwhm)
+        fwhm_pos = params_2g.get('fwhm_pos', 2*fwhm)
+        theta_neg = params_2g.get('theta_neg', 0.)
+        theta_pos = params_2g.get('theta_pos', 0.)
+        neg_amp = params_2g.get('neg_amp', 1)
+        
+    res_DF = fit_2d2gaussian(cube[frnum], crop=True, cent=(pos_x,pos_y), 
+                          cropsize=size, fwhm_neg=fwhm_neg, fwhm_pos=fwhm_pos, 
+                          neg_amp=neg_amp, fix_neg=fix_neg, theta_neg=theta_neg, 
+                          theta_pos=theta_pos, threshold=threshold, 
+                          sigfactor=sigfactor, full_output=True, debug=debug)
+    y_i = res_DF['centroid_y']
+    x_i = res_DF['centroid_x']
+
+    if not fix_neg:
+        y_neg = res_DF['centroid_y_neg']
+        x_neg = res_DF['centroid_x_neg']
+        fwhm_x = res_DF['fwhm_x']
+        fwhm_y = res_DF['fwhm_y']
+        fwhm_neg_x = res_DF['fwhm_x_neg']
+        fwhm_neg_y = res_DF['fwhm_y_neg']
+        theta = res_DF['theta']
+        theta_neg = res_DF['theta_neg']
+        amp_pos = res_DF['amplitude']
+        amp_neg = res_DF['amplitude_neg']
+        return (y_i, x_i, y_neg, x_neg, fwhm_x, fwhm_y, fwhm_neg_x, fwhm_neg_y, 
+                theta, theta_neg, amp_pos, amp_neg)
+    return y_i, x_i
+    
+
 # TODO: make parameter names match the API
 def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
                                gammaval=1, min_spat_freq=0.5, max_spat_freq=3,
-                               fwhm=4, debug=False, negative=True,
-                               recenter_median=False, subframesize=20,
-                               imlib='opencv', interpolation='bilinear',
-                               save_shifts=False, plot=True):
+                               fwhm=4, debug=False, recenter_median=False,
+                               fit_type='gaus', negative=True, crop=True,
+                               subframesize=21, imlib='opencv', 
+                               interpolation='lanczos4', plot=True, 
+                               full_output=False):
     """ Registers frames based on the median speckle pattern. Optionally centers
     based on the position of the vortex null in the median frame. Images are
     filtered to isolate speckle spatial frequencies.
@@ -1177,10 +1323,18 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
         Full width at half maximum.
     debug : bool, optional
         Outputs extra info.
-    negative : bool, optional
-        Use a negative gaussian fit to determine the center of the median frame.
     recenter_median : bool, optional
-        Recenter the frames at each iteration based on the gaussian fit.
+        Recenter the frames at each iteration based on a 2d fit.
+    fit_type : str, optional
+        If recenter_median is True, this is the model to which the image is 
+        fitted to for recentering. 'gaus' works well for NIRC2_AGPM data. 
+        'ann' works better for NACO+AGPM data.
+    negative : bool, optional
+        If True, uses a negative gaussian fit to determine the center of the 
+        median frame.
+    crop: bool, optional
+        Whether to calculate the recentering on a cropped version of the cube
+        that is speckle-dominated (recommended).
     subframesize : int, optional
         Sub-frame window size used. Should cover the region where speckles are
         the dominant noise source.
@@ -1188,30 +1342,39 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
         Image processing library to use.
     interpolation : str, optional
         Interpolation method to use.
-    save_shifts : bool, optional
-        Whether to save the shifts to a file in disk.
     plot : bool, optional
         If True, the shifts are plotted.
+    full_ouput: bool, optional
+        Whether to return more varibales, useful for debugging.
 
     Returns
     -------
-    array_shifted : numpy ndarray
-        Shifted 2d array.
+    if full_output is False, returns:
+        cube_reg_sci: Registered science cube (numpy 3d ndarray)
+    
+        If cube_ref is not None, also returns:
 
-    If cube_ref is not None, returns:
-    cube_reg_sci: Registered science cube.
-    cube_reg_ref: Ref. cube registered to science frames.
-    cum_x_shifts_sci: Vector of x shifts for science frames.
-    cum_y_shifts_sci: Vector of y shifts for science frames.
-    cum_x_shifts_ref: Vector of x shifts for ref. frames.
-    cum_y_shifts_ref: Vector of y shifts for ref. frames.
+        cube_reg_ref: Ref. cube registered to science frames (np 3d ndarray)
+    
+    If full_output is True, returns in addition to the above:
+        cube_sci_lpf: Low+high-pass filtered science cube (np 3d ndarray)
+        cube_stret: Cube with stretched values used for cross-corr (np 3d ndarray)
+        cum_x_shifts_sci: Vector of x shifts for science frames (np 1d array)
+        cum_y_shifts_sci: Vector of y shifts for science frames (np 1d array)
+        
+        And if cube_ref is not None, also returns:
+        cum_x_shifts_ref: Vector of x shifts for ref. frames.
+        cum_y_shifts_ref: Vector of y shifts for ref. frames.
 
-    Otherwise, returns: cube_reg_sci, cum_x_shifts_sci, cum_y_shifts_sci
+    
     """
     n, y, x = cube_sci.shape
     check_array(cube_sci, dim=3)
 
-    if not subframesize < y/2.:
+    if recenter_median and fit_type not in {'gaus','ann'}:
+        raise TypeError("fit type not recognized. Should be 'ann' or 'gaus'")
+
+    if crop and not subframesize < y/2.:
         raise ValueError('`Subframesize` is too large')
 
     if cube_ref is not None:
@@ -1220,10 +1383,16 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
     else:
         ref_star = False
 
-    cube_sci_subframe = cube_crop_frames(cube_sci, subframesize, verbose=False)
-    if ref_star:
-        cube_ref_subframe = cube_crop_frames(cube_ref, subframesize,
-                                             verbose=False)
+    if crop:
+        cube_sci_subframe = cube_crop_frames(cube_sci, subframesize, verbose=False)
+        if ref_star:
+            cube_ref_subframe = cube_crop_frames(cube_ref, subframesize,
+                                                 verbose=False)
+    else:
+        subframesize = cube_sci.shape[-1]
+        cube_sci_subframe = cube_sci.copy()
+        if ref_star:
+            cube_ref_subframe = cube_ref.copy()             
 
     ceny, cenx = frame_center(cube_sci_subframe[0])
     print('Sub frame shape: {}'.format(cube_sci_subframe.shape))
@@ -1242,17 +1411,23 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
     # Remove spatial frequencies <0.5 lam/D and >3lam/D to isolate speckles
     cube_sci_hpf = cube_filter_highpass(cube_sci_lpf, 'median-subt',
                                         median_size=median_size, verbose=False)
-    cube_sci_lpf = cube_filter_lowpass(cube_sci_hpf, 'gauss',
-                                       fwhm_size=min_spat_freq * fwhm, verbose=False)
+    if min_spat_freq>0:
+        cube_sci_lpf = cube_filter_lowpass(cube_sci_hpf, 'gauss',
+                                           fwhm_size=min_spat_freq * fwhm, verbose=False)
+    else:
+        cube_sci_lpf = cube_sci_hpf
 
     if ref_star:
         cube_ref_hpf = cube_filter_highpass(cube_ref_lpf, 'median-subt',
                                             median_size=median_size,
                                             verbose=False)
-        cube_ref_lpf = cube_filter_lowpass(cube_ref_hpf, 'gauss',
+        if min_spat_freq>0:                                    
+            cube_ref_lpf = cube_filter_lowpass(cube_ref_hpf, 'gauss',
                                            fwhm_size=min_spat_freq * fwhm,
                                            verbose=False)
-
+        else:
+            cube_ref_lpf = cube_ref_hpf
+        
     if ref_star:
         alignment_cube = np.zeros((1 + n + nref, subframesize, subframesize))
         alignment_cube[1:(n + 1), :, :] = cube_sci_lpf
@@ -1264,31 +1439,47 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
     n_frames = alignment_cube.shape[0]  # 1+n or 1+n+nref
     cum_y_shifts = 0
     cum_x_shifts = 0
-
+    
     for i in range(alignment_iter):
         alignment_cube[0] = np.median(alignment_cube[1:(n + 1)], axis=0)
         if recenter_median:
-            # Recenter the median frame using a neg. gaussian fit
-            sub_image, y1, x1 = get_square(alignment_cube[0], size=int(fwhm),
+            # Recenter the median frame using a 2d fit
+            if fit_type == 'gaus':
+                crop_sz = int(fwhm)
+            else:
+                crop_sz = int(6*fwhm)
+            if not crop_sz%2:
+                crop_sz+=1
+            sub_image, y1, x1 = get_square(alignment_cube[0], size=crop_sz,
                                            y=ceny, x=cenx, position=True)
-            if negative:
-                sub_image = -sub_image + np.abs(np.min(-sub_image))
-            y_i, x_i = fit_2dgaussian(sub_image, crop=False, threshold=False,
-                                      sigfactor=1, debug=debug,
-                                      full_output=False)
+
+            if fit_type == 'gaus':
+                if negative:
+                    sub_image = -sub_image + np.abs(np.min(-sub_image))
+                y_i, x_i = fit_2dgaussian(sub_image, crop=False, threshold=False,
+                                          sigfactor=1, debug=debug,
+                                          full_output=False)
+            elif fit_type == 'ann':
+                y_i, x_i, rad = _fit_2dannulus(sub_image, fwhm=fwhm, crop=False,  
+                                             hole_rad=0.5, sampl_cen=0.1, 
+                                             sampl_rad=0.2, ann_width=0.5, 
+                                             unc_in=2.)                         
             yshift = ceny - (y1 + y_i)
             xshift = cenx - (x1 + x_i)
-
+            
             alignment_cube[0] = frame_shift(alignment_cube[0, :, :], yshift,
                                             xshift, imlib=imlib,
                                             interpolation=interpolation)
 
         # center the cube with stretched values
         cube_stret = np.log10((np.abs(alignment_cube) + 1) ** gammaval)
-        _, y_shift, x_shift = cube_recenter_dft_upsampling(cube_stret, ceny,
-                                            cenx, fwhm=fwhm, subi_size=None,
-                                            full_output=True, verbose=False,
-                                            plot=False)
+        _, y_shift, x_shift = cube_recenter_dft_upsampling(cube_stret, 
+                                                           (ceny, cenx), 
+                                                           fwhm=fwhm, 
+                                                           subi_size=None,
+                                                           full_output=True, 
+                                                           verbose=False,
+                                                           plot=False)
         sqsum_shifts = np.sum(np.sqrt(y_shift ** 2 + x_shift ** 2))
         print('Square sum of shift vecs: ' + str(sqsum_shifts))
 
@@ -1335,11 +1526,114 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
                                           cum_x_shifts_ref[i], imlib=imlib,
                                           interpolation=interpolation)
 
-    if save_shifts:
-        np.savetxt('recent_gauss_shifts.txt',
-                   np.transpose([cum_y_shifts_sci, cum_x_shifts_sci]), fmt='%f')
     if ref_star:
-        return (cube_reg_sci, cube_reg_ref, cum_x_shifts_sci, cum_y_shifts_sci,
-                cum_x_shifts_ref, cum_y_shifts_ref)
+        if full_output:
+            return (cube_reg_sci, cube_reg_ref, cube_sci_lpf, cube_stret, 
+                    cum_x_shifts_sci, cum_y_shifts_sci, cum_x_shifts_ref, 
+                    cum_y_shifts_ref)
+        else:
+            return (cube_reg_sci, cube_reg_ref)
     else:
-        return cube_reg_sci, cum_x_shifts_sci, cum_y_shifts_sci
+        if full_output:
+            return (cube_reg_sci, cube_sci_lpf, cube_stret, 
+                    cum_x_shifts_sci, cum_y_shifts_sci)
+        else:
+            return cube_reg_sci
+
+
+
+def _fit_2dannulus(array, fwhm=4, crop=False, cent=None, cropsize=15, 
+                   hole_rad=0.5, sampl_cen=0.1, sampl_rad=None, ann_width=0.5, 
+                   unc_in=2.):
+                    
+    """Finds the center the center of a donut-shape signal (e.g. a coronagraphic 
+    PSF) by fitting an annulus, using a grid of positions for the center and 
+    radius of the annulus. The best fit is found by maximizing the mean flux 
+    measured in the annular mask. Requires the image to be already roughly 
+    centered (by an uncertainty provided by unc_in).
+    
+    Parameters
+    ----------
+    array : array_like
+        Image with a single donut-like source, already approximately at the 
+        center of the frame. 
+    fwhm : float
+        Gaussian PSF full width half maximum from fitting (in pixels).
+    hole_rad: float, opt
+        First estimate of the hole radius (in terms of fwhm). The grid search 
+        on the radius of the optimal annulus goes from 0.5 to 2 times hole_rad.
+        Note: for the AGPM PSF of VLT/NACO, the optimal hole_rad ~ 0.5FWHM.
+    sampl_cen: float, opt
+        Precision of the grid sampling to find the center of the annulus (in 
+        pixels)
+    sampl_rad: float, opt or None.
+        Precision of the grid sampling to find the optimal radius of the 
+        annulus (in pixels). If set to None, there is no grid search for the 
+        optimal radius of the annulus, the value given by hole_rad is used.
+    ann_width: float, opt
+        Width of the annulus in FWHM; default is 0.5 FWHM.
+    unc_in: float, opt
+        Initial uncertainty on the center location (with respect to center of 
+        input subframe) in pixels; this will set the grid width.
+        
+    Returns
+    -------
+    mean_y : float
+        Source centroid y position on the full image from fitting. 
+    mean_x : float
+        Source centroid x position on the full image from fitting.
+    if sampl_rad is not None, also returns final_hole_rad:   
+    final_hole_rad : float
+        Best fit radius of the hole, in terms of fwhm.
+    """
+    
+    if cent is None:
+        ceny, cenx = frame_center(array)
+    else:
+        cenx, ceny = cent
+        
+    if crop:
+        x_sub_px = cenx%1
+        y_sub_px = ceny%1
+
+        imside = array.shape[0]
+        psf_subimage, suby, subx = get_square(array, min(cropsize, imside),
+                                              int(ceny), int(cenx), 
+                                              position=True)
+        ceny, cenx = frame_center(psf_subimage)
+        ceny+=y_sub_px
+        cenx+=x_sub_px              
+    else:
+        psf_subimage = array.copy()
+        
+    ann_sz = ann_width*fwhm
+    
+    grid_sh_x = np.arange(-unc_in,unc_in,sampl_cen)
+    grid_sh_y = np.arange(-unc_in,unc_in,sampl_cen)
+    if sampl_rad is None:
+        rads = [hole_rad*fwhm]
+    else:
+        rads = np.arange(0.5*hole_rad*fwhm,2*hole_rad*fwhm,sampl_rad)        
+    flux_ann = np.zeros([grid_sh_x.shape[0],grid_sh_y.shape[0]])
+    best_rad = np.zeros([grid_sh_x.shape[0],grid_sh_y.shape[0]])
+    
+    for ii, xx in enumerate(grid_sh_x):
+        for jj, yy in enumerate(grid_sh_y):
+            tmp_tmp = frame_shift(array,yy,xx)
+            for rr, rad in enumerate(rads):
+                # mean flux in the annulus
+                tmp = frame_basic_stats(tmp_tmp, 'annulus',inner_radius=rad, 
+                                        size=ann_sz, plot=False)
+            
+                if tmp > flux_ann[ii,jj]:
+                    flux_ann[ii,jj] = tmp
+                    best_rad[ii,jj] = rad
+    i_max,j_max = np.unravel_index(np.argmax(flux_ann),flux_ann.shape)
+    mean_x = cenx - grid_sh_x[i_max]
+    mean_y = ceny - grid_sh_y[j_max]
+    
+    if sampl_rad is None:
+        return mean_y, mean_x
+    else:
+        final_hole_rad = best_rad[i_max,j_max]/fwhm   
+        return mean_y, mean_x, final_hole_rad

--- a/vip_hci/preproc/rescaling.py
+++ b/vip_hci/preproc/rescaling.py
@@ -23,7 +23,7 @@ from ..var import frame_center, get_square
 from .subsampling import cube_collapse
 
 
-def cube_px_resampling(array, scale, imlib='ndimage', interpolation='lanczos4',
+def cube_px_resampling(array, scale, imlib='opencv', interpolation='lanczos4',
                        verbose=True):
     """
     Resample the frames of a cube with a single scale factor.
@@ -70,7 +70,7 @@ def cube_px_resampling(array, scale, imlib='ndimage', interpolation='lanczos4',
     return array_resc
 
 
-def frame_px_resampling(array, scale, imlib='ndimage', interpolation='lanczos4',
+def frame_px_resampling(array, scale, imlib='opencv', interpolation='lanczos4',
                         verbose=False):
     """
     Resample the pixels of a frame wrt to the center, changing the frame size.
@@ -88,7 +88,7 @@ def frame_px_resampling(array, scale, imlib='ndimage', interpolation='lanczos4',
     imlib : {'ndimage', 'opencv'}, optional
         Library used for image transformations.
     interpolation : str, optional
-        For 'ndimage' library: 'nearneig', bilinear', 'bicuadratic', 'bicubic',
+        For 'ndimage' library: 'nearneig', bilinear', 'biquadratic', 'bicubic',
         'biquartic', 'biquintic'. The 'nearneig' interpolation is the fastest
         and the 'biquintic' the slowest. The 'nearneig' is the worst
         option for interpolation of noisy astronomical images.
@@ -120,7 +120,7 @@ def frame_px_resampling(array, scale, imlib='ndimage', interpolation='lanczos4',
             order = 0
         elif interpolation == 'bilinear':
             order = 1
-        elif interpolation == 'bicuadratic':
+        elif interpolation == 'biquadratic':
             order = 2
         elif interpolation == 'bicubic':
             order = 3
@@ -456,6 +456,8 @@ def _cube_resc_wave(array, scaling_list, ref_xy=None, imlib='opencv',
         raise TypeError('Input array is not a cube or 3d array')
 
     array_sc = []
+    if scaling_list is None:
+        scaling_list = [None]*array.shape[0]
     for i in range(array.shape[0]):
         array_sc.append(_frame_rescaling(array[i], ref_xy=ref_xy,
                                          scale=scaling_list[i], imlib=imlib,

--- a/vip_hci/preproc/skysubtraction.py
+++ b/vip_hci/preproc/skysubtraction.py
@@ -11,8 +11,9 @@ import numpy as np
 from ..var import prepare_matrix
 
 
-def cube_subtract_sky_pca(sci_cube, sky_cube, mask, ref_cube=None, ncomp=2):
-    """ PCA based sky subtraction.
+def cube_subtract_sky_pca(sci_cube, sky_cube, mask, ref_cube=None, ncomp=2,
+                          full_output=False):
+    """ PCA-based sky subtraction.
 
     Parameters
     ----------
@@ -23,14 +24,24 @@ def cube_subtract_sky_pca(sci_cube, sky_cube, mask, ref_cube=None, ncomp=2):
     mask : numpy ndarray
         Mask indicating the region for the analysis. Can be created with the
         function vip_hci.var.create_ringed_spider_mask.
-    ref_cube : numpy ndarray or None
+    ref_cube : numpy ndarray or None, opt
         Reference cube.
-    ncomp : int
+    ncomp : int, opt
         Sets the number of PCs you want to use in the sky subtraction.
+    full_output: bool, opt
+        Whether to also output pcs, reconstructed cube, residuals cube and 
+        derotated residual cube.        
 
     Returns
     -------
-    Sky subtracted cube.
+    Sky-subtracted science cube. 
+    If ref_cube is not None, also returns sky-subtracted reference cube.
+    If full_ouput, returns (in the following order):
+         - sky-subtracted science cube, 
+         - sky-subtracted reference cube (if any provided),
+         - principal components (non-masked),
+         - principal components (masked), and 
+         - reconstructed cube.
 
     """
     from ..pca.svd import svd_wrapper
@@ -47,7 +58,7 @@ def cube_subtract_sky_pca(sci_cube, sky_cube, mask, ref_cube=None, ncomp=2):
     Msky = prepare_matrix(sky_cube, scaling=None, verbose=False)
     sky_pcs = svd_wrapper(Msky, 'lapack', sky_cube.shape[0], False)
     sky_pcs_cube = sky_pcs.reshape(sky_cube.shape[0], sky_cube.shape[1],
-                                   sky_cube.shape[1])
+                                   sky_cube.shape[2])
 
     # Masking the science cube
     sci_cube_masked = np.zeros_like(sci_cube)
@@ -77,10 +88,11 @@ def cube_subtract_sky_pca(sci_cube, sky_cube, mask, ref_cube=None, ncomp=2):
 
     # Obtaining the optimized sky and subtraction
     sci_cube_skysub = np.zeros_like(sci_cube)
+    sky_opt = sci_cube.copy()
     for i in range(Msci_masked.shape[0]):
-        sky_opt = np.array([np.sum(
+        sky_opt[i] = np.array([np.sum(
             transf_sci_scaled[j, i] * sky_pcs_cube[j] for j in range(ncomp))])
-        sci_cube_skysub[i] = sci_cube[i] - sky_opt
+        sci_cube_skysub[i] = sci_cube[i] - sky_opt[i]
 
     # Processing the reference cube (if any)
     if ref_cube is not None:
@@ -102,7 +114,14 @@ def cube_subtract_sky_pca(sci_cube, sky_cube, mask, ref_cube=None, ncomp=2):
             sky_opt = np.array([np.sum(transf_ref_scaled[j, i] * sky_pcs_cube[j]
                                        for j in range(ncomp))])
             ref_cube_skysub[i] = ref_cube[i] - sky_opt
-
-        return sci_cube_skysub, ref_cube_skysub
+        
+        if full_output:
+            return (sci_cube_skysub, ref_cube_skysub, sky_pcs_cube, 
+                    sky_pcs_cube_masked, sky_opt)
+        else:
+            return sci_cube_skysub, ref_cube_skysub
     else:
-        return sci_cube_skysub
+        if full_output:
+            return (sci_cube_skysub, sky_pcs_cube, sky_pcs_cube_masked, sky_opt)
+        else:
+            return sci_cube_skysub

--- a/vip_hci/specfit/__init__.py
+++ b/vip_hci/specfit/__init__.py
@@ -1,0 +1,14 @@
+"""
+Subpackage ``specfit`` has helping functions such as:
+
+- spectral fitting
+- mcmc sampling of model parameter space
+- best fit search within a template libraty
+- utility functions for the spectral fit
+"""
+
+from .chi import *
+from .model_resampling import *
+from .mcmc_sampling_spec import *
+from .template_lib import *
+from .utils_spec import *

--- a/vip_hci/specfit/chi.py
+++ b/vip_hci/specfit/chi.py
@@ -1,0 +1,271 @@
+#! /usr/bin/env python
+
+"""
+Function defining the goodness of fit.
+"""
+
+__author__ = 'Valentin Christiaens'
+__all__ = ['goodness_of_fit',
+           'gof_scal']
+
+import numpy as np
+from matplotlib import pyplot as plt
+from ..conf import vip_figsize
+from .model_resampling import resample_model
+from .utils_spec import extinction
+
+def goodness_of_fit(lbda_obs, spec_obs, err_obs, lbda_mod, spec_mod, 
+                    dlbda_obs=None, instru_corr=None, instru_fwhm=None, 
+                    instru_idx=None, filter_reader=None, plot=False, 
+                    outfile=None):
+    """ Function to estimate the goodness of fit indicator defined as 
+    in Olofsson et al. 2016 (Eq. 8). In addition, if a spectral 
+    correlation matrix is provided, it is used to take into account the 
+    correlated noise between spectral channels (see Greco & Brandt 2016).
+    The goodness of fit indicator is identical to a chi square when all
+    points are obtained from the same instrument (no additional weighting).
+
+    Parameters
+    ----------
+    lbda_obs : numpy 1d ndarray or list
+        Wavelength of observed spectrum. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs).
+    spec_obs : numpy 1d ndarray or list
+        Observed spectrum for each value of lbda_obs.
+    err_obs : numpy 1d/2d ndarray or list
+        Uncertainties on the observed spectrum. If 2d array, should be [2,n_ch]
+        where the first (resp. second) column corresponds to lower (upper) 
+        uncertainty, and n_ch is the length of lbda_obs and spec_obs.
+    lbda_mod : numpy 1d ndarray or list
+        Wavelength of tested model. Should have a wider wavelength extent than 
+        the observed spectrum.
+    spec_mod : numpy 1d ndarray
+        Model spectrum. It does not require the same wavelength sampling as the
+        observed spectrum. If higher spectral resolution, it will be convolved
+        with the instrumental spectral psf (if instru_fwhm is provided) and 
+        then binned to the same sampling. If lower spectral resolution, a 
+        linear interpolation is performed to infer the value at the observed 
+        spectrum wavelength sampling.
+    dlbda_obs: numpy 1d ndarray or list, optional
+        Spectral channel width for the observed spectrum. It should be provided 
+        IF one wants to weigh each point based on the spectral 
+        resolution of the respective instruments (as in Olofsson et al. 2016).
+    instru_corr : numpy 2d ndarray or list, optional
+        Spectral correlation throughout post-processed images in which the 
+        spectrum is measured. It is specific to the combination of instrument, 
+        algorithm and radial separation of the companion from the central star.
+        Can be computed using distances.spectral_correlation(). In case of
+        a spectrum obtained with different instruments, build it with
+        distances.combine_corrs(). If not provided, it will consider the 
+        uncertainties in each spectral channels are independent. See Greco & 
+        Brandt (2017) for details.
+    instru_fwhm : float or list, optional
+        The instrumental spectral fwhm provided in nm. This is used to convolve
+        the model spectrum. If several instruments are used, provide a list of 
+        instru_fwhm values, one for each instrument whose spectral resolution
+        is coarser than the model - including broad band
+        filter FWHM if relevant.
+    instru_idx: numpy 1d array, optional
+        1d array containing an index representing each instrument used 
+        to obtain the spectrum, label them from 0 to n_instru. Zero for points 
+        that don't correspond to any instru_fwhm provided above, and i in 
+        [1,n_instru] for points associated to instru_fwhm[i-1]. This parameter 
+        must be provided if the spectrum consists of points obtained with 
+        different instruments.
+    filter_reader: python routine, optional
+        External routine that reads a filter file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains transmission values. Important: if not provided, but strings 
+        are detected in instru_fwhm, the default format assumed for the files:
+        - first row containing header
+        - starting from 2nd row: 1st column: WL in mu, 2nd column: transmission
+        Note: files should all have the same format and wavelength units.
+    plot : bool, optional
+        Whether to plot the 
+    outfile : string, optional
+        Path+filename for the plot to be saved if provided.
+        
+    Returns
+    -------
+    chi_sq : float
+        Goodness of fit indicator.
+
+    """
+
+    lbda_obs = np.array(lbda_obs)
+    spec_obs = np.array(spec_obs)
+    err_obs = np.array(err_obs)
+    lbda_mod = np.array(lbda_mod)
+    spec_mod = np.array(spec_mod)
+    
+    if lbda_obs.ndim != 1 or spec_obs.ndim != 1:
+        raise TypeError('Observed lbda and spec must be lists or 1d arrays')
+    if lbda_obs.shape[0] != spec_obs.shape[0]:
+        raise TypeError('Obs lbda and spec need same shape')        
+    if lbda_obs.shape[0] != err_obs.shape[-1]:
+        raise TypeError('Obs lbda and err need same shape')
+    if lbda_mod.ndim != 1 or spec_mod.ndim != 1:
+        raise TypeError('The input model lbda/spec must be lists or 1d arrays')
+    else:
+        if lbda_mod.shape != spec_mod.shape:
+            raise TypeError('The input model lbda and spec need same shape')
+    if dlbda_obs is not None:
+        if isinstance(dlbda_obs, list):
+            dlbda_obs = np.array(dlbda_obs)
+        if lbda_obs.shape != dlbda_obs.shape:
+            raise TypeError('The input lbda_obs and dlbda_obs need same shape')
+
+    n_ch = lbda_obs.shape[0]
+             
+    # interpolate OR convolve+bin model spectrum if not same sampling
+    if not np.allclose(lbda_obs, lbda_mod):
+        spec_mod_fin = resample_model(lbda_obs, lbda_mod, spec_mod, dlbda_obs, 
+                                      instru_fwhm, instru_idx, filter_reader)    
+    else:
+        spec_mod_fin = spec_mod
+        
+    # compute covariance matrix
+    if err_obs.ndim == 2:
+        err_obs = (np.absolute(err_obs[0])+np.absolute(err_obs[1]))/2.
+    if instru_corr is None:
+        instru_corr = np.diag(np.ones(n_ch))
+    cov = np.ones_like(instru_corr)
+    for ii in range(n_ch):
+        for jj in range(n_ch):
+            cov[ii,jj] = instru_corr[ii,jj]*err_obs[ii]*err_obs[jj] 
+
+    delta = spec_obs-spec_mod_fin
+    wi = np.ones_like(dlbda_obs)
+    if dlbda_obs is not None:
+        if np.sum(np.power((dlbda_obs[1:]/lbda_obs[1:])-(dlbda_obs[:-1]/lbda_obs[:-1]),2))!=0:
+            # normalize weights for their sum to be equal to the number of points
+            wi = np.sqrt(((dlbda_obs/lbda_obs)/np.sum(dlbda_obs/lbda_obs))*dlbda_obs.shape[0])    
+   
+    chi_sq = np.linalg.multi_dot((wi*delta,np.linalg.inv(cov),wi*delta))
+                
+    if plot:
+        _, ax = plt.subplots(figsize=vip_figsize)
+
+        ax.plot(lbda_obs, lbda_obs*spec_obs, 'o', alpha=0.6, color='#1f77b4',
+                label="Measured spectrum")
+        ax.plot(lbda_obs, lbda_mod*spec_mod, '-', alpha=0.4, color='#1f77b4',
+                label="Model")
+        plt.xlabel('Wavelength')
+        plt.ylabel(r'Flux density ($\lambda F_{\lambda}$)')
+
+        plt.xlim(xmin=0.9*lbda_obs[0], xmax=1.1*lbda_obs[-1])
+        plt.minorticks_on()
+        plt.legend(fancybox=True, framealpha=0.5, fontsize=12, loc='best')
+        plt.grid(which='major', alpha=0.2)
+        if outfile:
+            plt.savefig(outfile, bbox_inches='tight')
+        plt.show()
+
+    return chi_sq
+
+
+def gof_scal(params, lbda_obs, spec_obs, err_obs, lbda_mod, spec_mod, dlbda_obs, 
+             instru_corr, instru_fwhm, instru_idx, filter_reader, ext_range):
+    """ Wrapper for the goodness of fit routine to search for best template 
+    library fitting spectrum. The only difference is the "params" argument, 
+    
+    Parameters
+    ----------
+    params: tuple
+        Tuple of 1 or 2 elements: scaling factor and (optionally) differential
+        optical extinction (i.e. Delta A_V can be negative if template spectra
+        are not dereddened).
+    lbda_obs : numpy 1d ndarray or list
+        Wavelength of observed spectrum. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs).
+    spec_obs : numpy 1d ndarray or list
+        Observed spectrum for each value of lbda_obs.
+    err_obs : numpy 1d/2d ndarray or list
+        Uncertainties on the observed spectrum. If 2d array, should be [2,n_ch]
+        where the first (resp. second) column corresponds to lower (upper) 
+        uncertainty, and n_ch is the length of lbda_obs and spec_obs.
+    lbda_mod : numpy 1d ndarray or list
+        Wavelength of tested model. Should have a wider wavelength extent than 
+        the observed spectrum.
+    spec_mod : numpy 1d ndarray
+        Model spectrum. It does not require the same wavelength sampling as the
+        observed spectrum. If higher spectral resolution, it will be convolved
+        with the instrumental spectral psf (if instru_fwhm is provided) and 
+        then binned to the same sampling. If lower spectral resolution, a 
+        linear interpolation is performed to infer the value at the observed 
+        spectrum wavelength sampling.
+    dlbda_obs: numpy 1d ndarray or list, optional
+        Spectral channel width for the observed spectrum. It should be provided 
+        IF one wants to weigh each point based on the spectral 
+        resolution of the respective instruments (as in Olofsson et al. 2016).
+    instru_corr : numpy 2d ndarray or list, optional
+        Spectral correlation throughout post-processed images in which the 
+        spectrum is measured. It is specific to the combination of instrument, 
+        algorithm and radial separation of the companion from the central star.
+        Can be computed using distances.spectral_correlation(). In case of
+        a spectrum obtained with different instruments, build it with
+        distances.combine_corrs(). If not provided, it will consider the 
+        uncertainties in each spectral channels are independent. See Greco & 
+        Brandt (2017) for details.
+    instru_fwhm : float or list, optional
+        The instrumental spectral fwhm provided in nm. This is used to convolve
+        the model spectrum. If several instruments are used, provide a list of 
+        instru_fwhm values, one for each instrument whose spectral resolution
+        is coarser than the model - including broad band
+        filter FWHM if relevant.
+    instru_idx: numpy 1d array, optional
+        1d array containing an index representing each instrument used 
+        to obtain the spectrum, label them from 0 to n_instru. Zero for points 
+        that don't correspond to any instru_fwhm provided above, and i in 
+        [1,n_instru] for points associated to instru_fwhm[i-1]. This parameter 
+        must be provided if the spectrum consists of points obtained with 
+        different instruments.
+    filter_reader: python routine, optional
+        External routine that reads a filter file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains transmission values. Important: if not provided, but strings 
+        are detected in instru_fwhm, the default format assumed for the files:
+        - first row containing header
+        - starting from 2nd row: 1st column: WL in mu, 2nd column: transmission
+        Note: files should all have the same format and wavelength units.
+    ext_range: tuple or None, opt
+        If None: differential extinction is not to be considered as a free 
+        parameter. Elif a tuple of 3 floats is provided, differential extinction 
+        will be considered, with the floats as lower limit, upper limit and step 
+        of the grid search.
+        Note: if simplex search, the range is still used to set a chi of 
+        np.inf outside of the range.
+        
+    Returns
+    -------
+    chi_sq : float
+        Goodness of fit indicator.
+    """
+    tmp_spec = spec_mod*params[0]
+    
+    if len(params) == 2:
+        if ext_range is None:
+            raise TypeError("ext_range should be a tuple of 3 elements")
+        else:
+            if params[1]<ext_range[0] or params[1]>ext_range[1]:
+                return np.inf
+            AV=params[1]
+            thr = ext_range[-1]
+            if abs(AV) < thr:
+                AV = 0
+            Albdas = extinction(lbda_obs,abs(AV))
+            extinc_fac = np.power(10.,-Albdas/2.5)
+            if AV>0:
+                tmp_spec *= extinc_fac
+            elif AV<0:
+                tmp_spec /= extinc_fac
+    elif len(params) > 2:
+        raise TypeError("params tuple should have length 1 or 2")
+    
+    
+    return goodness_of_fit(lbda_obs, spec_obs, err_obs, lbda_obs, tmp_spec, 
+                           dlbda_obs=dlbda_obs, instru_corr=instru_corr, 
+                           instru_fwhm=instru_fwhm, instru_idx=instru_idx, 
+                           filter_reader=filter_reader)

--- a/vip_hci/specfit/mcmc_sampling_spec.py
+++ b/vip_hci/specfit/mcmc_sampling_spec.py
@@ -1,0 +1,1610 @@
+#! /usr/bin/env python
+
+"""
+Module with the MCMC (``emcee``) sampling for model spectra parameter estimation.
+"""
+
+
+__author__ = 'V. Christiaens, O. Wertz, Carlos Alberto Gomez Gonzalez'
+__all__ = ['mcmc_spec_sampling',
+           'spec_lnprob',
+           'spec_chain_zero_truncated',
+           'spec_show_corner_plot',
+           'spec_show_walk_plot',
+           'spec_confidence']
+
+from astropy import constants as con
+import numpy as np
+import os
+from os.path import isdir, isfile
+import emcee
+import inspect
+import datetime
+import corner
+from matplotlib import pyplot as plt
+from matplotlib.ticker import MaxNLocator
+import pickle
+from scipy.stats import norm
+from ..conf import time_ini, timing
+from ..conf.utils_conf import sep
+from ..fits import open_fits, write_fits
+from ..negfc.utils_mcmc import gelman_rubin, autocorr_test
+from .chi import goodness_of_fit
+from .model_resampling import make_model_from_params, make_resampled_models
+from .utils_spec import mj_from_rj_and_logg
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+def spec_lnprior(params, labels, bounds, priors=None):
+    """ Define the prior log-function.
+    
+    Parameters
+    ----------
+    params: tuple
+        The model parameters.
+    labels: Tuple of strings
+        Tuple of labels in the same order as initial_state, that is:
+        - first all parameters related to loaded models (e.g. 'Teff', 'logg')
+        - then the planet photometric radius 'R', in Jupiter radius
+        - (optionally) the flux of emission lines (labels should match those in
+        the em_lines dictionary), in units of the model spectrum (times mu)
+        - (optionally) the optical extinction 'Av', in mag
+        - (optionally) the ratio of total to selective optical extinction 'Rv'
+        - (optionally) 'Tbb1', 'Rbb1', 'Tbb2', 'Rbb2', etc. for each extra bb
+        contribution.
+    bounds: dictionary
+        Each entry should be associated with a tuple corresponding to lower and 
+        upper bounds respectively. Bounds should be provided for ALL model
+        parameters, including 'R' (planet photometric radius). 'Av' (optical 
+        extinction) is optional. If provided here, Av will also be fitted.
+        All keywords that are neither 'R', 'Av' nor 'M' will 
+        be considered model grid parameters.
+        Example for BT-SETTL: bounds = {'Teff':(1000,2000), 'logg':(3.0,4.5),
+        'R':(0.1,5), 'Av':(0.,2.5)}
+        'M' can be used for a prior on the mass of the planet. In that case the
+        corresponding prior log probability is computed from the values for 
+        parameters 'logg' and 'R'.
+    priors: dictionary, opt
+        If not None, sets prior estimates for each parameter of the model. Each 
+        entry should be set to either None (no prior) or a tuple of 2 elements 
+        containing prior estimate and uncertainty on the estimate.
+        Missing entries (i.e. provided in bounds dictionary but not here) will
+        be associated no prior.
+        e.g. priors = {'Teff':(1600,100), 'logg':(3.5,0.5),
+                       'R':(1.6,0.1), 'Av':(1.8,0.2), 'M':(10,3)}
+        Important: dictionary entry names should match exactly those of bounds.
+    
+    Returns
+    -------
+    out: float.
+        If all parameters are within bounds:
+            * 0 if no prior,
+            * the sum of gaussian log proba for each prior otherwise.
+        If at least one model parameters is out of bounds:
+        returns -np.inf 
+    """
+    n_params = len(params)
+    n_labs = len(labels)
+    n_dico = len(bounds)    
+    if n_dico!=n_params or n_dico != n_labs:
+        raise TypeError('params, labels and bounds should have same length')
+
+    cond = True
+    for pp in range(n_params):
+        if not bounds[labels[pp]][0] <= params[pp] <= bounds[labels[pp]][1]:
+            cond=False
+
+    if cond:
+        lnprior = 0.
+        if priors is not None:
+            for key, prior in priors.items():
+                if key == 'M' and 'logg' in labels:
+                    idx_logg =labels.index("logg")
+                    idx_rp = labels.index("R")
+                    rp = params[idx_rp]
+                    logg = params[idx_logg]
+                    mp = mj_from_rj_and_logg(rp, logg)
+                    lnprior += -0.5 * (mp - prior[0])**2 / prior[1]**2
+                else:
+                    idx_prior = labels.index(key)
+                    lnprior += -0.5*(params[idx_prior]-prior[0])**2/prior[1]**2
+        return lnprior
+    else:
+        return -np.inf
+
+
+def spec_lnlike(params, labels, grid_param_list, lbda_obs, spec_obs, err_obs, 
+                dist, model_grid=None, model_reader=None, em_lines={}, 
+                em_grid={}, dlbda_obs=None, instru_corr=None, 
+                instru_fwhm=None, instru_idx=None, filter_reader=None, 
+                AV_bef_bb=False, units_obs='si', units_mod='si', interp_order=1):
+    """ Define the likelihood log-function.
+    
+    Parameters
+    ----------
+    params : tuple
+        Set of models parameters for which the model grid has to be 
+        interpolated.
+    labels: Tuple of strings
+        Tuple of labels in the same order as initial_state, that is:
+        - first all parameters related to loaded models (e.g. 'Teff', 'logg')
+        - then the planet photometric radius 'R', in Jupiter radius
+        - (optionally) the flux of emission lines (labels should match those in
+        the em_lines dictionary), in units of the model spectrum (times mu)
+        - (optionally) the optical extinction 'Av', in mag
+        - (optionally) the ratio of total to selective optical extinction 'Rv'
+        - (optionally) 'Tbb1', 'Rbb1', 'Tbb2', 'Rbb2', etc. for each extra bb
+        contribution.
+    grid_param_list : list of 1d numpy arrays/lists OR None
+        - If list, should contain list/numpy 1d arrays with available grid of 
+        model parameters. 
+        - Set to None for a pure n-blackbody fit, n=1,2,...
+        - Note1: model grids should not contain grids on radius and Av, but 
+        these should still be passed in initial_state (Av optional).
+        - Note2: for a combined grid model + black body, just provide
+        the grid parameter list here, and provide values for 'Tbbn' and 'Rbbn'
+        in initial_state, labels and bounds.
+    lbda_obs : numpy 1d ndarray or list
+        Wavelength of observed spectrum. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs).
+    spec_obs : numpy 1d ndarray or list
+        Observed spectrum for each value of lbda_obs.
+    err_obs : numpy 1d/2d ndarray or list
+        Uncertainties on the observed spectrum. If 2d array, should be [2,n_ch]
+        where the first (resp. second) column corresponds to lower (upper) 
+        uncertainty, and n_ch is the length of lbda_obs and spec_obs.
+    dist :  float
+        Distance in parsec, used for flux scaling of the models.
+    model_grid : numpy N-d array, optional
+        If provided, should contain the grid of model spectra for each
+        free parameter of the given grid. I.e. for a grid of n_T values of Teff 
+        and n_g values of Logg, the numpy array should be n_T x n_g x n_ch x 2, 
+        where n_ch is the number of wavelengths for the observed spectrum,
+        and the last 2 dims are for wavelength and fluxes respectively.
+        If provided, takes precedence over model_name/model_reader.
+    model_reader : python routine, opt
+        External routine that reads a model file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains model values. See example routine in model_interpolation() 
+        description.
+    em_lines: dictionary, opt
+        Dictionary of emission lines to be added on top of the model spectrum.
+        Each dict entry should be the name of the line, assigned to a tuple of
+        4 values: 
+            1) the wavelength (in mu); 
+            2) a string indicating whether line intensity is expressed in flux 
+            ('F'), luminosity ('L') or log(L/LSun) ("LogL");
+            3) the FWHM of the gaussian (or None if to be set automatically); 
+            4) whether the FWHM is expressed in 'nm', 'mu' or 'km/s'. 
+        The third and fourth can also be set to None. In that case, the FWHM of 
+        the gaussian will automatically be set to the equivalent width of the
+        line, calculated from the flux to be injected and the continuum 
+        level (measured in the grid model to which the line is injected). 
+        Examples: em_lines = {'BrG':(2.1667,'F',None, None)};
+                  em_lines = {'BrG':(2.1667,'LogL', 100, 'km/s')}
+    em_grid: dictionary pointing to lists, opt
+        Dictionary where each entry corresponds to an emission line and points
+        to a list of values to inject for emission line fluxes. For computation 
+        efficiency, interpolation will be performed between the points of this 
+        grid during the MCMC sampling. Dict entries should match labels and 
+        em_lines.
+    dlbda_obs: numpy 1d ndarray or list, optional
+        Spectral channel width for the observed spectrum. It should be provided 
+        IF one wants to weigh each point based on the spectral 
+        resolution of the respective instruments (as in Olofsson et al. 2016).
+    instru_corr : numpy 2d ndarray or list, optional
+        Spectral correlation throughout post-processed images in which the 
+        spectrum is measured. It is specific to the combination of instrument, 
+        algorithm and radial separation of the companion from the central star.
+        Can be computed using distances.spectral_correlation(). In case of
+        a spectrum obtained with different instruments, build it with
+        distances.combine_corrs(). If not provided, it will consider the 
+        uncertainties in each spectral channels are independent. See Greco & 
+        Brandt (2017) for details.
+    instru_fwhm : float or list, optional
+        The instrumental spectral fwhm provided in nm. This is used to convolve
+        the model spectrum. If several instruments are used, provide a list of 
+        instru_fwhm values, one for each instrument whose spectral resolution
+        is coarser than the model - including broad band
+        filter FWHM if relevant.
+    instru_idx: numpy 1d array, optional
+        1d array containing an index representing each instrument used 
+        to obtain the spectrum, label them from 0 to n_instru. Zero for points 
+        that don't correspond to any instru_fwhm provided above, and i in 
+        [1,n_instru] for points associated to instru_fwhm[i-1]. This parameter 
+        must be provided if the spectrum consists of points obtained with 
+        different instruments.
+    filter_reader: python routine, optional
+        External routine that reads a filter file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains transmission values. Important: if not provided, but strings 
+        are detected in instru_fwhm, the default format assumed for the files:
+        - first row containing header
+        - starting from 2nd row: 1st column: WL in mu, 2nd column: transmission
+        Note: files should all have the same format and wavelength units.
+    AV_bef_bb: bool, optional
+        If both extinction and an extra bb component are free parameters, 
+        whether to apply extinction before adding the BB component (e.g. 
+        extinction mostly from circumplanetary dust) or after the BB component
+        (e.g. mostly insterstellar extinction).
+    units_obs : str, opt {'si','cgs','jy'}
+        Units of observed spectrum. 'si' for W/m^2/mu; 'cgs' for ergs/s/cm^2/mu 
+        or 'jy' for janskys.
+    units_mod: str, opt {'si','cgs','jy'}
+        Units of the model. 'si' for W/m^2/mu; 'cgs' for ergs/s/cm^2/mu or 'jy'
+        for janskys. If different to units_obs, the spectrum units will be 
+        converted.
+    interp_order: int, opt, {-1,0,1} 
+        Interpolation mode for model interpolation.
+        -1: log interpolation (i.e. linear interpolatlion on log(Flux))
+        0: nearest neighbour model.
+        1: Order 1 spline interpolation.
+        
+    Returns
+    -------
+    out: float
+        The log of the likelihood.
+        
+    """
+
+    if grid_param_list is not None:
+        if model_grid is None and model_reader is None:
+            msg = "model_name and model_reader must be provided"
+            raise TypeError(msg)
+                           
+    lbda_mod, spec_mod = make_model_from_params(params, labels, grid_param_list, 
+                                                dist, lbda_obs, model_grid, 
+                                                model_reader, em_lines, em_grid, 
+                                                dlbda_obs, instru_fwhm, 
+                                                instru_idx, filter_reader, 
+                                                AV_bef_bb, units_obs, units_mod, 
+                                                interp_order)
+    
+    # evaluate the goodness of fit indicator
+    chi = goodness_of_fit(lbda_obs, spec_obs, err_obs, lbda_mod, spec_mod, 
+                          dlbda_obs=dlbda_obs, instru_corr=instru_corr, 
+                          instru_fwhm=instru_fwhm, instru_idx=instru_idx, 
+                          filter_reader=filter_reader, plot=False, outfile=None)
+    
+    # log likelihood
+    lnlikelihood = -0.5 * chi
+    
+    return lnlikelihood
+
+
+def spec_lnprob(params, labels, bounds, grid_param_list, lbda_obs, spec_obs, 
+                err_obs, dist, model_grid=None, model_reader=None, em_lines={},
+                em_grid={}, dlbda_obs=None, instru_corr=None, instru_fwhm=None, 
+                instru_idx=None, filter_reader=None, AV_bef_bb=False, 
+                units_obs='si', units_mod='si', interp_order=1, priors=None, 
+                physical=True):
+    """ Define the probability log-function as the sum between the prior and
+    likelihood log-functions.
+    
+    Parameters
+    ----------
+    params: tuple
+        The model parameters.
+    labels: Tuple of strings
+        Tuple of labels in the same order as initial_state, that is:
+        - first all parameters related to loaded models (e.g. 'Teff', 'logg')
+        - then the planet photometric radius 'R', in Jupiter radius
+        - (optionally) the flux of emission lines (labels should match those in
+        the em_lines dictionary), in units of the model spectrum (times mu)
+        - (optionally) the optical extinction 'Av', in mag
+        - (optionally) the ratio of total to selective optical extinction 'Rv'
+        - (optionally) 'Tbb1', 'Rbb1', 'Tbb2', 'Rbb2', etc. for each extra bb
+        contribution.
+    bounds: dictionary
+        Each entry should be associated with a tuple corresponding to lower and 
+        upper bounds respectively. Bounds should be provided for ALL model
+        parameters, including 'R' (planet photometric radius). 'Av' (optical 
+        extinction) is optional. If provided here, Av will also be fitted.
+        All keywords that are neither 'R', 'Av' nor 'M' will 
+        be considered model grid parameters.
+        Example for BT-SETTL: bounds = {'Teff':(1000,2000), 'logg':(3.0,4.5),
+        'R':(0.1,5), 'Av':(0.,2.5)}
+        'M' can be used for a prior on the mass of the planet. In that case the
+        corresponding prior log probability is computed from the values for 
+        parameters 'logg' and 'R'.
+    grid_param_list : list of 1d numpy arrays/lists OR None
+        - If list, should contain list/numpy 1d arrays with available grid of 
+        model parameters. 
+        - Set to None for a pure n-blackbody fit, n=1,2,...
+        - Note1: model grids should not contain grids on radius and Av, but 
+        these should still be passed in initial_state (Av optional).
+        - Note2: for a combined grid model + black body, just provide
+        the grid parameter list here, and provide values for 'Tbbn' and 'Rbbn'
+        in initial_state, labels and bounds.
+    lbda_obs : numpy 1d ndarray or list
+        Wavelength of observed spectrum. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs).
+    spec_obs : numpy 1d ndarray or list
+        Observed spectrum for each value of lbda_obs.
+    err_obs : numpy 1d/2d ndarray or list
+        Uncertainties on the observed spectrum. If 2d array, should be [2,n_ch]
+        where the first (resp. second) column corresponds to lower (upper) 
+        uncertainty, and n_ch is the length of lbda_obs and spec_obs.
+    dist :  float
+        Distance in parsec, used for flux scaling of the models.
+    model_grid : numpy N-d array, optional
+        If provided, should contain the grid of model spectra for each
+        free parameter of the given grid. I.e. for a grid of n_T values of Teff 
+        and n_g values of Logg, the numpy array should be n_T x n_g x n_ch x 2, 
+        where n_ch is the number of wavelengths for the observed spectrum,
+        and the last 2 dims are for wavelength and fluxes respectively.
+        If provided, takes precedence over model_name/model_reader.
+    model_reader : python routine
+        External routine that reads a model file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains model values. See example routine in model_interpolation() 
+        description.
+    em_lines: dictionary, opt
+        Dictionary of emission lines to be added on top of the model spectrum.
+        Each dict entry should be the name of the line, assigned to a tuple of
+        4 values: 
+            1) the wavelength (in mu); 
+            2) a string indicating whether line intensity is expressed in flux 
+            ('F'), luminosity ('L') or log(L/LSun) ("LogL");
+            3) the FWHM of the gaussian (or None if to be set automatically); 
+            4) whether the FWHM is expressed in 'nm', 'mu' or 'km/s'. 
+        The third and fourth can also be set to None. In that case, the FWHM of 
+        the gaussian will automatically be set to the equivalent width of the
+        line, calculated from the flux to be injected and the continuum 
+        level (measured in the grid model to which the line is injected). 
+        Examples: em_lines = {'BrG':(2.1667,'F',None, None)};
+                  em_lines = {'BrG':(2.1667,'LogL', 100, 'km/s')}
+    em_grid: dictionary pointing to lists, opt
+        Dictionary where each entry corresponds to an emission line and points
+        to a list of values to inject for emission line fluxes. For computation 
+        efficiency, interpolation will be performed between the points of this 
+        grid during the MCMC sampling. Dict entries should match labels and 
+        em_lines.
+    dlbda_obs: numpy 1d ndarray or list, optional
+        Spectral channel width for the observed spectrum. It should be provided 
+        IF one wants to weigh each point based on the spectral 
+        resolution of the respective instruments (as in Olofsson et al. 2016).
+    instru_corr : numpy 2d ndarray or list, optional
+        Spectral correlation throughout post-processed images in which the 
+        spectrum is measured. It is specific to the combination of instrument, 
+        algorithm and radial separation of the companion from the central star.
+        Can be computed using distances.spectral_correlation(). In case of
+        a spectrum obtained with different instruments, build it with
+        distances.combine_corrs(). If not provided, it will consider the 
+        uncertainties in each spectral channels are independent. See Greco & 
+        Brandt (2017) for details.
+    instru_fwhm : float or list, optional
+        The instrumental spectral fwhm provided in nm. This is used to convolve
+        the model spectrum. If several instruments are used, provide a list of 
+        instru_fwhm values, one for each instrument whose spectral resolution
+        is coarser than the model - including broad band
+        filter FWHM if relevant.
+    instru_idx: numpy 1d array, optional
+        1d array containing an index representing each instrument used 
+        to obtain the spectrum, label them from 0 to n_instru. Zero for points 
+        that don't correspond to any instru_fwhm provided above, and i in 
+        [1,n_instru] for points associated to instru_fwhm[i-1]. This parameter 
+        must be provided if the spectrum consists of points obtained with 
+        different instruments.
+    filter_reader: python routine, optional
+        External routine that reads a filter file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains transmission values. Important: if not provided, but strings 
+        are detected in instru_fwhm, the default format assumed for the files:
+        - first row containing header
+        - starting from 2nd row: 1st column: WL in mu, 2nd column: transmission
+        Note: files should all have the same format and wavelength units.
+    AV_bef_bb: bool, optional
+        If both extinction and an extra bb component are free parameters, 
+        whether to apply extinction before adding the BB component (e.g. 
+        extinction mostly from circumplanetary dust) or after the BB component
+        (e.g. mostly insterstellar extinction).
+    units_obs : str, opt {'si','cgs','jy'}
+        Units of observed spectrum. 'si' for W/m^2/mu; 'cgs' for ergs/s/cm^2/mu 
+        or 'jy' for janskys.
+    units_mod: str, opt {'si','cgs','jy'}
+        Units of the model. 'si' for W/m^2/mu; 'cgs' for ergs/s/cm^2/mu or 'jy'
+        for janskys. If different to units_obs, the spectrum units will be 
+        converted.
+    interp_order: int, opt, {-1,0,1} 
+        Interpolation mode for model interpolation.
+        -1: log interpolation (i.e. linear interpolatlion on log(Flux))
+        0: nearest neighbour model.
+        1: Order 1 spline interpolation.
+    priors: dictionary, opt
+        If not None, sets prior estimates for each parameter of the model. Each 
+        entry should be set to either None (no prior) or a tuple of 2 elements 
+        containing prior estimate and uncertainty on the estimate.
+        Missing entries (i.e. provided in bounds dictionary but not here) will
+        be associated no prior.
+        e.g. priors = {'Teff':(1600,100), 'logg':(3.5,0.5),
+                       'R':(1.6,0.1), 'Av':(1.8,0.2), 'M':(10,3)}
+        Important: dictionary entry names should match exactly those of bounds.
+    physical: bool, opt
+        In case of extra black body component(s) to a photosphere, whether to 
+        force lower temperature than the photosphere effective temperature.
+        
+    Returns
+    -------
+    out: float
+        The probability log-function.
+    
+    """
+    
+    lp = spec_lnprior(params, labels, bounds, priors)
+    
+    if np.isinf(lp):
+        return -np.inf
+    
+    if 'Tbb1' in labels:
+        condT = ('T' in labels or 'Teff' in labels)
+        n_bb = 0
+        for label in labels:
+            if 'Tbb' in label:
+                n_bb+=1
+        idx_Tbb1 = labels.index("Tbb1")
+        for ii in range(n_bb):
+            idx = ii*2
+            if grid_param_list is not None and condT:
+                if 'T' in labels:
+                    idx_Teff = labels.index("T")
+                else:
+                    idx_Teff = labels.index("Teff")
+                # COND 1: only allow Tbb < Teff
+                if physical and params[idx_Tbb1+idx] >= params[idx_Teff]:
+                    return -np.inf
+                elif physical:
+                    idx_R= labels.index("R")
+                    R = params[idx_R]
+                    Rbb = params[idx_Tbb1+idx+1]
+                    if Rbb<=R:
+                        pass
+                    else:
+                        Teq = params[idx_Teff] * np.sqrt(R/(2*Rbb))
+                        # COND 2: only allow Tbb <= Teq at Rbb
+                        if params[idx_Tbb1+idx] >= Teq:
+                            return -np.inf
+            if ii>0:
+                # avoid unnecessary degenerecaies by only allowing:
+                # Teff1 > Teff2, Teff2 > Teff3
+                if params[idx_Tbb1+idx] >= params[idx_Tbb1+idx-2]:
+                    return -np.inf
+        
+    return lp + spec_lnlike(params, labels, grid_param_list, lbda_obs, spec_obs, 
+                            err_obs, dist, model_grid, model_reader, em_lines,
+                            em_grid, dlbda_obs, instru_corr, instru_fwhm, 
+                            instru_idx, filter_reader, AV_bef_bb, units_obs, 
+                            units_mod, interp_order)
+
+
+def mcmc_spec_sampling(lbda_obs, spec_obs, err_obs, dist, grid_param_list, 
+                       initial_state, labels, bounds, resamp_before=True, 
+                       model_grid=None, model_reader=None, em_lines={}, 
+                       em_grid={}, dlbda_obs=None, instru_corr=None, 
+                       instru_fwhm=None, instru_idx=None, filter_reader=None, 
+                       AV_bef_bb=False, units_obs='si', units_mod='si', 
+                       interp_order=1, priors=None, physical=True, 
+                       interp_nonexist=True, ini_ball=1e-1, a=2.0, 
+                       nwalkers=1000, niteration_min=10, niteration_limit=1000, 
+                       niteration_supp=0, check_maxgap=20, conv_test='ac', 
+                       ac_c=50, ac_count_thr=3, burnin=0.3, rhat_threshold=1.01, 
+                       rhat_count_threshold=1, grid_name='resamp_grid.fits', 
+                       output_dir='specfit/', output_file=None, nproc=1, 
+                       display=False, verbosity=0, save=False):
+    """ Runs an affine invariant MCMC sampling algorithm in order to determine
+    the most likely parameters for given spectral model and observed spectrum. 
+    Allowed features:
+        - Spectral models can either be read from a grid (e.g. BT-SETTL) or 
+        be purely parametric (e.g. a blackbody model). 
+        - Extinction (A_V) and total-to-selective optical extinction ratio (R_V)
+        can be sampled. Default: A_V=0. If non-zero, default R_V=3.1 (ISM).
+        - A dictionary of emission lines can be provided and their flux can be 
+        sampled too.
+        - Gaussian priors can be provided for each parameter, including the 
+        mass of the object. The latter will be used if 'logg' is a parameter.
+        - Spectral correlation between measurements will be taken into account 
+        if provided in 'instru_corr'.
+        - Convolution of the model spectra with instrumental FWHM or 
+        photometric filter can be performed using 'instru_fwhm' and/or 
+        'filter_reader' (done before resampling to observed).
+        - The weight of each observed point will be directly proportional to
+        Delta lbda_i/lbda_i, where Delta lbda_i is either the FWHM of the 
+        photometric filter (imager) or the width of the spectral channel (IFS).
+        - MCMC convergence criterion can either be based on auto-correlation 
+        time (default) or the Gelman-Rubin test.
+    The result of this procedure is a chain with the samples from the posterior 
+    distributions of each of the free parameters in the model.
+    More details in Christiaens et al. (2021).
+    
+    Parameters
+    ----------
+    lbda_obs : numpy 1d ndarray or list
+        Wavelength of observed spectrum. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs).
+    spec_obs : numpy 1d ndarray or list
+        Observed spectrum for each value of lbda_obs.
+    err_obs : numpy 1d/2d ndarray or list
+        Uncertainties on the observed spectrum. If 2d array, should be [2,n_ch]
+        where the first (resp. second) column corresponds to lower (upper) 
+        uncertainty, and n_ch is the length of lbda_obs and spec_obs.
+    dist :  float
+        Distance in parsec, used for flux scaling of the models.
+    grid_param_list : list of 1d numpy arrays/lists OR None
+        - If list, should contain list/numpy 1d arrays with available grid of 
+        model parameters. 
+        - Set to None for a pure n-blackbody fit, n=1,2,...
+        - Note1: model grids should not contain grids on radius and Av, but 
+        these should still be passed in initial_state (Av optional).
+        - Note2: for a combined grid model + black body, just provide
+        the grid parameter list here, and provide values for 'Tbbn' and 'Rbbn'
+        in initial_state, labels and bounds.
+    initial_state: tuple of floats
+        Initial guess on the best fit parameters of the spectral fit. Length of 
+        the tuple should match the total number of free parameters. Walkers
+        will all be initialised in a small ball of parameter space around that
+        first guess.
+        - first all parameters related to loaded models (e.g. 'Teff', 'logg')
+        - then the planet photometric radius 'R', in Jupiter radius
+        - (optionally) the intensity of emission lines (labels must match 
+        those in the em_lines dict), in units of the model spectrum (x mu)
+        - (optionally) the optical extinction 'Av', in mag
+        - (optionally) the ratio of total to selective optical extinction 'Rv'
+        - (optionally) 'Tbb1', 'Rbb1', 'Tbb2', 'Rbb2', etc. for each extra bb
+        contribution
+    labels: Tuple of strings
+        Tuple of labels in the same order as initial_state, that is:
+        - first all parameters related to loaded models (e.g. 'Teff', 'logg')
+        - then the planet photometric radius 'R', in Jupiter radius
+        - (optionally) the flux of emission lines (labels should match those in
+        the em_lines dictionary), in units of the model spectrum (times mu)
+        - (optionally) the optical extinction 'Av', in mag
+        - (optionally) the ratio of total to selective optical extinction 'Rv'
+        - (optionally) 'Tbb1', 'Rbb1', 'Tbb2', 'Rbb2', etc. for each extra bb
+        contribution.
+    bounds: dictionary
+        Each entry should be associated with a tuple corresponding to lower and 
+        upper bounds respectively. Bounds should be provided for ALL model
+        parameters, including 'R' (planet photometric radius). 'Av' (optical 
+        extinction) is optional. If provided here, Av will also be fitted.
+        Example for BT-SETTL: bounds = {'Teff':(1000,2000), 'logg':(3.0,4.5),
+        'R':(0.1,5), 'Av':(0.,2.5)}
+        'M' can be used for a prior on the mass of the planet. In that case the
+        corresponding prior log probability is computed from the values for 
+        parameters 'logg' and 'R' (if both exist).
+    resamp_before: bool, optional
+        Whether to prepare the whole grid of resampled models before entering 
+        the MCMC, i.e. to avoid doing it at every MCMC step. Recommended.
+        Only reason not to: model grid is too large and individual models 
+        require being opened and resampled at each step.
+    model_grid : numpy N-d array, optional
+        If provided, should contain the grid of model spectra for each
+        free parameter of the given grid. I.e. for a grid of n_T values of Teff 
+        and n_g values of Logg, the numpy array should be n_T x n_g x n_ch x 2, 
+        where n_ch is the number of wavelengths for the observed spectrum,
+        and the last 2 dims are for wavelength and fluxes respectively.
+        If provided, takes precedence over filename/file_reader.
+    model_reader : python routine, optional
+        External routine that reads a model file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains model values. See example routine in model_interpolation() 
+        description.
+    em_lines: dictionary, opt
+        Dictionary of emission lines to be added on top of the model spectrum.
+        Each dict entry should be the name of the line, assigned to a tuple of
+        4 values: 
+            1) the wavelength (in mu); 
+            2) a string indicating whether line intensity is expressed in flux 
+            ('F'), luminosity ('L') or log(L/LSun) ("LogL");
+            3) the FWHM of the gaussian (or None if to be set automatically); 
+            4) whether the FWHM is expressed in 'nm', 'mu' or 'km/s'. 
+        The third and fourth can also be set to None. In that case, the FWHM of 
+        the gaussian will automatically be set to the equivalent width of the
+        line, calculated from the flux to be injected and the continuum 
+        level (measured in the grid model to which the line is injected). 
+        Examples: em_lines = {'BrG':(2.1667,'F',None, None)};
+                  em_lines = {'BrG':(2.1667,'LogL', 100, 'km/s')}
+    em_grid: dictionary pointing to lists, opt
+        Dictionary where each entry corresponds to an emission line and points
+        to a list of values to inject for emission line fluxes. For computation 
+        efficiency, interpolation will be performed between the points of this 
+        grid during the MCMC sampling. Dict entries should match labels and 
+        em_lines.
+    dlbda_obs: numpy 1d ndarray or list, optional
+        Spectral channel width for the observed spectrum. It should be provided 
+        IF one wants to weigh each point based on the spectral 
+        resolution of the respective instruments (as in Olofsson et al. 2016).
+    instru_corr : numpy 2d ndarray or list, optional
+        Spectral correlation throughout post-processed images in which the 
+        spectrum is measured. It is specific to the combination of instrument, 
+        algorithm and radial separation of the companion from the central star.
+        Can be computed using distances.spectral_correlation(). In case of
+        a spectrum obtained with different instruments, build it with
+        distances.combine_corrs(). If not provided, it will consider the 
+        uncertainties in each spectral channels are independent. See Greco & 
+        Brandt (2017) for details.
+    instru_fwhm : float OR list of either floats or strings, optional
+        The instrumental spectral fwhm provided in nm. This is used to convolve
+        the model spectrum. If several instruments are used, provide a list of 
+        instru_fwhm values, one for each instrument whose spectral resolution
+        is coarser than the model - including broad band filter FWHM if 
+        relevant.
+        If strings are provided, they should correspond to filenames (including 
+        full paths) of text files containing the filter information for each 
+        observed wavelength. Strict format: 
+    instru_idx: numpy 1d array, optional
+        1d array containing an index representing each instrument used 
+        to obtain the spectrum, label them from 0 to n_instru. Zero for points 
+        that don't correspond to any instru_fwhm provided above, and i in 
+        [1,n_instru] for points associated to instru_fwhm[i-1]. This parameter 
+        must be provided if the spectrum consists of points obtained with 
+        different instruments.
+    filter_reader: python routine, optional
+        External routine that reads a filter file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains transmission values. Important: if not provided, but strings 
+        are detected in instru_fwhm, the default file reader will be used. 
+        It assumes the following format for the files:
+        - first row containing header
+        - starting from 2nd row: 1st column: wavelength, 2nd col.: transmission
+        - Unit of wavelength can be provided in parentheses of first header key
+        name: e.g. "WL(AA)" for angstrom, "wavelength(mu)" for micrometer or
+        "lambda(nm)" for nanometer. Note: Only what is in parentheses matters.
+        Important: filter files should all have the same format and WL units.
+    AV_bef_bb: bool, optional
+        If both extinction and an extra bb component are free parameters, 
+        whether to apply extinction before adding the BB component (e.g. 
+        extinction mostly from circumplanetary dust) or after the BB component
+        (e.g. mostly insterstellar extinction).
+    units_obs : str, opt {'si','cgs','jy'}
+        Units of observed spectrum. 'si' for W/m^2/mu; 'cgs' for ergs/s/cm^2/mu 
+        or 'jy' for janskys.
+    units_mod: str, opt {'si','cgs','jy'}
+        Units of the model. 'si' for W/m^2/mu; 'cgs' for ergs/s/cm^2/mu or 'jy'
+        for janskys. If different to units_obs, the spectrum units will be 
+        converted.
+    interp_order: int, opt, {-1,0,1} 
+        Interpolation mode for model interpolation.
+        -1: log interpolation (i.e. linear interpolatlion on log(Flux))
+        0: nearest neighbour model.
+        1: Order 1 spline interpolation.
+    priors: dictionary, opt
+        If not None, sets prior estimates for each parameter of the model. Each 
+        entry should be set to either None (no prior) or a tuple of 2 elements 
+        containing prior estimate and uncertainty on the estimate.
+        Missing entries (i.e. provided in bounds dictionary but not here) will
+        be associated no prior.
+        e.g. priors = {'Teff':(1600,100), 'logg':(3.5,0.5),
+                       'R':(1.6,0.1), 'Av':(1.8,0.2), 'M':(10,3)}
+        Important: dictionary entry names should match exactly those of bounds.
+    physical: bool, opt
+        In case of extra black body component(s) to a photosphere, whether to 
+        force lower temperature than the photosphere effective temperature.
+    interp_nonexist: bool, opt
+        Whether to interpolate non-existing models in the grid. Only used if 
+        resamp_before is set to True.
+    ini_ball: float or string, default=1e-1
+        Size of the initial ball in parameter space from which walkers start 
+        their chain. If "uniform" is provided, a uniform ini_ball spanning
+        the bounds interval will be used to initialise walkers.
+    a: float, default=2.0
+        The proposal scale parameter. See notes.
+    nwalkers: int, default: 1000
+        Number of walkers
+    niteration_min: int, optional
+        Steps per walker lower bound. The simulation will run at least this
+        number of steps per walker.
+    niteration_limit: int, optional
+        Steps per walker upper bound. If the simulation runs up to
+        'niteration_limit' steps without having reached the convergence
+        criterion, the run is stopped.
+    niteration_supp: int, optional
+        Number of iterations to run after having "reached the convergence".
+    burnin: float, default=0.3
+        The fraction of a walker which is discarded.
+    rhat_threshold: float, default=0.01
+        The Gelman-Rubin threshold used for the test for nonconvergence.
+    rhat_count_threshold: int, optional
+        The Gelman-Rubin test must be satisfied 'rhat_count_threshold' times in
+        a row before claiming that the chain has converged.
+    check_maxgap: int, optional
+        Maximum number of steps per walker between two convergence tests.
+    conv_test: str, optional {'gb','autocorr'}
+        Method to check for convergence: 
+        - 'gb' for gelman-rubin test
+        (http://digitalassets.lib.berkeley.edu/sdtr/ucb/text/305.pdf)
+        - 'autocorr' for autocorrelation analysis 
+        (https://emcee.readthedocs.io/en/stable/tutorials/autocorr/)
+    nproc: int, optional
+        The number of processes to use for parallelization.
+    grid_name: str, optional
+        Name of the fits file containing the model grid (numpy array) AFTER
+        convolution+resampling as the observed spectrum given as input.
+        If provided, will read it if it exists (and resamp_before is set
+        to True), or make it and write it if it doesn't.
+    output_dir: str, optional
+        The name of the output directory which contains the output files in the 
+        case  ``save`` is True.        
+    output_file: str, optional
+        The name of the output file which contains the MCMC results in the case
+        ``save`` is True.
+    display: bool, optional
+        If True, the walk plot is displayed at each evaluation of the Gelman-
+        Rubin test.
+    verbosity: 0, 1 or 2, optional
+        Verbosity level. 0 for no output and 2 for full information.
+    save: bool, optional
+        If True, the MCMC results are pickled.
+                    
+    Returns
+    -------
+    out : numpy.array
+        The MCMC samples after truncation of zeros.
+    lnprobability: emcee sample object
+        The corresponding probabilities for each sample
+        
+    Notes
+    -----
+    The parameter `a` must be > 1. For more theoretical information concerning
+    this parameter, see Goodman & Weare, 2010, Comm. App. Math. Comp. Sci.,
+    5, 65, Eq. [9] p70.
+    
+    The parameter 'rhat_threshold' can be a numpy.array with individual
+    threshold value for each model parameter.
+    """
+    nparams = len(initial_state)
+    
+    if grid_param_list is not None:
+        if model_grid is None and model_reader is None:
+            msg = "Either model_grid or model_reader have to be provided"
+            raise TypeError(msg)
+        n_gparams = len(grid_param_list)
+        gp_dims = []
+        for nn in range(n_gparams):
+            gp_dims.append(len(grid_param_list[nn]))
+        gp_dims = tuple(gp_dims)
+    else:
+        n_gparams = 0
+        
+    # format emission line dictionary and em grid
+    if len(em_grid)>0:
+        n_em = len(em_grid)
+        em_dims = []
+        for lab in labels:
+            if lab in em_grid.keys():
+                em_dims.append(len(em_grid[lab]))
+        em_dims = tuple(em_dims)
+        # update the grids depending on input units => make it surface flux
+        idx_R = labels.index('R')
+        for key, val in em_lines.items():
+            if val[1] == 'L':
+                idx_line = labels.index(key)
+                # adapt grid
+                R_si = initial_state[idx_R]*con.R_jup.value
+                conv_fac = 4*np.pi*R_si**2
+                tmp = np.array(em_grid[key])/conv_fac
+                em_grid[key] = tmp.tolist()
+                # adapt ini state 
+                initial_state = list(initial_state)
+                initial_state[idx_line] /= conv_fac
+                initial_state = tuple(initial_state)
+                #adapt bounds
+                bounds_ori = list(bounds[key])
+                bounds[key] = (bounds_ori[0]/conv_fac, bounds_ori[1]/conv_fac) 
+            elif val[1] == 'LogL':
+                idx_line = labels.index(key)
+                R_si = initial_state[idx_R]*con.R_jup.value
+                conv_fac = con.L_sun.value/(4*np.pi*R_si**2)
+                tmp = np.power(10,np.array(em_grid[key]))*conv_fac
+                em_grid[key] = tmp.tolist()  
+                # adapt ini state 
+                initial_state = list(initial_state)
+                initial_state[idx_line] = conv_fac*10**initial_state[idx_line]
+                initial_state = tuple(initial_state)
+                #adapt bounds
+                bounds_ori = list(bounds[key])
+                bounds[key] = (conv_fac*10**bounds_ori[0], 
+                               conv_fac*10**bounds_ori[1]) 
+            if em_lines[key][2] is not None:
+                if em_lines[key][-1] == 'km/s':
+                    v = em_lines[key][2]
+                    em_lines_tmp = list(em_lines[key])
+                    em_lines_tmp[2] = (1000*v/con.c.value)*em_lines[key][0]
+                    em_lines_tmp[3] = 'mu'
+                    em_lines[key] = tuple(em_lines_tmp)
+                elif em_lines[key][-1] == 'nm':
+                    em_lines_tmp = list(em_lines[key])
+                    em_lines_tmp[2] = em_lines[key][2]/1000
+                    em_lines_tmp[3] = 'mu'
+                    em_lines[key] = tuple(em_lines_tmp)
+                elif em_lines[key][-1] != 'mu':
+                    msg = "Invalid unit of FWHM for line injection"
+                    raise ValueError(msg)
+                
+    if model_grid is not None and grid_param_list is not None:
+        if model_grid.ndim-2 != n_gparams:
+            msg = "Ndim-2 of model_grid should match len(grid_param_list)"
+            raise TypeError(msg)
+    
+    if verbosity > 0:
+        start_time = time_ini()
+        print("       MCMC sampler for spectral fitting       ")
+        print(sep)
+
+
+    # If required, create the output folder.
+    if save or resamp_before:
+        if not output_dir:
+            raise ValueError('Please provide an output directory path')
+        if not isdir(output_dir):
+            os.makedirs(output_dir)
+        if output_dir[-1] != '/':
+            output_dir = output_dir+'/'
+
+        #output_file_tmp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+ 
+    # Check model grid parameters extend beyond bounds to avoid extrapolation
+    if grid_param_list is not None:
+        for pp in range(n_gparams):
+            if grid_param_list[pp][0]>bounds[labels[pp]][0]:
+                msg= "Grid has to extend beyond bounds for {}."
+                msg+="\n Consider increasing the lower bound to >{}."
+                raise ValueError(msg.format(labels[pp],grid_param_list[pp][0]))
+            if grid_param_list[pp][-1]<bounds[labels[pp]][1]:
+                msg= "Grid has to extend beyond bounds for {}."
+                msg+="\n Consider decreasing the upper bound to <{}."
+                raise ValueError(msg.format(labels[pp],grid_param_list[pp][1]))
+                
+    # Check initial state is within bounds for all params (not only grid)
+    for pp in range(nparams):
+        if initial_state[pp]<bounds[labels[pp]][0]:
+            msg= "Initial state has to be within bounds for {}."
+            msg+="\n Consider decreasing the lower bound to <{}."
+            raise ValueError(msg.format(labels[pp],initial_state[pp]))            
+        if initial_state[pp]>bounds[labels[pp]][1]:
+            msg= "Initial state has to be within bounds for {}."
+            msg+="\n Consider decreasing the upper bound to >{}."
+            raise ValueError(msg.format(labels[pp],initial_state[pp]))
+        
+    # Prepare model grid: convolve+resample models as observations 
+    if resamp_before and grid_param_list is not None:
+        if isfile(output_dir+grid_name):
+            model_grid = open_fits(output_dir+grid_name)
+            # check its shape is consistent with grid_param_list
+            if model_grid.shape[:n_gparams] != gp_dims:
+                msg="the loaded model grid ({}) doesn't have expected dims ({})"
+                raise TypeError(msg.format(model_grid.shape,gp_dims))
+            elif model_grid.shape[-2] != len(lbda_obs):
+                msg="the loaded model grid doesn't have expected WL dimension"
+                raise TypeError(msg)
+            elif model_grid.shape[-1] != 2:
+                msg="the loaded model grid doesn't have expected last dimension"
+                raise TypeError(msg)
+            elif len(em_grid) > 0:
+                if model_grid.shape[n_gparams:n_gparams+n_em] != em_dims:
+                    msg="loaded model grid ({}) doesn't have expected dims ({})"
+                    raise TypeError(msg.format(model_grid.shape,em_dims))
+        else:
+            model_grid = make_resampled_models(lbda_obs, grid_param_list, 
+                                               model_grid, model_reader, 
+                                               em_lines, em_grid, dlbda_obs, 
+                                               instru_fwhm, instru_idx, 
+                                               filter_reader, interp_nonexist)
+            if output_dir and grid_name:
+                write_fits(output_dir+grid_name, model_grid)
+        # note: if model_grid is provided, it is still resampled to the 
+        # same wavelengths as observed spectrum. However, if a fits name is 
+        # provided in grid_name and that file exists, it is assumed the model 
+        # grid in it is already resampled to match lbda_obs.
+
+    if save and output_file is None:
+        output_file = 'MCMC_results'
+
+    
+    # #########################################################################
+    # Initialization of the MCMC variables                                    #
+    # #########################################################################
+    dim = len(labels)
+    itermin = niteration_min
+    limit = niteration_limit
+    supp = niteration_supp
+    maxgap = check_maxgap
+    initial_state = np.array(initial_state)
+    
+    if itermin > limit:
+        itermin = 0
+
+    fraction = 0.3
+    geom = 0
+    lastcheck = 0
+    konvergence = np.inf
+    rhat_count = 0
+    ac_count = 0
+    chain = np.empty([nwalkers, 1, dim])
+    ar_frac = np.empty([nwalkers, 1])
+    nIterations = limit + supp
+    rhat = np.zeros(dim)
+    stop = np.inf
+    
+    # initialise ball of walkers
+    if ini_ball == "uniform":
+        pos = np.zeros([nwalkers, dim])
+        for ii in range(dim):
+            low_b = bounds[labels[ii]][0]
+            up_b = (bounds[labels[ii]][1])
+            pos[:,ii] = np.random.uniform(low_b + 0.01*(up_b-low_b), 
+                                          up_b, nwalkers)
+    elif isinstance(ini_ball,float):
+        pos = initial_state + np.random.normal(0, ini_ball, (nwalkers, dim))
+    else:
+        raise ValueError("ini_ball must be string or float")
+    
+    sampler = emcee.EnsembleSampler(nwalkers, dim, spec_lnprob, a,
+                                    args=([labels, bounds, grid_param_list, 
+                                           lbda_obs, spec_obs, err_obs, dist,
+                                           model_grid, model_reader, em_lines,
+                                           em_grid, dlbda_obs, instru_corr, 
+                                           instru_fwhm,instru_idx,filter_reader, 
+                                           AV_bef_bb, units_obs, units_mod, 
+                                           interp_order, priors, physical]),
+                                    threads=nproc)
+                                    
+    start = datetime.datetime.now()
+
+    # #########################################################################
+    # Affine Invariant MCMC run
+    # #########################################################################
+    if verbosity > 1:
+        print('\nStart of the MCMC run ...')
+        print('Step  |  Duration/step (sec)  |  Remaining Estimated Time (sec)')
+    
+    for k, res in enumerate(sampler.sample(pos, iterations=nIterations,
+                                           storechain=True)):
+        elapsed = (datetime.datetime.now()-start).total_seconds()
+        if verbosity > 1:
+            if k == 0:
+                q = 0.5
+            else:
+                q = 1
+            print('{}\t\t{:.5f}\t\t\t{:.5f}'.format(k, elapsed * q,
+                                                    elapsed * (limit-k-1) * q))
+            
+        start = datetime.datetime.now()
+
+        # ---------------------------------------------------------------------
+        # Store the state manually in order to handle with dynamical sized chain
+        # ---------------------------------------------------------------------
+        # Check if the size of the chain is long enough.
+        s = chain.shape[1]
+        if k+1 > s:     # if not, one doubles the chain length
+            empty = np.zeros([nwalkers, 2*s, dim])
+            chain = np.concatenate((chain, empty), axis=1)
+            empty = np.zeros([nwalkers, 2*s])
+            ar_frac = np.concatenate((ar_frac, empty), axis=1)
+        # Store the state of the chain
+        chain[:, k] = res[0]
+        ar_frac[:,k] = sampler.acceptance_fraction
+
+        # ---------------------------------------------------------------------
+        # If k meets the criterion, one tests the non-convergence.
+        # ---------------------------------------------------------------------
+        criterion = int(np.amin([np.ceil(itermin*(1+fraction)**geom),
+                        lastcheck+np.floor(maxgap)]))
+        if k == criterion:
+            
+            geom += 1
+            lastcheck = k
+            if display:
+                spec_show_walk_plot(chain)
+                
+            # We only test the rhat if we have reached the min # of steps
+            if (k+1) >= itermin and konvergence == np.inf:
+                if verbosity > 1:
+                    print('\n{} convergence test in progress...'.format(conv_test))
+                if conv_test == 'gb':
+                    thr0 = int(np.floor(burnin*k))
+                    thr1 = int(np.floor((1-burnin)*k*0.25))
+    
+                    # We calculate the rhat for each model parameter.
+                    for j in range(dim):
+                        part1 = chain[:, thr0:thr0 + thr1, j].reshape(-1)
+                        part2 = chain[:, thr0 + 3 * thr1:thr0 + 4 * thr1, j
+                                     ].reshape(-1)
+                        series = np.vstack((part1, part2))
+                        rhat[j] = gelman_rubin(series)
+                    if verbosity > 0:
+                        print('   r_hat = {}'.format(rhat))
+                        cond = rhat <= rhat_threshold
+                        print('   r_hat <= threshold = {} \n'.format(cond))
+                    # We test the rhat.
+                    if (rhat <= rhat_threshold).all():
+                        rhat_count += 1
+                        if rhat_count < rhat_count_threshold:
+                            if verbosity > 0:
+                                msg = "Gelman-Rubin test OK {}/{}"
+                                print(msg.format(rhat_count, 
+                                                 rhat_count_threshold))
+                        elif rhat_count >= rhat_count_threshold:
+                            if verbosity > 0:
+                                print('... ==> convergence reached')
+                            konvergence = k
+                            stop = konvergence + supp
+                    else:
+                        rhat_count = 0
+                elif conv_test == 'ac':
+                    # We calculate the auto-corr test for each model parameter.
+                    for j in range(dim):
+                        rhat[j] = autocorr_test(chain[:,:k,j])
+                    thr = 1./ac_c
+                    if verbosity > 0:
+                        print('Auto-corr tau/N = {}'.format(rhat))
+                        print('tau/N <= {} = {} \n'.format(thr, rhat<thr))
+                    if (rhat <= thr).all():
+                        ac_count+=1
+                        if verbosity > 0:
+                            msg = "Auto-correlation test passed for all params!"
+                            msg+= "{}/{}".format(ac_count,ac_count_thr)
+                            print(msg)
+                        if ac_count >= ac_count_thr:
+                            msg='\n ... ==> convergence reached'
+                            print(msg)
+                            stop = k
+                    else:
+                        ac_count = 0
+                else:
+                    raise ValueError('conv_test value not recognized')
+                
+                                
+                if save and verbosity == 3:
+                    ac_time = []
+                    for j in range(dim):
+                        ac_time.append(k*autocorr_test(chain[:,:k,j]))
+                    fname = '{d}/{f}_temp_k{k}'.format(d=output_dir,
+                                                       f=output_file, k=k)
+                    data = {'chain': sampler.chain,
+                            'lnprob': sampler.lnprobability,
+                            'ac_time': ac_time,
+                             'AR': ar_frac}
+                    with open(fname, 'wb') as fileSave:
+                        pickle.dump(data, fileSave)
+
+        # We have reached convergence
+        if k+1 >= stop:
+            if verbosity > 0:
+                print('We break the loop because we have reached convergence')
+            break
+        # We have reached the maximum number of steps for our Markov chain.
+        if k+1 >= nIterations-1:
+            # break to avoid a bug related to font type
+            break
+        
+    isamples, ln_proba, ar = spec_chain_zero_truncated(chain, 
+                                                       sampler.lnprobability,
+                                                       ar_frac)   
+    # update units in the chain if needed
+    if len(em_grid)>0:
+        for key, val in em_lines.items():
+            idx_line = labels.index(key)
+            if val[1] == 'L':
+                R_si = isamples[:,:,idx_R]*con.R_jup.value
+                isamples[:,:,idx_line] *= 4*np.pi*R_si**2
+            elif val[1] == 'LogL':
+                R_si = isamples[:,:,idx_R]*con.R_jup.value
+                conv_fac = 4*np.pi*R_si**2/con.L_sun.value
+                isamples[:,:,idx_line] = np.log10(isamples[:,:,idx_line]*conv_fac)
+      
+    if k == nIterations-1:
+        if verbosity > 0:
+            print("We have reached the limit # of steps without convergence")
+            print("You may have to increase niteration_limit")
+    # #########################################################################
+    # Construction of the independent samples
+    # #########################################################################
+ 
+
+    if save:
+        frame = inspect.currentframe()
+        args, _, _, values = inspect.getargvalues(frame)
+        input_parameters = {j: values[j] for j in args[1:]}
+        ac_time = []
+        for j in range(dim):
+            ac_time.append(isamples.shape[1]*autocorr_test(isamples[:,:,j]))
+        output = {'isamples': isamples,
+                  #'chain': chain,
+                  'input_parameters': input_parameters,
+                  'AR': ar,
+                  'ac_time': ac_time,
+                  'lnprobability': ln_proba}
+                  
+        with open(output_dir+output_file, 'wb') as fileSave:
+            pickle.dump(output, fileSave)
+        
+        msg = "\nThe file MCMC_results has been stored in the folder {}"
+        print(msg.format(output_dir))
+
+    if verbosity > 0:
+        timing(start_time)
+                                    
+    return isamples, ln_proba
+
+                                    
+def spec_chain_zero_truncated(chain, ln_proba=None, ar=None):
+    """
+    Return the Markov chain with the dimension: walkers x steps* x parameters,
+    where steps* is the last step before having 0 (not yet constructed chain).
+    
+    Parameters
+    ----------
+    chain: numpy.array
+        The MCMC chain.
+    ln_proba: numpy.array, opt
+        Corresponding ln-probabilities.
+     
+    Returns
+    -------
+    out: numpy.array
+        The truncated MCMC chain, that is to say, the chain which only contains
+        relevant information.
+    out_ln_proba: numpy.array
+        If ln_proba is provided as input, out_ln_proba contains the 
+        zero-truncated ln-proba (i.e. matching shape with non-zero samples)
+    """
+    try:
+        idxzero = np.where(chain[0, :, 0] == 0.0)[0][0]
+    except:
+        idxzero = chain.shape[1]
+    res = [chain[:, 0:idxzero, :]]
+        
+    if ln_proba is not None:
+        res.append(ln_proba[:,0:idxzero])
+    if ar is not None:
+        res.append(ar[:,0:idxzero])
+    if len(res) == 1:
+        return res[0]
+    else:
+        return tuple(res)
+ 
+   
+def spec_show_walk_plot(chain, labels, save=False, output_dir='', ntrunc=100,
+                        **kwargs):
+    """
+    Display/save a figure showing the path of each walker during the MCMC run.
+    
+    Parameters
+    ----------
+    chain: numpy.array
+        The Markov chain. The shape of chain must be nwalkers x length x dim.
+        If a part of the chain is filled with zero values, the method will
+        discard these steps.
+    labels: Tuple of strings
+        Tuple of labels in the same order as initial_state, that is:
+        - first all parameters related to loaded models (e.g. 'Teff', 'logg')
+        - next the planet photometric radius 'R',
+        - (optionally) the optical extinction 'Av'.
+        - (optionally) 'Tbb1', 'Rbb1', 'Tbb2', 'Rbb2', etc. for each extra bb
+        contribution
+    save: boolean, default: False
+        If True, a pdf file is created.
+    ntrunc: int, opt
+        max number of walkers plotted. If too many walkers the plot will become
+        too voluminous and too crowded. Plot will be truncated to only ntrunc 
+        first walkers
+    kwargs:
+        Additional attributes are passed to the matplotlib plot method.
+                                                        
+    Returns
+    -------
+    Display the figure or create a pdf file named walk_plot.pdf in the working
+    directory.
+    
+    """
+    npar = chain.shape[-1]
+    if len(labels) != npar:
+        raise ValueError("Labels length should match chain last dimension")
+    temp = np.where(chain[0, :, 0] == 0.0)[0]
+    if len(temp) != 0:
+        chain = chain[:, :temp[0], :]
+
+
+    color = kwargs.pop('color', 'k')
+    alpha = kwargs.pop('alpha', 0.1)
+    filename = kwargs.pop('filename','walk_plot.pdf')
+    #labels = kwargs.pop('labels', ["$r$", r"$\theta$", "$f$"])
+    fig, axes = plt.subplots(npar, 1, sharex=True,
+                             figsize=kwargs.pop('figsize', (8, int(2*npar))))
+    if npar>1:
+        axes[-1].set_xlabel(kwargs.pop('xlabel', 'step number'))
+        axes[-1].set_xlim(kwargs.pop('xlim', [0, chain.shape[1]]))
+        for j in range(npar):
+            axes[j].plot(chain[:ntrunc, :, j].T, color=color, alpha=alpha, **kwargs)
+            axes[j].yaxis.set_major_locator(MaxNLocator(5))
+            axes[j].set_ylabel(labels[j])
+    else:
+        axes.set_xlabel(kwargs.pop('xlabel', 'step number'))
+        axes.set_xlim(kwargs.pop('xlim', [0, chain.shape[1]]))            
+        for j in range(npar):
+            axes.plot(chain[:ntrunc, :, j].T, color=color, alpha=alpha, **kwargs)
+            axes.yaxis.set_major_locator(MaxNLocator(5))
+            axes.set_ylabel(labels[j])
+    fig.tight_layout(h_pad=0)
+    if save:
+        plt.savefig(output_dir+filename)
+        plt.close(fig)
+    else:
+        plt.show()
+
+
+def spec_show_corner_plot(chain, burnin=0.5, save=False, output_dir='', 
+                          mcmc_res=None, units=None, ndig=None, 
+                          labels_plot=None, plot_name='corner_plot.pdf', **kwargs):
+    """
+    Display/save a figure showing the corner plot (pdfs + correlation plots).
+    
+    Parameters
+    ----------
+    chain: numpy.array
+        The Markov chain. The shape of chain must be nwalkers x length x dim.
+        If a part of the chain is filled with zero values, the method will
+        discard these steps.
+    burnin: float, default: 0
+        The fraction of a walker we want to discard.
+    save: boolean, default: False
+        If True, a pdf file is created.
+    mcmc_res: numpy array OR tuple of 2 dictionaries/np.array, opt
+        Values to be printed on top of each 1d posterior distribution   
+        - if numpy array: 
+            - npar x 3 dimensions (where npar is the number of parameters), 
+            containing the most likely value of each parameter and the lower 
+            and upper uncertainties at the desired quantiles, resp. 
+            - npar x 2 dimensions: same as above but with a single value of  
+            uncertainty. E.g. output of spec_confidence() for a gaussian fit
+        - if tuple of 2 dictionaries: output of spec_confidence without 
+                                      gaussian fit
+        - if tuple of 2 np.array: output of spec_confidence() with gaussian fit
+    units: tuple, opt
+        Tuple of strings containing units for each parameter. If provided,
+        mcmc_res will be printed on top of each 1d posterior distribution along 
+        with these units.
+    ndig: tuple, opt
+        Number of digits precision for each printed parameter
+    labels_plot: tuple, opt
+        Labels corresponding to parameter names, used for the plot. If None,
+        will use "labels" passed in kwargs.
+    kwargs:
+        Additional attributes passed to the corner.corner() method.
+        (e.g. 'labels', 'show_title')
+                    
+    Returns
+    -------
+    Display the figure or create a pdf file named walk_plot.pdf in the working
+    directory.
+        
+    Raises
+    ------
+    ImportError
+    
+    """
+    
+    npar = chain.shape[-1]
+    if "labels" in kwargs.keys():
+        labels = kwargs.pop('labels')
+        if labels_plot is None:
+            labels_plot = labels
+    else:
+        labels = None
+        
+    # allows for different title/units on top of 1D posterior distributions
+    labels_tit = kwargs.pop('labels_tit', labels_plot)
+    labels_tit_unit = kwargs.pop('labels_tit_unit', units)
+    
+    try:
+        temp = np.where(chain[0, :, 0] == 0.0)[0]
+        if len(temp) != 0:
+            chain = chain[:, :temp[0], :]
+        length = chain.shape[1]
+        indburn = int(np.floor(burnin*(length-1)))
+        chain = chain[:, indburn:length, :].reshape((-1, npar))
+    except IndexError:
+        pass
+
+    if chain.shape[0] == 0:
+        raise ValueError("It seems the chain is empty. Have you run the MCMC?")
+    else:
+        fig = corner.corner(chain, labels=labels_plot, **kwargs)
+
+        
+    if mcmc_res is not None and labels is not None:
+        title_kwargs = kwargs.pop('title_kwargs', None)
+        if isinstance(mcmc_res,tuple):
+            if len(mcmc_res) != 2:
+                msg = "mcmc_res should have 2 elements"
+                raise TypeError(msg)
+            if len(mcmc_res[0]) != npar or len(mcmc_res[1]) != npar:
+                msg = "dict should have as many entries as there are params"
+                raise TypeError(msg)
+            if labels is None:
+                msg = "labels should be provided"
+                raise TypeError(msg)                
+        elif isinstance(mcmc_res,np.ndarray):
+            if mcmc_res.shape[0] != npar:
+                msg = "mcmc_res first dim should be equal to number of params"
+                raise TypeError(msg)  
+        else:
+            msg = "type of mcmc_res not recognised"
+            raise TypeError(msg)
+        # Extract the axes
+        axes = np.array(fig.axes).reshape((npar, npar))
+                
+        # Loop over the diagonal
+        for i in range(npar):
+            ax = axes[i, i]
+            title = None
+            if isinstance(mcmc_res,tuple):
+                if isinstance(mcmc_res[0],dict):
+                    q_50 = mcmc_res[0][labels[i]]
+                    q_m = mcmc_res[1][labels[i]][0]
+                    q_p = mcmc_res[1][labels[i]][1]
+                else:
+                    q_50 = mcmc_res[0][i][0]
+                    q_m = mcmc_res[1][i][0]
+                    q_p = q_m
+            else:
+                q_50 = mcmc_res[i,0]
+                q_m = mcmc_res[i,1]
+                q_p = mcmc_res[i,2]
+
+            # Format the quantile display.
+            try:
+                fmt = "{{:.{0}f}}".format(ndig[i]).format
+            except:
+                fmt = "{{:.2f}}".format
+            title = r"${{{0}}}_{{{1}}}^{{+{2}}}$"
+            title = title.format(fmt(q_50), fmt(q_m), fmt(q_p))
+
+            # Add in the column name if it's given.
+            try:
+                title = "{0} = {1} {2}".format(labels_tit[i], title, 
+                                               labels_tit_unit[i])
+            except:
+                title = "{0} = {1}".format(labels_tit[i], title)
+                
+            ax.set_title(title, **title_kwargs)
+    
+    if save:
+        plt.savefig(output_dir+plot_name)
+        plt.close(fig)
+    else:
+        plt.show()
+
+
+def spec_confidence(isamples, labels, cfd=68.27, bins=100, gaussian_fit=False, 
+                    weights=None, verbose=True, save=False, output_dir='', 
+                    bounds=None, priors=None, **kwargs):
+    """
+    Determine the highly probable value for each model parameter, as well as
+    the 1-sigma confidence interval.
+    
+    Parameters
+    ----------
+    isamples: numpy.array
+        The independent samples for each model parameter.
+    labels: Tuple of strings
+        Tuple of labels in the same order as initial_state, that is:
+        - first all parameters related to loaded models (e.g. 'Teff', 'logg')
+        - next the planet photometric radius 'R',
+        - (optionally) the optical extinction 'Av'.
+        - (optionally) 'Tbb1', 'Rbb1', 'Tbb2', 'Rbb2', etc. for each extra bb
+        contribution
+    cfd: float, optional
+        The confidence level given in percentage.
+    bins: int, optional
+        The number of bins used to sample the posterior distributions.
+    gaussian_fit: boolean, optional
+        If True, a gaussian fit is performed in order to determine (\mu,\sigma)
+    weights : (n, ) numpy ndarray or None, optional
+        An array of weights for each sample.
+    verbose: boolean, optional
+        Display information in the shell.
+    save: boolean, optional
+        If "True", a txt file with the results is saved in the output
+        repository.
+    bounds: dictionary, opt
+        Only used if a text file is saved summarizing results+bounds+priors.
+        Should be the same bounds as provided to the MCMC.
+    priors: dictionary, opt
+        Only used if a text file is saved summarizing results+bounds+priors.
+        Should be the same priors as provided to the MCMC.
+    kwargs: optional
+        Additional attributes are passed to the matplotlib hist() method.
+        
+    Returns
+    -------
+    out: tuple
+        A 2 elements tuple with the highly probable solution and the confidence
+        interval.
+        
+    """
+    title = kwargs.pop('title', None)
+        
+    output_file = kwargs.pop('filename', 'confidence.txt')
+    
+    if gaussian_fit:
+        output_pdf = kwargs.pop('pdfname','confi_hist_spec_params_gaussfit.pdf')
+    else:
+        output_pdf = kwargs.pop('pdfname','confi_hist_spec_params.pdf')
+        
+    try:
+        l = isamples.shape[1]
+    except:
+        l = 1
+     
+    confidenceInterval = {}
+    val_max = {}
+    pKey = labels #['r', 'theta', 'f']
+    
+    if l != len(pKey):
+        raise ValueError("Labels length should match chain last dimension")
+    
+    if cfd == 100:
+        cfd = 99.9
+        
+    #########################################
+    ##  Determine the confidence interval  ##
+    #########################################
+    if gaussian_fit:
+        mu = np.zeros(l)
+        sigma = np.zeros_like(mu)
+    
+    if gaussian_fit:
+        fig, ax = plt.subplots(2, l, figsize=(int(4*l),8))
+    else:
+        fig, ax = plt.subplots(1, l, figsize=(int(4*l),4))
+    
+    for j in range(l):
+        
+        if gaussian_fit:
+            n, bin_vertices, _ = ax[0][j].hist(isamples[:,j], bins=bins,
+                                               weights=weights, histtype='step',
+                                               edgecolor='gray')
+        else:
+            n, bin_vertices, _ = ax[j].hist(isamples[:,j], bins=bins,
+                                            weights=weights, histtype='step',
+                                            edgecolor='gray')
+        bins_width = np.mean(np.diff(bin_vertices))
+        surface_total = np.sum(np.ones_like(n)*bins_width * n)
+        n_arg_sort = np.argsort(n)[::-1]
+        
+        test = 0
+        pourcentage = 0
+        for k, jj in enumerate(n_arg_sort):
+            test = test + bins_width*n[int(jj)]
+            pourcentage = test/surface_total*100
+            if pourcentage > cfd:
+                if verbose:
+                    msg = 'percentage for {}: {}%'
+                    print(msg.format(pKey[j], pourcentage))
+                break
+        n_arg_min = int(n_arg_sort[:k].min())
+        n_arg_max = int(n_arg_sort[:k+1].max())
+        
+        if n_arg_min == 0:
+            n_arg_min += 1
+        if n_arg_max == bins:
+            n_arg_max -= 1
+        
+        val_max[pKey[j]] = bin_vertices[int(n_arg_sort[0])]+bins_width/2.
+        confidenceInterval[pKey[j]] = np.array([bin_vertices[n_arg_min-1],
+                                               bin_vertices[n_arg_max+1]]
+                                               - val_max[pKey[j]])
+                        
+        arg = (isamples[:, j] >= bin_vertices[n_arg_min - 1]) * \
+              (isamples[:, j] <= bin_vertices[n_arg_max + 1])
+        if gaussian_fit:
+            ax[0][j].hist(isamples[arg,j], bins=bin_vertices,
+                          facecolor='gray', edgecolor='darkgray',
+                          histtype='stepfilled', alpha=0.5)
+            ax[0][j].vlines(val_max[pKey[j]], 0, n[int(n_arg_sort[0])],
+                            linestyles='dashed', color='red')
+            ax[0][j].set_xlabel(pKey[j])
+            if j == 0:
+                ax[0][j].set_ylabel('Counts')
+
+            mu[j], sigma[j] = norm.fit(isamples[:, j])
+            n_fit, bins_fit = np.histogram(isamples[:, j], bins, normed=1,
+                                           weights=weights)
+            ax[1][j].hist(isamples[:, j], bins, density=1, weights=weights,
+                          facecolor='gray', edgecolor='darkgray',
+                          histtype='step')
+            y = norm.pdf(bins_fit, mu[j], sigma[j])
+            ax[1][j].plot(bins_fit, y, 'r--', linewidth=2, alpha=0.7)
+
+            ax[1][j].set_xlabel(pKey[j])
+            if j == 0:
+                ax[1][j].set_ylabel('Counts')
+
+            if title is not None:
+                msg = r"{}   $\mu$ = {:.4f}, $\sigma$ = {:.4f}"
+                ax[1][j].set_title(msg.format(title, mu[j], sigma[j]),
+                                   fontsize=10)
+
+        else:
+            ax[j].hist(isamples[arg,j],bins=bin_vertices, facecolor='gray',
+                       edgecolor='darkgray', histtype='stepfilled',
+                       alpha=0.5)
+            ax[j].vlines(val_max[pKey[j]], 0, n[int(n_arg_sort[0])],
+                         linestyles='dashed', color='red')
+            ax[j].set_xlabel(pKey[j])
+            if j == 0:
+                ax[j].set_ylabel('Counts')
+
+            if title is not None:
+                msg = r"{} - {:.3f} {:.3f} +{:.3f}"
+                ax[1].set_title(msg.format(title, val_max[pKey[j]], 
+                                           confidenceInterval[pKey[j]][0], 
+                                           confidenceInterval[pKey[j]][1]),
+                                fontsize=10)
+
+        plt.tight_layout(w_pad=0.1)
+
+    if save:
+        plt.savefig(output_dir+output_pdf)
+
+
+    if verbose:
+        for j in range(l):
+            print("******* Results for {} ***** ".format(pKey[j]))
+            print('\n\nConfidence intervals:')
+            print('{}: {} [{},{}]'.format(pKey[j], val_max[pKey[j]],
+                                          confidenceInterval[pKey[j]][0],
+                                          confidenceInterval[pKey[j]][1]))
+            if gaussian_fit:
+                print('Gaussian fit results:')
+                print('{}: {} +-{}'.format(pKey[j], mu[j], sigma[j]))
+
+    ##############################################
+    ##  Write inference results in a text file  ##
+    ##############################################
+    if save:
+        with open(output_dir+output_file, "w") as f:
+            f.write('######################################\n')
+            f.write('####   MCMC results (confidence)   ###\n')
+            f.write('######################################\n')
+            f.write(' \n')
+            f.write('Results of the MCMC fit\n')
+            f.write('----------------------- \n')
+            f.write(' \n')
+            if bounds is not None:
+                f.write('Bounds\n')
+                f.write('------')
+                for j in range(l):
+                    f.write('\n{}: [{},{}]'.format(pKey[j], bounds[pKey[j]][0],
+                                                   bounds[pKey[j]][1]))
+                f.write(' \n')
+                f.write(' \n')
+            f.write('Priors\n')
+            f.write('------')
+            if priors is not None:
+                for key, prior in priors.items():
+                    f.write('\n{}: {}+-{}'.format(key, prior[0], prior[1]))
+            else:
+                f.write('\n None')
+            f.write(' \n')
+            f.write(' \n')
+            f.write('>> Spectral parameters for a ')
+            f.write('{} % confidence interval:\n'.format(cfd))
+            
+            for j in range(l):
+                f.write('{}: {} [{},{}]'.format(pKey[j], val_max[pKey[j]],
+                                              confidenceInterval[pKey[j]][0],
+                                              confidenceInterval[pKey[j]][1]))
+                if gaussian_fit:
+                    f.write('Gaussian fit results:')
+                    f.write('{}: {} +-{}'.format(pKey[j], mu[j], sigma[j]))
+
+    if gaussian_fit:
+        return mu, sigma
+    else:
+        return val_max, confidenceInterval

--- a/vip_hci/specfit/model_resampling.py
+++ b/vip_hci/specfit/model_resampling.py
@@ -1,0 +1,1047 @@
+#! /usr/bin/env python
+
+"""
+Functions useful for spectral fitting of companions, and model interpolation.
+"""
+
+__author__ = 'Valentin Christiaens'
+__all__ = ['make_model_from_params',
+           'make_resampled_models',
+           'resample_model',
+           'interpolate_model']
+
+import numpy as np
+import astropy.constants as con
+from astropy.convolution import Gaussian1DKernel, convolve_fft
+from astropy.stats import gaussian_fwhm_to_sigma
+import itertools
+from scipy.interpolate import InterpolatedUnivariateSpline
+import pandas as pd
+import pdb
+from scipy.ndimage import map_coordinates
+from ..fits import open_fits
+from .utils_spec import (convert_F_units, blackbody, find_nearest, extinction,
+                         inject_em_line)
+
+
+def make_model_from_params(params, labels, grid_param_list, dist, lbda_obs=None, 
+                           model_grid=None, model_reader=None, em_lines={}, 
+                           em_grid={}, dlbda_obs=None, instru_fwhm=None, 
+                           instru_idx=None, filter_reader=None, AV_bef_bb=False,
+                           units_obs='si', units_mod='si', interp_order=1):
+    """
+    Routine to make the model from input parameters.
+    
+        Parameters
+    ----------
+    params : tuple
+        Set of models parameters for which the model grid has to be 
+        interpolated.
+    labels: Tuple of strings
+        Tuple of labels in the same order as initial_state, that is:
+        - first all parameters related to loaded models (e.g. 'Teff', 'logg')
+        - then the planet photometric radius 'R', in Jupiter radius
+        - (optionally) the flux of emission lines (labels should match those in
+        the em_lines dictionary), in units of the model spectrum (times mu)
+        - (optionally) the optical extinction 'Av', in mag
+        - (optionally) the ratio of total to selective optical extinction 'Rv'
+        - (optionally) 'Tbb1', 'Rbb1', 'Tbb2', 'Rbb2', etc. for each extra bb
+        contribution.
+    grid_param_list : list of 1d numpy arrays/lists OR None
+        - If list, should contain list/numpy 1d arrays with available grid of 
+        model parameters. 
+        - Set to None for a pure n-blackbody fit, n=1,2,...
+        - Note1: model grids should not contain grids on radius and Av, but 
+        these should still be passed in initial_state (Av optional).
+        - Note2: for a combined grid model + black body, just provide
+        the grid parameter list here, and provide values for 'Tbbn' and 'Rbbn'
+        in initial_state, labels and bounds.
+    dist :  float
+        Distance in parsec, used for flux scaling of the models.
+    lbda_obs : numpy 1d ndarray or list, opt
+        Wavelength of observed spectrum. If provided, the model spectrum will 
+        be resampled to match lbda_obs. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs). 
+    model_grid : numpy N-d array, optional
+        If provided, should contain the grid of model spectra for each
+        free parameter of the given grid. I.e. for a grid of n_T values of Teff 
+        and n_g values of Logg, the numpy array should be n_T x n_g x n_ch x 2, 
+        where n_ch is the number of wavelengths for the observed spectrum,
+        and the last 2 dims are for wavelength and fluxes respectively.
+        If provided, takes precedence over model_name/model_reader.
+    model_reader : python routine, opt
+        External routine that reads a model file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains model values. See example routine in interpolate_model() 
+        description.
+    em_lines: dictionary, opt
+        Dictionary of emission lines to be added on top of the model spectrum.
+        Each dict entry should be the name of the line, assigned to a tuple of
+        3 values: 1) the wavelength (in mu), 2) a string indicating whether line 
+        intensity is expressed in flux ('F'), luminosity ('L') or log(L/LSun) 
+        ("LogL"), and 3) the latter quantity. The intensity of the emission 
+        lines can be sampled by MCMC, in that case the last element of the 
+        tuple can be set to None. If not to be sampled, a value for the 
+        intensity should be provided (in the same system of units as the model 
+        spectra, multiplied by mu). Examples:
+        em_lines = {'BrG':(2.1667,'F',263)};
+        em_lines = {'BrG':(2.1667,'LogL',-5.1)}
+    em_grid: dictionary pointing to lists, opt
+        Dictionary where each entry corresponds to an emission line and points
+        to a list of values to inject for emission line fluxes. For computation 
+        efficiency, interpolation will be performed between the points of this 
+        grid during the MCMC sampling. Dict entries should match labels and 
+        em_lines.
+    dlbda_obs: numpy 1d ndarray or list, optional
+        Spectral channel width for the observed spectrum. It should be provided 
+        IF one wants to weigh each point based on the spectral 
+        resolution of the respective instruments (as in Olofsson et al. 2016).
+    instru_fwhm : float or list, optional
+        The instrumental spectral fwhm provided in nm. This is used to convolve
+        the model spectrum. If several instruments are used, provide a list of 
+        instru_fwhm values, one for each instrument whose spectral resolution
+        is coarser than the model - including broad band
+        filter FWHM if relevant.
+    instru_idx: numpy 1d array, optional
+        1d array containing an index representing each instrument used 
+        to obtain the spectrum, label them from 0 to n_instru. Zero for points 
+        that don't correspond to any instru_fwhm provided above, and i in 
+        [1,n_instru] for points associated to instru_fwhm[i-1]. This parameter 
+        must be provided if the spectrum consists of points obtained with 
+        different instruments.
+    filter_reader: python routine, optional
+        External routine that reads a filter file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains transmission values. Important: if not provided, but strings 
+        are detected in instru_fwhm, the default format assumed for the files:
+        - first row containing header
+        - starting from 2nd row: 1st column: WL in mu, 2nd column: transmission
+        Note: files should all have the same format and wavelength units.
+    AV_bef_bb: bool, optional
+        If both extinction and an extra bb component are free parameters, 
+        whether to apply extinction before adding the BB component (e.g. 
+        extinction mostly from circumplanetary dust) or after the BB component
+        (e.g. mostly insterstellar extinction).
+    units_obs : str, opt {'si','cgs','jy'}
+        Units of observed spectrum. 'si' for W/m^2/mu; 'cgs' for ergs/s/cm^2/mu 
+        or 'jy' for janskys.
+    units_mod: str, opt {'si','cgs','jy'}
+        Units of the model. 'si' for W/m^2/mu; 'cgs' for ergs/s/cm^2/mu or 'jy'
+        for janskys. If different to units_obs, the spectrum units will be 
+        converted.
+    interp_order: int, opt, {-1,0,1} 
+        Interpolation mode for model interpolation.
+        -1: log interpolation (i.e. linear interpolatlion on log(Flux))
+        0: nearest neighbour model.
+        1: Order 1 spline interpolation.
+        
+    Returns
+    -------
+    out: numpy array
+        The model wavelength and spectrum
+    """
+    
+    
+    if 'Tbb1' in labels and grid_param_list is None and lbda_obs is None:
+        raise ValueError("lbda_obs should be provided because there is no grid")
+      
+    if grid_param_list is None:
+        lbda_mod = lbda_obs
+        spec_mod = np.zeros_like(lbda_obs)
+    else:
+        npar_grid = len(grid_param_list)
+        params_grid = [params[i] for i in range(npar_grid)]
+        params_grid = tuple(params_grid)        
+        if len(em_grid) == 0:
+            p_em_grid = None
+        else:
+            p_em_grid = {}
+            for key, _ in em_grid.items():
+                j = labels.index(key)
+                p_em_grid[key] = params[j]
+        # interpolate model to requested parameters
+        lbda_mod, spec_mod = interpolate_model(params_grid, grid_param_list, 
+                                               p_em_grid, em_grid, em_lines,
+                                               labels, model_grid, 
+                                               model_reader, interp_order)
+        
+        # resample to lbda_obs if needed
+        if lbda_obs is not None:
+            cond = False
+            if len(lbda_obs) != len(lbda_mod):
+                cond = True
+            elif not np.allclose(lbda_obs, lbda_mod):
+                cond = True
+            if cond:
+                lbda_mod, spec_mod = resample_model(lbda_obs, lbda_mod, spec_mod, 
+                                                    dlbda_obs, instru_fwhm, 
+                                                    instru_idx, filter_reader)
+            
+        # convert model to same units as observed spectrum if necessary
+        if units_mod != units_obs:
+            spec_mod = convert_F_units(spec_mod, lbda_mod, in_unit=units_mod, 
+                                       out_unit=units_obs)
+
+        # scale by (R/dist)**2
+        idx_R = labels.index("R")
+        dilut_fac = ((params[idx_R]*con.R_jup.value)/(dist*con.pc.value))**2
+        spec_mod *= dilut_fac
+
+        
+    # apply extinction if requested
+    if 'Av' in labels and AV_bef_bb:
+        ## so far only assume Cardelli extinction law
+        idx_AV = labels.index("Av")
+        if 'Rv' in labels:
+            idx_RV = labels.index("Rv")
+            RV = params[idx_RV]
+        else:
+            RV=3.1
+        extinc_curve = extinction(lbda_mod, params[idx_AV], RV)
+        flux_ratio_ext = np.power(10.,-extinc_curve/2.5)
+        spec_mod *= flux_ratio_ext
+        ## TBD: add more options
+
+    # add n blackbody component(s) if requested 
+    if 'Tbb1' in labels:
+         n_bb = 0
+         for label in labels:
+             if 'Tbb' in label:
+                 n_bb+=1
+         idx_Tbb1 = labels.index("Tbb1")
+         Rj = con.R_jup.value
+         pc = con.pc.value
+         for ii in range(n_bb):
+             idx = ii*2
+             dilut_fac = ((params[idx_Tbb1+idx+1]*Rj)/(dist*pc))**2
+             bb = dilut_fac*blackbody(lbda_mod, params[idx_Tbb1+idx])
+             spec_mod += bb
+
+    # apply extinction if requested
+    if 'Av' in labels and not AV_bef_bb:
+        ## so far only assume Cardelli extinction law
+        idx_AV = labels.index("Av")
+        if 'Rv' in labels:
+            idx_RV = labels.index("Rv")
+            RV = params[idx_RV]
+        else:
+            RV=3.1
+        extinc_curve = extinction(lbda_mod, params[idx_AV], RV)
+        flux_ratio_ext = np.power(10.,-extinc_curve/2.5)
+        spec_mod *= flux_ratio_ext
+        ## TBD: add more options                
+        
+    return lbda_mod, spec_mod
+
+
+def make_resampled_models(lbda_obs, grid_param_list, model_grid=None,
+                          model_reader=None, em_lines={}, em_grid=None, 
+                          dlbda_obs=None, instru_fwhm=None, instru_idx=None, 
+                          filter_reader=None, interp_nonexist=True):
+    """
+    Returns a cube of models after convolution and resampling as in the 
+    observations.
+    
+    Parameters:
+    -----------   
+    lbda_obs : numpy 1d ndarray or list
+        Wavelength of observed spectrum. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs).
+    grid_param_list : list of 1d numpy arrays/lists
+        Should contain list/numpy 1d arrays with available grid of model 
+        parameters. Note: model grids shouldn't contain grids on radius and Av.
+    model_grid: list of 1d numpy arrays, or list of lists.
+        Available grid of model parameters (should only contain the parameter
+        values, not the models themselves). The latter will be loaded. 
+        Important: 1) Make sure the bounds are within the model grid to avoid 
+        extrapolation. 2) All keywords that are neither 'R', 'Av' nor 'M' will 
+        be considered model grid parameters.
+        length of params, with the same order. OR '1bb' or '2bb' for black-body
+        models. In that case the model will be created on the fly at each 
+        iteration using 1 or 2 Planck functions respectively. There are 2 params 
+        for each Planck function: Teff and radius.
+    model_reader : python routine
+        External routine that reads a model file, converts it to required 
+        units and returns a 2D numpy array, where the first column corresponds
+        to wavelengths, and the second contains model values. Example below.
+    em_lines: dictionary, opt
+        Dictionary of emission lines to be added on top of the model spectrum.
+        Each dict entry should be the name of the line, assigned to a tuple of
+        3 values: 1) the wavelength (in mu), 2) a string indicating whether line 
+        intensity is expressed in flux ('F'), luminosity ('L') or log(L/LSun) 
+        ("LogL"), and 3) the latter quantity. The intensity of the emission 
+        lines can be sampled by MCMC, in that case the last element of the 
+        tuple can be set to None. If not to be sampled, a value for the 
+        intensity should be provided (in the same system of units as the model 
+        spectra, multiplied by mu). Example:
+        em_lines = {'BrG':(2.1667,'F',263)}
+    em_grid: dictionary pointing to lists, opt
+        Dictionary where each entry corresponds to an emission line and points
+        to a list of values to inject for emission line fluxes. For computation 
+        efficiency, interpolation will be performed between the points of this 
+        grid during the MCMC sampling. Dict entries should match labels and 
+        em_lines. Note: length of this dictionary can be different of em_lines;
+        i.e. if a line is in em_lines but not in em_grid, it will not be 
+        considered an MCMC parameter.
+    lbda_mod : numpy 1d ndarray or list
+        Wavelength of tested model. Should have a wider wavelength extent than 
+        the observed spectrum.
+    spec_mod : numpy 1d ndarray
+        Model spectrum. It does not require the same wavelength sampling as the
+        observed spectrum. If higher spectral resolution, it will be convolved
+        with the instrumental spectral psf (if instru_fwhm is provided) and 
+        then binned to the same sampling. If lower spectral resolution, a 
+        linear interpolation is performed to infer the value at the observed 
+        spectrum wavelength sampling.
+    dlbda_obs: numpy 1d ndarray or list, optional
+        Spectral channel width for the observed spectrum. It should be provided 
+        IF one wants to weigh each point based on the spectral 
+        resolution of the respective instruments (as in Olofsson et al. 2016).
+    instru_fwhm : float or list, optional
+        The instrumental spectral fwhm provided in nm. This is used to convolve
+        the model spectrum. If several instruments are used, provide a list of 
+        instru_fwhm values, one for each instrument whose spectral resolution
+        is coarser than the model - including broad band
+        filter FWHM if relevant.
+    instru_idx: numpy 1d array, optional
+        1d array containing an index representing each instrument used 
+        to obtain the spectrum, label them from 0 to n_instru. Zero for points 
+        that don't correspond to any instru_fwhm provided above, and i in 
+        [1,n_instru] for points associated to instru_fwhm[i-1]. This parameter 
+        must be provided if the spectrum consists of points obtained with 
+        different instruments.
+    filter_reader: python routine, optional
+        External routine that reads a filter file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains transmission values. Important: if not provided, but strings 
+        are detected in instru_fwhm, the default format assumed for the files:
+        - first row containing header
+        - starting from 2nd row: 1st column: WL in mu, 2nd column: transmission
+        Note: files should all have the same format and wavelength units.
+    interp_nonexist: bool, opt
+        Whether to interpolate if models do not exist, based on closest model(s)
+        
+    Returns
+    -------
+    resamp_mod: 1d numpy array
+        Grid of model spectra resampled at wavelengths matching the observed 
+        spectrum.
+    """
+    n_params = len(grid_param_list)
+    n_mods = len(grid_param_list[0])
+    dims = [len(grid_param_list[0])]
+    
+    if n_params>1:
+        for pp in range(1,n_params):
+            n_mods *= len(grid_param_list[pp])
+            dims.append(len(grid_param_list[pp]))
+
+    if em_grid is None:
+        n_em = 0
+        final_dims = dims+[len(lbda_obs)]+[2]
+    else:
+        n_em = len(em_grid)
+        n_em_mods = 1
+        dims_em = []
+        for key, _ in em_grid.items():
+            n_em_mods *= len(em_grid[key])
+            dims_em.append(len(em_grid[key]))
+        final_dims = dims+dims_em+[len(lbda_obs)]+[2]
+        dims_em = tuple(dims_em)
+     
+    final_dims = tuple(final_dims)
+    dims = tuple(dims)
+    resamp_mod = []
+    
+    # Loop on all models whose parameters are provided in model grid
+    for nn in range(n_mods):            
+        if model_grid is not None:
+            indices = []
+            idx = np.unravel_index(nn,dims)
+            for pp in range(n_params):
+                indices.append(idx[pp])
+            indices = tuple(indices)
+            tmp = model_grid[indices]
+            lbda_mod = tmp[:,0]
+            spec_mod = tmp[:,1]             
+        else:
+            params_tmp = []
+            idx = np.unravel_index(nn,dims)
+            for pp in range(n_params):
+                params_tmp.append(grid_param_list[pp][idx[pp]])  
+            try:
+                lbda_mod, spec_mod = model_reader(params_tmp)
+                if np.sum(np.isnan(spec_mod))>0:
+                    print("There are nan values in spec for params: ")
+                    pdb.set_trace()
+            except:
+                msg= "Model does not exist for param combination ({})"
+                print(msg.format(params_tmp))
+                print("Press c if you wish to interpolate that model from neighbours")
+                pdb.set_trace()
+                if interp_nonexist:
+                    # find for which dimension the model doesn't exist;
+                    for qq in range(n_params):
+                        interp_params1=[]
+                        interp_params2=[]
+                        for pp in range(n_params):
+                            if pp == qq:
+                                try:
+                                    interp_params1.append(grid_param_list[pp][idx[pp]-1])
+                                    interp_params2.append(grid_param_list[pp][idx[pp]+1])
+                                except:
+                                    continue
+                            else:
+                                interp_params1.append(grid_param_list[pp][idx[pp]])
+                                interp_params2.append(grid_param_list[pp][idx[pp]])
+                        try:
+                            lbda_mod1, spec_mod1 = model_reader(interp_params1)
+                            lbda_mod2, spec_mod2 = model_reader(interp_params2)
+                            lbda_mod = np.mean([lbda_mod1,lbda_mod2],axis=0)
+                            spec_mod = np.mean([spec_mod1,spec_mod2],axis=0)
+                            msg= "Model was interpolated based on models: {} "
+                            msg+="and {}"
+                            print(msg.format(interp_params1,interp_params2))
+                            break
+                        except:
+                            pass
+                        if qq == n_params-1:
+                            msg = "Impossible to interpolate model!" 
+                            msg += "Consider reducing bounds."
+                            raise ValueError(msg)
+                else:
+                    msg = "Model interpolation not allowed for non existing " 
+                    msg += "models in the grid."
+                    raise ValueError(msg)                    
+                    
+        # inject emission lines if any
+        if n_em > 0:
+            flux_grids = []
+            wls = []
+            widths = []
+            for key, flux_grid in em_grid.items():
+                flux_grids.append(flux_grid)
+                wls.append(em_lines[key][0])
+                widths.append(em_lines[key][2])
+            # recursively inject em lines
+            for fluxes in itertools.product(*flux_grids):
+                for ff, flux in enumerate(fluxes):
+                    spec_mod = inject_em_line(wls[ff], flux, lbda_mod, spec_mod,
+                                              widths[ff])                
+                # interpolate OR convolve+bin model spectrum if required
+                if len(lbda_obs) != len(lbda_mod):
+                    res = resample_model(lbda_obs, lbda_mod, spec_mod, 
+                                         dlbda_obs, instru_fwhm, instru_idx, 
+                                         filter_reader)
+                elif not np.allclose(lbda_obs, lbda_mod):
+                    res = resample_model(lbda_obs, lbda_mod, spec_mod, 
+                                         dlbda_obs, instru_fwhm, instru_idx, 
+                                         filter_reader)
+                else:
+                    res = np.array([lbda_obs, spec_mod])
+                    
+                resamp_mod.append(res)                
+        else:
+                    
+            # interpolate OR convolve+bin model spectrum if not same sampling
+            if len(lbda_obs) != len(lbda_mod):
+                res = resample_model(lbda_obs, lbda_mod, spec_mod, dlbda_obs, 
+                                     instru_fwhm, instru_idx, filter_reader)
+            elif not np.allclose(lbda_obs, lbda_mod):
+                res = resample_model(lbda_obs, lbda_mod, spec_mod, dlbda_obs, 
+                                     instru_fwhm, instru_idx, filter_reader)
+            else:
+                res = np.array([lbda_obs, spec_mod])
+                
+            resamp_mod.append(res)
+
+    resamp_mod = np.array(resamp_mod)
+    resamp_mod = np.swapaxes(resamp_mod,-1,-2)
+       
+    return resamp_mod.reshape(final_dims)
+
+ 
+def resample_model(lbda_obs, lbda_mod, spec_mod, dlbda_obs=None, 
+                   instru_fwhm=None, instru_idx=None, filter_reader=None,
+                   no_constraint=False, verbose=False):
+    """
+    Convolve, interpolate and resample a model spectrum to match observed 
+    spectrum.
+
+    Parameters:
+    -----------
+    lbda_obs : numpy 1d ndarray or list
+        Wavelength of observed spectrum. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs).
+    lbda_mod : numpy 1d ndarray or list
+        Wavelength of tested model. Should have a wider wavelength extent than 
+        the observed spectrum.
+    spec_mod : numpy 1d ndarray
+        Model spectrum. It does not require the same wavelength sampling as the
+        observed spectrum. If higher spectral resolution, it will be convolved
+        with the instrumental spectral psf (if instru_fwhm is provided) and 
+        then binned to the same sampling. If lower spectral resolution, a 
+        linear interpolation is performed to infer the value at the observed 
+        spectrum wavelength sampling.
+    dlbda_obs: numpy 1d ndarray or list, optional
+        Spectral channel width for the observed spectrum. It should be provided 
+        IF one wants to weigh each point based on the spectral 
+        resolution of the respective instruments (as in Olofsson et al. 2016).
+    instru_fwhm : float or list, optional
+        The instrumental spectral fwhm provided in nm. This is used to convolve
+        the model spectrum. If several instruments are used, provide a list of 
+        instru_fwhm values, one for each instrument whose spectral resolution
+        is coarser than the model - including broad band
+        filter FWHM if relevant.
+    instru_idx: numpy 1d array, optional
+        1d array containing an index representing each instrument used 
+        to obtain the spectrum, label them from 0 to n_instru. Zero for points 
+        that don't correspond to any instru_fwhm provided above, and i in 
+        [1,n_instru] for points associated to instru_fwhm[i-1]. This parameter 
+        must be provided if the spectrum consists of points obtained with 
+        different instruments.
+    filter_reader: python routine, optional
+        External routine that reads a filter file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains transmission values. Important: if not provided, but strings 
+        are detected in instru_fwhm, the default format assumed for the files:
+        - first row containing header
+        - starting from 2nd row: 1st column: WL in mu, 2nd column: transmission
+        Note: files should all have the same format and wavelength units.
+    no_constraint: bool, optional
+        If set to True, will not use 'floor' and 'ceil' constraints when
+        cropping the model wavelength ranges, i.e. faces the risk of 
+        extrapolation. May be useful, if the bounds of the wavelength ranges 
+        are known to match exactly. 
+    verbose: bool, optional
+        Whether to print more information during resampling.
+        
+    Returns
+    -------
+    lbda_obs, spec_mod_res: 2x 1d numpy array
+        Observed lambdas, and resampled model spectrum (at those lambdas)
+    
+    """
+    
+    def _default_file_reader(filter_name):
+        """
+        Default file reader if no filter file reader is provided.
+        """
+        filt_table = pd.read_csv(filter_name, sep=' ', header=0, 
+                                 skipinitialspace=True)
+        keys = filt_table.keys()
+        lbda_filt = np.array(filt_table[keys[0]])
+        if '(AA)' in keys[0]:
+            lbda_filt /=10000
+        elif '(mu)' in keys[0]:
+            pass
+        elif '(nm)' in keys[0]:
+            lbda_filt /=10000
+        else:
+            raise ValueError('Wavelength unit not recognised in filter file')
+        trans = np.array(filt_table[keys[1]])
+        return lbda_filt, trans      
+                    
+    n_ch = len(lbda_obs)
+    spec_mod_res = np.zeros_like(lbda_obs)
+    
+    if dlbda_obs is None:
+        # this is only to trim out useless WL ranges, hence significantly 
+        # improving speed for large (>1M pts) models (e.g. BT-SETTL).
+        # 0.3 factor to consider possible broad-band filters.
+        dlbda_obs1 = [min(0.3*lbda_obs[0],lbda_obs[1]-lbda_obs[0])]
+        dlbda_obs2 = [(lbda_obs[i+2]-lbda_obs[i])/2 for i in range(n_ch-2)]
+        dlbda_obs3 = [min(0.3*lbda_obs[-1],lbda_obs[-1]-lbda_obs[-2])]
+        dlbda_obs = np.array(dlbda_obs1+dlbda_obs2+dlbda_obs3)
+
+    if verbose:
+        print("checking whether WL samplings are the same for obs and model")        
+        
+    if isinstance(instru_fwhm, float) or isinstance(instru_fwhm, int):
+        instru_fwhm = [instru_fwhm]
+    cond = False
+    if len(lbda_obs) != len(lbda_mod):
+        cond = True
+    elif not np.allclose(lbda_obs, lbda_mod):
+        cond = True
+    if cond:
+        lbda_min = lbda_obs[0]-dlbda_obs[0]
+        lbda_max = lbda_obs[-1]+dlbda_obs[-1]
+        try:
+            lbda_min_tmp = min(lbda_min,lbda_obs[0]-3*np.amax(instru_fwhm)/1000)
+            lbda_max_tmp = max(lbda_max,lbda_obs[-1]+3*np.amax(instru_fwhm)/1000)
+            if lbda_min_tmp > 0:
+                lbda_min = lbda_min_tmp
+                lbda_max = lbda_max_tmp
+        except:
+            pass
+            
+        if no_constraint:
+            idx_ini = find_nearest(lbda_mod, lbda_min)
+            idx_fin = find_nearest(lbda_mod, lbda_max)
+        else:
+            idx_ini = find_nearest(lbda_mod, lbda_min, 
+                                   constraint='floor')
+            idx_fin = find_nearest(lbda_mod, lbda_max, 
+                                   constraint='ceil')
+
+        lbda_mod = lbda_mod[idx_ini:idx_fin+1]
+        spec_mod = spec_mod[idx_ini:idx_fin+1]
+        
+        
+    nmod = lbda_mod.shape[0]
+    ## compute the wavelength sampling of the model
+    dlbda_mod1 = [lbda_mod[1]-lbda_mod[0]]
+    dlbda_mod2 = [(lbda_mod[i+1]-lbda_mod[i-1])/2 for i in range(1,nmod-1)]
+    dlbda_mod3 = [lbda_mod[-1]-lbda_mod[-2]]
+    dlbda_mod = np.array(dlbda_mod1+dlbda_mod2+dlbda_mod3)
+
+
+    if verbose:
+        print("testing whether observed spectral res could be > than model's ")
+        print("(in at least parts of the spectrum)")
+    dlbda_obs_min = np.amin(dlbda_obs)
+    idx_obs_min = np.argmin(dlbda_obs)
+    idx_near = find_nearest(lbda_mod, lbda_obs[idx_obs_min])
+    dlbda_mod_tmp = (lbda_mod[idx_near+1]-lbda_mod[idx_near-1])/2
+    do_interp = np.zeros(n_ch, dtype='int32')
+    
+    if dlbda_mod_tmp>dlbda_obs_min and dlbda_obs_min > 0:
+        if verbose:
+            print("checking where obs spec res is < or > than model's")
+        ## check where obs spec res is < or > than model's
+        nchunks_i = 0
+        for ll in range(n_ch):
+            idx_near = find_nearest(lbda_mod, lbda_obs[ll])
+            do_interp[ll] = (dlbda_obs[ll] < dlbda_mod[idx_near])
+            if ll > 0:
+                if do_interp[ll] and not do_interp[ll-1]:
+                    nchunks_i+=1
+            elif do_interp[ll]:
+                nchunks_i=1
+            
+    ## interpolate model if the observed spectrum has higher resolution 
+    ## and is monotonically increasing
+    if np.sum(do_interp) and dlbda_obs_min > 0:
+        if verbose:
+            print("interpolating model where obs spectrum has higher res")    
+        idx_0=0
+        for nc in range(nchunks_i):
+            idx_1 = np.argmax(do_interp[idx_0:])+idx_0
+            idx_0 = np.argmin(do_interp[idx_1:])+idx_1
+            if idx_0==idx_1:
+                idx_0=-1
+                if nc != nchunks_i-1:
+                    pdb.set_trace() # should not happen
+            idx_ini = find_nearest(lbda_mod,lbda_obs[idx_1],
+                                   constraint='floor')
+            idx_fin = find_nearest(lbda_mod,lbda_obs[idx_0],
+                                   constraint='ceil')
+
+
+            spl = InterpolatedUnivariateSpline(lbda_mod[idx_ini:idx_fin], 
+                                               spec_mod[idx_ini:idx_fin],
+                                                   k=min(3,idx_fin-idx_ini-1))
+            spec_mod_res[idx_1:idx_0] = spl(lbda_obs[idx_1:idx_0])
+
+            
+    ## convolve+bin where the model spectrum has higher resolution (most likely)
+    if np.sum(do_interp) < n_ch or dlbda_obs_min > 0:
+    # Note: if dlbda_obs_min < 0, it means several instruments are used with 
+    # overlapping WL ranges. instru_fwhm should be provided!
+        if instru_fwhm is None:
+            msg = "Warning! No spectral FWHM nor filter file provided"
+            msg+= " => binning without convolution"
+            print(msg)
+            for ll, lbda in enumerate(lbda_obs):
+                mid_lbda_f = lbda_obs-dlbda_obs/2.
+                mid_lbda_l = lbda_obs+dlbda_obs/2.
+                i_f = find_nearest(lbda_mod,
+                                   mid_lbda_f[ll])
+                i_l = find_nearest(lbda_mod,
+                                   mid_lbda_l[ll])
+                spec_mod_res[ll] = np.mean(spec_mod[i_f:i_l+1])
+        else:
+            if verbose:
+                print("convolving+binning where model spectrum has higher res")   
+            if isinstance(instru_idx, list):
+                instru_idx = np.array(instru_idx)
+            elif not isinstance(instru_idx, np.ndarray):
+                instru_idx = np.array([1]*n_ch)
+    
+            for i in range(1,len(instru_fwhm)+1):
+                if isinstance(instru_fwhm[i-1], (float,int)):
+                    ifwhm = instru_fwhm[i-1]/(1000*np.mean(dlbda_mod))
+                    gau_ker = Gaussian1DKernel(stddev=ifwhm*gaussian_fwhm_to_sigma)
+                    spec_mod_conv = convolve_fft(spec_mod, gau_ker)
+                    tmp = np.zeros_like(lbda_obs[np.where(instru_idx==i)])
+                    for ll, lbda in enumerate(lbda_obs[np.where(instru_idx==i)]):
+                        mid_lbda_f = lbda_obs-dlbda_obs/2.
+                        mid_lbda_l = lbda_obs+dlbda_obs/2.
+                        i_f = find_nearest(lbda_mod,
+                                           mid_lbda_f[np.where(instru_idx==i)][ll])
+                        i_l = find_nearest(lbda_mod,
+                                           mid_lbda_l[np.where(instru_idx==i)][ll])
+                        tmp[ll] = np.mean(spec_mod_conv[i_f:i_l+1])
+                    spec_mod_res[np.where(instru_idx==i)] = tmp  
+                elif isinstance(instru_fwhm[i-1], str):
+                    if filter_reader is not None:
+                        lbda_filt, trans = filter_reader(instru_fwhm[i-1])
+                    else:
+                        lbda_filt, trans = _default_file_reader(instru_fwhm[i-1])
+                    idx_ini = find_nearest(lbda_mod, lbda_filt[0], 
+                                           constraint='ceil')
+                    idx_fin = find_nearest(lbda_mod, lbda_filt[-1], 
+                                           constraint='floor')
+                    interp_trans = np.interp(lbda_mod[idx_ini:idx_fin], lbda_filt,
+                                             trans)
+                    num = np.sum(interp_trans*dlbda_mod[idx_ini:idx_fin]*spec_mod[idx_ini:idx_fin])
+                    denom = np.sum(interp_trans*dlbda_mod[idx_ini:idx_fin])
+                    spec_mod_res[np.where(instru_idx==i)] = num/denom
+                else:
+                    msg = "instru_fwhm is a {}, while it should be either a"
+                    msg+= " scalar or a string"
+                    raise TypeError(msg.format(type(instru_fwhm[i-1])))
+
+    return np.array([lbda_obs, spec_mod_res])
+
+    
+def interpolate_model(params, grid_param_list, params_em={}, em_grid={}, 
+                      em_lines={}, labels=None, model_grid=None, 
+                      model_reader=None, interp_order=1, max_dlbda=2e-4,
+                      verbose=False):
+    """
+    Parameters
+    ----------
+    params : tuple
+        Set of models parameters for which the model grid has to be 
+        interpolated.
+    grid_param_list : list of 1d numpy arrays/lists
+        - If list, should contain list/numpy 1d arrays with available grid of 
+        model parameters.
+        - Note1: model grids should not contain grids on radius and Av, but 
+        these should still be passed in initial_state (Av optional).
+    params_em : dictionary, opt
+        Set of emission line parameters (typically fluxes) for which the model 
+        grid has to be interpolated.
+    em_grid: dictionary pointing to lists, opt
+        Dictionary where each entry corresponds to an emission line and points
+        to a list of values to inject for emission line fluxes. For computation 
+        efficiency, interpolation will be performed between the points of this 
+        grid during the MCMC sampling. Dict entries should match labels and 
+        em_lines. Note: length of this dictionary can be different of em_lines;
+        i.e. if a line is in em_lines but not in em_grid, it will not be 
+        considered an MCMC parameter.
+    em_lines: dictionary, opt
+        Dictionary of emission lines to be added on top of the model spectrum.
+        Each dict entry should be the name of the line, assigned to a tuple of
+        3 values: 1) the wavelength (in mu), 2) a string indicating whether line 
+        intensity is expressed in flux ('F'), luminosity ('L') or log(L/LSun) 
+        ("LogL"), and 3) the latter quantity. The intensity of the emission 
+        lines can be sampled by MCMC, in that case the last element of the 
+        tuple can be set to None. If not to be sampled, a value for the 
+        intensity should be provided (in the same system of units as the model 
+        spectra, multiplied by mu). Example:
+        em_lines = {'BrG':(2.1667,'F',263)}
+    labels: Tuple of strings
+        Tuple of labels in the same order as initial_state, that is:
+        - first all parameters related to loaded models (e.g. 'Teff', 'logg')
+        - next the planet photometric radius 'R', in Jupiter radius
+        - (optionally) the flux of emission lines (labels should match those in
+        the em_lines dictionary), in units of the model spectrum (times mu)
+        - (optionally) the optical extinction 'Av', in mag
+        - (optionally) the ratio of total to selective optical extinction 'Rv'
+        - (optionally) 'Tbb1', 'Rbb1', 'Tbb2', 'Rbb2', etc. for each extra bb
+        contribution.
+        Note: only necessary if an emission list dictionary is provided.
+    model_grid : numpy N-d array
+        If provided, should contain the grid of model spectra for each
+        free parameter of the given grid. I.e. for a grid of n_T values of Teff 
+        and n_g values of Logg, the numpy array should be n_T x n_g x n_ch x 2, 
+        where n_ch is the number of wavelengths for the observed spectrum.
+        If provided, takes precedence over filename/file_reader which would 
+        open and read models at each step of the MCMC.
+    model_reader : python routine
+        External routine that reads a model file, converts it to required 
+        units and returns a 2D numpy array, where the first column corresponds
+        to wavelengths, and the second contains model values. Example below.
+    interp_order: int, opt, {0,1} 
+        0: nearest neighbour model.
+        1: Order 1 spline interpolation.
+    max_dlbda: float, opt
+        Maximum delta lbda in mu allowed if binning of lbda_model is necessary. 
+        This is necessary for grids of models (e.g. BT-SETTL) where the wavelength
+        sampling is not the same depending on parameters (e.g. between 4000K
+        and 4100K models for BT-SETTL): resampling preserving original 
+        resolution is too prohibitive computationally.
+    verbose: bool, optional
+        Whether to print more information during resampling.
+        
+    Returns
+    -------
+    model : 2d numpy array
+        Interpolated model for input parameters. First column corresponds
+        to wavelengths, and the second contains model values.
+        
+    Example file_reader:
+    -------------------
+    def _example_file_reader(params):
+        '''This is a minimal example for the file_reader routine to be provided 
+        as argument to model_interpolation. The routine should only take as 
+        inputs grid parameters, and returns as output: both the wavelengths and 
+        model values as a 2D numpy array.
+        This example assumes the model is in a fits file, that is already a 2D
+        numpy array, where the first column is the wavelength, and 2nd column 
+        is the corresponding model values.'''
+        
+        model = open_fits(filename.format(params[0],params[1]))
+
+        return model       
+        
+    """
+
+    def _example_file_reader(filename):
+        """ This is a minimal example for the file_reader routine to be provided 
+        as argument to model_interpolation. The routine should take as input a 
+        template filename format with blanks and parameters, and return as output 
+        the wavelengths and model values as a 2D numpy array.
+        This example assumes the model is in a fits file, that is already a 2D
+        numpy array, where the first column is the wavelength, and second column 
+        is the corresponding model values.
+        """
+        model = open_fits(filename.format(params[0],params[1]))
+
+        return model
+
+    def _den_to_bin(denary,ndigits=3):
+        """
+        Convert denary to binary number, keeping n digits for binary (i.e.
+        padding with zeros if necessary)
+        """
+        binary=""  
+        while denary>0:  
+          #A left shift in binary means /2  
+          binary = str(denary%2) + binary  
+          denary = denary//2  
+        if len(binary) < ndigits:
+            pad = '0'*(ndigits-len(binary))
+        else:
+            pad=''
+        return pad+binary  
+
+    n_params = len(grid_param_list)
+    n_em = len(em_grid)
+    n_params_tot = n_params+n_em
+
+    if interp_order == 0:
+        if model_grid is None:
+            params_tmp = np.zeros(n_params)    
+            for nn in range(n_params):
+                params_tmp[nn] = find_nearest(grid_param_list[nn], 
+                                              params[nn], output='value')
+            lbda, spec = model_reader(params_tmp)
+            if n_em>0:
+                for ll in range(len(labels)):
+                    if labels[ll] in em_grid.keys():
+                        key = labels[ll]
+                        spec = inject_em_line(em_lines[key][0], params_em[key], 
+                                              lbda, spec, em_lines[key][2])
+            return lbda, spec
+            
+        else:
+            idx_tmp = []
+            counter = 0
+            for nn in range(n_params_tot):
+                if nn < n_params:
+                    idx_tmp.append(find_nearest(grid_param_list[nn], params[nn],
+                                                output='index'))
+                else:
+                    for ll in range(len(labels)):
+                        if labels[counter+ll] in em_grid.keys():
+                            key = labels[counter+ll]
+                            counter+=1
+                            break
+                    idx_tmp.append(find_nearest(em_grid[key], params_em[key],
+                                                output='index'))                    
+            idx_tmp = tuple(idx_tmp)
+            tmp = model_grid[idx_tmp]
+            return tmp[:,0], tmp[:,1]
+    
+    
+    elif abs(interp_order) == 1:
+        # first compute new subgrid "coords" for interpolation
+        if verbose:
+            print("Computing new coords for interpolation")
+        constraints = ['floor','ceil']
+        new_coords = np.zeros([n_params_tot,1])
+        sub_grid_param = np.zeros([n_params_tot,2])
+        counter = 0
+        for nn in range(n_params_tot):
+            if nn < n_params:
+                grid_tmp = grid_param_list[nn]
+                params_tmp = params[nn]
+            else:
+                for ll in range(len(labels)):
+                    if labels[counter+ll] in em_grid.keys():
+                        key = labels[counter+ll]
+                        grid_tmp = em_grid[key] 
+                        params_tmp = params_em[key]
+                        counter+=1
+                        break
+            for ii in range(2):
+                try:
+                    sub_grid_param[nn,ii] = find_nearest(grid_tmp, 
+                                                         params_tmp,
+                                                         constraint=constraints[ii], 
+                                                         output='value')
+                except:
+                    pdb.set_trace()
+                
+            num = (params_tmp-sub_grid_param[nn,0])
+            denom = (sub_grid_param[nn,1]-sub_grid_param[nn,0])
+            new_coords[nn,0] = num/denom
+            
+        if verbose:
+            print("Making sub-grid of models")
+        sub_grid = []
+        sub_grid_lbda = []        
+        if model_grid is None:
+            ntot_subgrid = 2**n_params_tot
+            for dd in range(ntot_subgrid):
+                str_indices = _den_to_bin(dd, n_params_tot)
+                params_tmp = []
+                for nn in range(n_params):
+                    params_tmp.append(sub_grid_param[nn,int(str_indices[nn])])
+                params_tmp=np.array(params_tmp)
+                lbda, spec = model_reader(params_tmp)
+                if n_em>0:
+                    for nn in range(len(labels)):
+                        if labels[nn] in em_grid.keys():
+                            key = labels[nn]
+                            spec = inject_em_line(em_lines[key][0], 
+                                                  params_em[key], lbda, 
+                                                  spec, em_lines[key][2])
+                sub_grid.append(spec)
+                sub_grid_lbda.append(lbda)
+            
+            # resample to match sparser sampling if required
+            nch = np.amin([len(sub_grid_lbda[i]) for i in range(ntot_subgrid)])
+            nch_max = np.amax([len(sub_grid_lbda[i]) for i in range(ntot_subgrid)])
+            if nch_max != nch:
+                min_i = np.argmin([len(sub_grid_lbda[i]) for i in range(ntot_subgrid)])
+                min_dlbda = np.amin(sub_grid_lbda[min_i][1:]-sub_grid_lbda[min_i][:-1])
+                if min_dlbda < max_dlbda:
+                    bin_fac = int(max_dlbda/min_dlbda)
+                    if verbose:
+                        msg = "Models will be binned in WL by a factor {} to "
+                        msg += "min dlbda = {}mu"
+                        print(msg.format(bin_fac,max_dlbda))
+                    
+                    nch = int(len(sub_grid_lbda[min_i])/bin_fac)
+                    tmp_spec = []
+                    tmp_lbda = []
+                    for bb in range(nch):
+                        idx_ini = bb*bin_fac
+                        idx_fin = (bb+1)*bin_fac
+                        tmp_spec.append(np.mean(sub_grid[min_i][idx_ini:idx_fin]))
+                        tmp_lbda.append(np.mean(sub_grid_lbda[min_i][idx_ini:idx_fin]))
+                    sub_grid[min_i] = np.array(tmp_spec)
+                    sub_grid_lbda[min_i] = np.array(tmp_lbda)
+                for dd in range(ntot_subgrid):
+                    cond = False
+                    if len(sub_grid_lbda[dd]) != nch:
+                        cond = True
+                    else:
+                        # np.allclose() or np.array_equal are TOO slow
+                        dlbda = sub_grid_lbda[min_i][-1]-sub_grid_lbda[min_i][0]
+                        dlbda/=nch
+                        if np.sum(sub_grid_lbda[dd]-sub_grid_lbda[min_i])>dlbda:
+                            cond = True
+                    if cond:
+                        if verbose:
+                            msg = "Resampling model of different WL sampling. "
+                            msg+= "This may take a while for high-res/large WL"
+                            msg+= " ranges..."
+                            print(msg)
+                        res = resample_model(sub_grid_lbda[min_i], 
+                                             sub_grid_lbda[dd], 
+                                             sub_grid[dd],
+                                             no_constraint=True,
+                                             verbose=verbose)
+                        sub_grid_lbda[dd], sub_grid[dd] = res
+
+            # Create array with dimensions 'dims' for each wavelength
+            final_dims = tuple([nch]+[2]*n_params_tot)
+            sub_grid = np.array(sub_grid)
+            sub_grid_lbda = np.array(sub_grid_lbda)
+            sub_grid = np.swapaxes(sub_grid,0,1)            
+            sub_grid_lbda = np.swapaxes(sub_grid_lbda,0,1)
+            sub_grid = sub_grid.reshape(final_dims)
+            sub_grid_lbda = sub_grid_lbda.reshape(final_dims)
+        
+        else:
+            constraints = ['floor','ceil']
+            sub_grid_idx = np.zeros([n_params_tot,2], dtype=np.int32)
+            #list_idx = []
+            counter = 0
+            for nn in range(n_params_tot):
+                if nn < n_params:
+                    grid_tmp = grid_param_list[nn]
+                    params_tmp = params[nn]
+                else:
+                    for ll in range(len(labels)):
+                        if labels[counter+ll] in em_grid.keys():
+                            key = labels[counter+ll]
+                            grid_tmp = em_grid[key] 
+                            params_tmp = params_em[key]
+                            counter+=1
+                            break
+                for ii in range(2):
+                    sub_grid_idx[nn,ii]=find_nearest(grid_tmp, params_tmp,
+                                                     constraint=constraints[ii], 
+                                                     output='index')
+            for dd in range(2**n_params_tot):
+                str_indices = _den_to_bin(dd, n_params_tot)
+                idx_tmp = []
+                for nn in range(n_params_tot):
+                    idx_tmp.append(sub_grid_idx[nn,int(str_indices[nn])])
+                    #idx_tmp = sub_grid_idx[nn,int(str_indices[nn])]
+                #list_idx.append(idx_tmp)
+                #list_idx=np.array(list_idx)
+                sub_grid.append(model_grid[tuple(idx_tmp)])
+            
+            # first reshape
+            sub_grid = np.array(sub_grid)
+            dims = tuple([2]*n_params_tot+[sub_grid.shape[-2]]+[sub_grid.shape[-1]])
+            sub_grid = sub_grid.reshape(dims)
+            sub_grid = np.moveaxis(sub_grid,-1,0) # make last dim (lbda vs flux) come first
+            sub_grid_lbda = sub_grid[0]
+            sub_grid = sub_grid[1]
+            # move again axis to have nch as first axis
+            sub_grid = np.moveaxis(sub_grid,-1,0)
+            sub_grid_lbda = np.moveaxis(sub_grid_lbda,-1,0)
+            nch = sub_grid.shape[0]
+            
+        interp_model = np.zeros(nch)
+        interp_lbdas = np.zeros(nch)
+        
+        if interp_order == -1:
+            sub_grid = np.log10(sub_grid)
+        
+        for cc in range(nch):
+            interp_model[cc] = map_coordinates(sub_grid[cc], new_coords, 
+                                               order=abs(interp_order))
+            interp_lbdas[cc] = map_coordinates(sub_grid_lbda[cc], new_coords, 
+                                               order=abs(interp_order))
+            
+        if interp_order == -1:
+            interp_model = np.power(10,interp_model)
+            
+        return interp_lbdas, interp_model
+    
+    else:
+        msg = "Interpolation order not allowed. Only -1, 0 or 1 accepted"
+        raise TypeError(msg)

--- a/vip_hci/specfit/template_lib.py
+++ b/vip_hci/specfit/template_lib.py
@@ -1,0 +1,565 @@
+#! /usr/bin/env python
+
+"""
+Module for simplex or grid search of best fit spectrum in a template library.
+TBD: implement multiprocessing version.
+"""
+
+__author__ = 'V. Christiaens'
+__all__ = ['best_fit_tmp',
+           'get_chi']
+
+from datetime import datetime
+import numpy as np
+import os
+from scipy.optimize import minimize
+from ..conf import time_ini, timing, time_fin
+from .chi import gof_scal
+from .model_resampling import resample_model
+from .utils_spec import extinction, find_nearest
+import warnings
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
+
+def get_chi(lbda_obs, spec_obs, err_obs, tmp_name, tmp_reader, 
+            search_mode='simplex', lambda_scal=None, scale_range=(0.1,10,0.01), 
+            ext_range=None, dlbda_obs=None, instru_corr=None, instru_fwhm=None, 
+            instru_idx=None, filter_reader=None, simplex_options=None,
+            red_chi2=True, remove_nan=False, force_continue=False, 
+            verbose=False, **kwargs):
+    """ Routine calculating chi^2, optimal scaling factor and optimal 
+    extinction for a given template spectrum to match an observed spectrum.
+    
+    Parameters
+    ----------
+    lbda_obs : numpy 1d ndarray or list
+        Wavelength of observed spectrum. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs).
+    spec_obs : numpy 1d ndarray or list
+        Observed spectrum for each value of lbda_obs.
+    err_obs : numpy 1d/2d ndarray or list
+        Uncertainties on the observed spectrum. If 2d array, should be [2,n_ch]
+        where the first (resp. second) column corresponds to lower (upper) 
+        uncertainty, and n_ch is the length of lbda_obs and spec_obs.
+    tmp_name :  str
+        Template spectrum filename.
+    tmp_reader : python routine
+        External routine that reads a model file and returns a 3D numpy array, 
+        where the first column corresponds to wavelengths, the second 
+        contains flux values, and the third the uncertainties on the flux.
+    search_mode: str, opt {'simplex', 'grid'}
+        How is the best fit template found? Simplex or grid search.
+    lambda_scal: float, optional
+        Wavelength where a first scaling will be performed between template
+        and observed spectra. If not provided, the middle wavelength of the 
+        osberved spectra will be considered.
+    scale_range: tuple, opt
+        If grid search, this parameter should be provided as a tuple of 3 
+        floats: lower limit, upper limit and step of the grid search for the 
+        scaling factor to be applied AFTER the first rough scaling (i.e.
+        scale_range should always encompass 1).
+    ext_range: tuple or None, opt
+        If None: differential extinction is not to be considered as a free 
+        parameter. Elif a tuple of 3 floats is provided, differential extinction 
+        will be considered, with the floats as lower limit, upper limit and step 
+        of the grid search.
+        Note: if simplex search, the range is still used to set a chi of 
+        np.inf outside of the range.
+    dlbda_obs: numpy 1d ndarray or list, optional
+        Spectral channel width for the observed spectrum. It should be provided 
+        IF one wants to weigh each point based on the spectral 
+        resolution of the respective instruments (as in Olofsson et al. 2016).
+    instru_corr : numpy 2d ndarray or list, optional
+        Spectral correlation throughout post-processed images in which the 
+        spectrum is measured. It is specific to the combination of instrument, 
+        algorithm and radial separation of the companion from the central star.
+        Can be computed using distances.spectral_correlation(). In case of
+        a spectrum obtained with different instruments, build it with
+        distances.combine_corrs(). If not provided, it will consider the 
+        uncertainties in each spectral channels are independent. See Greco & 
+        Brandt (2017) for details.
+    instru_fwhm : float or list, optional
+        The instrumental spectral fwhm provided in nm. This is used to convolve
+        the model spectrum. If several instruments are used, provide a list of 
+        instru_fwhm values, one for each instrument whose spectral resolution
+        is coarser than the model - including broad band
+        filter FWHM if relevant.
+    instru_idx: numpy 1d array, optional
+        1d array containing an index representing each instrument used 
+        to obtain the spectrum, label them from 0 to n_instru. Zero for points 
+        that don't correspond to any instru_fwhm provided above, and i in 
+        [1,n_instru] for points associated to instru_fwhm[i-1]. This parameter 
+        must be provided if the spectrum consists of points obtained with 
+        different instruments.
+    filter_reader: python routine, optional
+        External routine that reads a filter file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains transmission values. Important: if not provided, but strings 
+        are detected in instru_fwhm, the default format assumed for the files:
+        - first row containing header
+        - starting from 2nd row: 1st column: WL in mu, 2nd column: transmission
+        Note: files should all have the same format and wavelength units.
+    red_chi2: bool, optional
+        Whether to compute the reduced chi square. If False, considers chi^2.
+    remove_nan: bool, optional
+        Whether to remove NaN values from template spectrum BEFORE resampling
+        to the wavelength sampling of the observed spectrum. Whether it is set
+        to True or False, a check is made just before chi^2 is calculated 
+        (after resampling), and only non-NaN values will be considered.
+    simplex_options: dict, optional
+        The scipy.optimize.minimize simplex (Nelder-Mead) options.
+    force_continue: bool, optional
+        In case of issue with the fit, whether to continue regardless (this may
+        be useful in an uneven spectral library, where some templates have too
+        few points for the fit to be performed).
+    verbose: str, optional
+        Whether to print more information when fit fails.
+    **kwargs: optional
+        Optional arguments to the scipy.optimize.minimize function.
+        
+    Returns
+    -------
+    best_chi: float
+        goodness of fit scored by the template
+    best_scal:
+        best-fit scaling factor for the considered template
+    best_ext:
+        best-fit optical extinction for the considered template
+        
+    """
+    # read template spectrum
+    try:
+        lbda_tmp, spec_tmp, spec_tmp_err = tmp_reader(tmp_name, 
+                                                  verbose=bool(verbose))
+    except:
+        msg = "{} could not be opened. Corrupt file?".format(tmp_name)
+        if force_continue:
+            if verbose:
+                print(msg)
+            return np.inf, 1, 0, 1
+        else:
+            raise ValueError(msg)
+            
+    # look for any nan and replace
+    if remove_nan:
+        if np.isnan(spec_tmp).any() or np.isnan(spec_tmp_err).any():
+            bad_idx1 = np.where(np.isnan(spec_tmp))[0]
+            bad_idx2 = np.where(np.isnan(spec_tmp_err))[1]
+            all_bad = np.concatenate(bad_idx1,bad_idx2)
+            nch = len(lbda_tmp)
+            new_lbda = [lbda_tmp[i] for i in range(nch) if i not in all_bad]
+            new_spec = [spec_tmp[i] for i in range(nch) if i not in all_bad]
+            new_err = [spec_tmp_err[i] for i in range(nch) if i not in all_bad]
+            lbda_tmp = np.array(new_lbda)
+            spec_tmp = np.array(new_spec)
+            spec_tmp_err = np.array(new_err)
+        
+    # don't consider template spectra whose range is smaller than observed one
+    if lbda_obs[0] < lbda_tmp[0] or lbda_obs[-1] > lbda_tmp[-1]:
+        msg = "Wavelength range of template {} ({:.2f}, {:.2f})mu too short"
+        msg+= " compared to that of observed spectrum ({:.2f}, {:.2f})mu"
+        if force_continue:
+            if verbose:
+                print(msg.format(tmp_name, lbda_tmp[0],lbda_tmp[-1],
+                                        lbda_obs[0],lbda_obs[-1]))
+            return np.inf, 1, 0, len(lbda_tmp)-2
+        else:
+            raise ValueError(msg.format(tmp_name, lbda_tmp[0],lbda_tmp[-1],
+                                        lbda_obs[0],lbda_obs[-1]))
+    
+    # resample as observed spectrum
+    try:
+        _, spec_tmp = resample_model(lbda_obs, lbda_tmp, spec_tmp, 
+                                     dlbda_obs=dlbda_obs, 
+                                     instru_fwhm=instru_fwhm, 
+                                     instru_idx=instru_idx, 
+                                     filter_reader=filter_reader)
+        lbda_tmp, spec_tmp_err = resample_model(lbda_obs, lbda_tmp, 
+                                                spec_tmp_err, 
+                                                dlbda_obs=dlbda_obs, 
+                                                instru_fwhm=instru_fwhm, 
+                                                instru_idx=instru_idx, 
+                                                filter_reader=filter_reader)
+    except:
+        msg = "Issue with resampling of template {}. Does the wavelength "
+        msg+= "range extend far enough ({:.2f}, {:.2f})mu?"
+        if force_continue:
+            if verbose:
+                print(msg.format(tmp_name, lbda_tmp[0],lbda_tmp[-1]))
+            return np.inf, 1, 0, len(lbda_tmp)-2
+        else:
+            raise ValueError(msg.format(tmp_name, lbda_tmp[0],lbda_tmp[-1]))
+    
+    # first rescaling fac
+    if not lambda_scal:
+        lambda_scal = (lbda_obs[0]+lbda_obs[-1])/2
+    idx_cen = find_nearest(lbda_obs, lambda_scal)
+    scal_fac = spec_obs[idx_cen]/spec_tmp[idx_cen]
+    spec_tmp*=scal_fac
+    spec_tmp_err*=scal_fac
+    
+    # combine observed and template uncertainties
+    # EDIT: Don't: the  best fit will be the most noisy tmp of the library!)
+    #err_obs = np.sqrt(np.power(spec_tmp_err,2)+np.power(err_obs,2))
+    
+    
+    # only consider non-zero and non-nan values for chi^2 calculation
+    cond1 = np.where(np.isfinite(spec_tmp))[0]
+    cond2 = np.where(np.isfinite(err_obs))[0] 
+    cond3 = np.where(spec_tmp>0)[0]
+    all_conds = np.sort(np.unique(np.concatenate((cond1,cond2,cond3))))
+    ngood_ch = len(all_conds)
+    good_ch = (all_conds,)
+    lbda_obs = lbda_obs[good_ch]
+    spec_obs = spec_obs[good_ch]
+    err_obs = err_obs[good_ch]
+    spec_tmp = spec_tmp[good_ch]
+    
+    n_dof = ngood_ch-1-(ext_range is not None)
+    if n_dof <= 0:
+        msg = "Not enough dof with remaining points of template spectrum {}"
+        if force_continue:
+            if verbose:
+                print(msg.format(tmp_name))
+            return np.inf, 1, 0, n_dof
+        else:
+            raise ValueError(msg.format(tmp_name))
+    
+    # simplex search
+    if search_mode == 'simplex':
+        if simplex_options is None:
+            simplex_options = {'xatol': 1e-6, 'fatol': 1e-6, 'maxiter': 1000,
+                               'maxfev': 5000}
+        if not ext_range:
+            p = (1,)
+        else:
+            AV_ini = (ext_range[0]+ext_range[1])/2
+            p = (1,AV_ini)
+        try:
+            res = minimize(gof_scal, p, args=(lbda_obs, spec_obs, err_obs, 
+                                              lbda_obs, spec_tmp, dlbda_obs, 
+                                              instru_corr, instru_fwhm, 
+                                              instru_idx, filter_reader,
+                                              ext_range),
+                           method='Nelder-Mead', options=simplex_options, 
+                           **kwargs)
+        except:
+            msg = "Issue with simplex minimization for template {}. "
+            msg+= "Try grid search?"
+            if force_continue:
+                if verbose:
+                    print(msg.format(tmp_name))
+                return np.inf, 1, 0, n_dof
+            else:
+                raise ValueError(msg.format(tmp_name))
+        best_chi = res.fun
+        if not ext_range:
+            best_scal = res.x
+            best_ext = 0
+        else:
+            best_scal, best_ext = res.x
+        
+    # or grid search        
+    elif search_mode == 'grid':
+        test_scale = np.arange(scale_range[0], scale_range[1], scale_range[2])
+        n_test = len(test_scale)
+        if ext_range is None:
+            test_ext = np.array([0])
+            n_ext = 1
+        elif isinstance(ext_range, tuple) and len(ext_range)==3:
+            test_ext = np.arange(ext_range[0], ext_range[1], ext_range[2])
+            n_ext = len(test_ext)
+        else:
+            raise TypeError("ext_range can only be None or tuple of length 3")
+
+        chi = np.zeros([n_test,n_ext])
+        
+        for cc, scal in enumerate(test_scale):
+            for ee, AV in enumerate(test_ext):
+                p = (scal,AV)
+                chi[cc,ee] = gof_scal(p, lbda_obs, spec_obs, err_obs, lbda_obs, 
+                                      spec_tmp, dlbda_obs=dlbda_obs, 
+                                      instru_corr=instru_corr, 
+                                      instru_fwhm=instru_fwhm, 
+                                      instru_idx=instru_idx, 
+                                      filter_reader=filter_reader,
+                                      ext_range=ext_range) 
+        best_chi = np.nanmin(chi)
+        best_idx = np.nanargmin(chi)
+        best_idx = np.unravel_index(best_idx,chi.shape)
+        best_scal = test_scale[best_idx[0]]
+        best_ext = test_ext[best_idx[1]]
+    
+    else:
+        msg = "Search mode not recognised. Should be 'simplex' or 'grid'."
+        raise TypeError(msg)
+    
+    if red_chi2:
+        best_chi /= n_dof
+        
+    
+    return best_chi, best_scal*scal_fac, best_ext, n_dof
+
+
+
+def best_fit_tmp(lbda_obs, spec_obs, err_obs, tmp_reader, search_mode='simplex',
+                 n_best=1, lambda_scal=None, scale_range=(0.1,10,0.01), 
+                 ext_range=None, simplex_options=None, dlbda_obs=None, 
+                 instru_corr=None, instru_fwhm=None, instru_idx=None, 
+                 filter_reader=None, lib_dir='tmp_lib/', tmp_endswith='.fits', 
+                 red_chi2=True, remove_nan=False, nproc=1, verbosity=0, 
+                 force_continue=False, **kwargs):
+    """ Finds the best fit template spectrum to a given observed spectrum, 
+    within a spectral library.  By default, a single free parameter is 
+    considered: the scaling factor of the spectrum. A first automatic scaling 
+    is performed by comparing the flux of the observed and template spectra at 
+    lambda_scal. Then a more refined scaling is performed, either through 
+    simplex or grid search (within scale_range).
+    If fit_extinction is set to True, the exctinction is also considered as a 
+    free parameter.
+    
+    Parameters
+    ----------
+    lbda_obs : numpy 1d ndarray or list
+        Wavelength of observed spectrum. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs).
+    spec_obs : numpy 1d ndarray or list
+        Observed spectrum for each value of lbda_obs.
+    err_obs : numpy 1d/2d ndarray or list
+        Uncertainties on the observed spectrum. If 2d array, should be [2,n_ch]
+        where the first (resp. second) column corresponds to lower (upper) 
+        uncertainty, and n_ch is the length of lbda_obs and spec_obs.
+    tmp_reader : python routine
+        External routine that reads a model file and returns a 3D numpy array, 
+        where the first column corresponds to wavelengths, the second 
+        contains flux values, and the third the uncertainties on the flux.
+    search_mode: str, optional, {'simplex','grid'}
+        How is the best fit template found? Simplex or grid search.
+    n_best: int, optional
+        Number of best templates to be returned (default: 1)
+    lambda_scal: float, optional
+        Wavelength where a first scaling will be performed between template
+        and observed spectra. If not provided, the middle wavelength of the 
+        osberved spectra will be considered.
+    scale_range: tuple, opt
+        If grid search, this parameter should be provided as a tuple of 3 
+        floats: lower limit, upper limit and step of the grid search for the 
+        scaling factor to be applied AFTER the first rough scaling (i.e.
+        scale_range should always encompass 1).
+    ext_range: tuple or None, opt
+        If None: differential extinction is not to be considered as a free 
+        parameter. Elif a tuple of 3 floats is provided, differential extinction 
+        will be considered, with the floats as lower limit, upper limit and step 
+        of the grid search.
+        Note: if simplex search, the range is still used to set a chi of 
+        np.inf outside of the range.
+    dlbda_obs: numpy 1d ndarray or list, optional
+        Spectral channel width for the observed spectrum. It should be provided 
+        IF one wants to weigh each point based on the spectral 
+        resolution of the respective instruments (as in Olofsson et al. 2016).
+    instru_corr : numpy 2d ndarray or list, optional
+        Spectral correlation throughout post-processed images in which the 
+        spectrum is measured. It is specific to the combination of instrument, 
+        algorithm and radial separation of the companion from the central star.
+        Can be computed using distances.spectral_correlation(). In case of
+        a spectrum obtained with different instruments, build it with
+        distances.combine_corrs(). If not provided, it will consider the 
+        uncertainties in each spectral channels are independent. See Greco & 
+        Brandt (2017) for details.
+    instru_fwhm : float OR list of either floats or strings, optional
+        The instrumental spectral fwhm provided in nm. This is used to convolve
+        the model spectrum. If several instruments are used, provide a list of 
+        instru_fwhm values, one for each instrument whose spectral resolution
+        is coarser than the model - including broad band filter FWHM if 
+        relevant.
+        If strings are provided, they should correspond to filenames (including 
+        full paths) of text files containing the filter information for each 
+        observed wavelength. Strict format: 
+    instru_idx: numpy 1d array, optional
+        1d array containing an index representing each instrument used 
+        to obtain the spectrum, label them from 0 to n_instru. Zero for points 
+        that don't correspond to any instru_fwhm provided above, and i in 
+        [1,n_instru] for points associated to instru_fwhm[i-1]. This parameter 
+        must be provided if the spectrum consists of points obtained with 
+        different instruments.
+    filter_reader: python routine, optional
+        External routine that reads a filter file and returns a 2D numpy array, 
+        where the first column corresponds to wavelengths, and the second 
+        contains transmission values. Important: if not provided, but strings 
+        are detected in instru_fwhm, the default file reader will be used. 
+        It assumes the following format for the files:
+        - first row containing header
+        - starting from 2nd row: 1st column: wavelength, 2nd col.: transmission
+        - Unit of wavelength can be provided in parentheses of first header key
+        name: e.g. "WL(AA)" for angstrom, "wavelength(mu)" for micrometer or
+        "lambda(nm)" for nanometer. Note: Only what is in parentheses matters.
+        Important: filter files should all have the same format and WL units.
+    simplex_options: dict, optional
+        The scipy.optimize.minimize simplex (Nelder-Mead) options.
+    red_chi2: bool, optional
+        Whether to compute the reduced chi square. If False, considers chi^2.
+    remove_nan: bool, optional
+        Whether to remove NaN values from template spectrum BEFORE resampling
+        to the wavelength sampling of the observed spectrum. Whether it is set
+        to True or False, a check is made just before chi^2 is calculated 
+        (after resampling), and only non-NaN values will be considered.
+    nproc: int, optional
+        The number of processes to use for parallelization.
+    verbosity: 0, 1 or 2, optional
+        Verbosity level. 0 for no output and 2 for full information.
+    force_continue: bool, optional
+        In case of issue with the fit, whether to continue regardless (this may
+        be useful in an uneven spectral library, where some templates have too
+        few points for the fit to be performed).
+    **kwargs: optional
+        Optional arguments to the scipy.optimize.minimize function
+         
+    Returns
+    -------
+    final_tmpname: tuple of n_best str
+        Best-fit template filenames
+    final_tmp: tuple of n_best 3D numpy array
+        Best-fit template spectra (3D: lbda+spec+spec_err)
+    final_chi: 1D numpy array of length n_best
+        Best-fit template chi^2
+    final_params: 2D numpy array (2xn_best)
+        Best-fit parameters (optimal scaling and optical extinction). Note if 
+        extinction is not fitted, optimal AV will be set to 0.
+        
+    """
+    # create list of template filenames
+    tmp_filelist = [x for x in os.listdir(lib_dir) if x.endswith(tmp_endswith)]
+    n_tmp = len(tmp_filelist)
+    
+    if verbosity > 0:
+        start_time = time_ini()
+        int_time = time_ini()
+        print("{:.0f} template spectra will be tested. \n".format(n_tmp))
+        print("****************************************\n")
+    
+    chi = np.ones(n_tmp)
+    scal = np.ones_like(chi)
+    ext = np.zeros_like(chi)
+    n_dof =  np.ones_like(chi)
+    counter = 0
+    
+    if nproc == 1:
+        for tt in range(n_tmp):
+            if verbosity>0 and search_mode=='simplex':
+                print('Nelder-Mead minimization is running...')
+            chi[tt], scal[tt], ext[tt], n_dof[tt] = get_chi(lbda_obs, spec_obs, err_obs, 
+                                                 tmp_filelist[tt], tmp_reader, 
+                                                 search_mode=search_mode, 
+                                                 scale_range=scale_range, 
+                                                 ext_range=ext_range,
+                                                 lambda_scal=lambda_scal,
+                                                 dlbda_obs=dlbda_obs, 
+                                                 instru_corr=instru_corr, 
+                                                 instru_fwhm=instru_fwhm, 
+                                                 instru_idx=instru_idx, 
+                                                 filter_reader=filter_reader,
+                                                 simplex_options=simplex_options,
+                                                 red_chi2=red_chi2,
+                                                 remove_nan=remove_nan,
+                                                 force_continue=force_continue,
+                                                 verbose=verbosity,
+                                                 **kwargs)
+            
+            if chi[tt]<np.inf:
+                counter+=1
+            elif verbosity>0:
+                msg = "{:.0f}/{:.0f} ({}) FAILED"
+                if np.isnan(chi[tt]):
+                    msg += " (simplex did not converge)"
+                print(msg.format(tt, n_tmp, tmp_filelist[tt]))
+
+            if verbosity > 0 and tt==0:
+                msg = "{:.0f}/{:.0f}: done in {}s"
+                indiv_time = time_fin(start_time)
+                print(msg.format(tt, n_tmp, indiv_time))
+                now = datetime.now()
+                delta_t = now.timestamp()-start_time.timestamp()
+                tot_time = n_tmp*delta_t/60
+                print("Fit may take a total of ~{:.0f}min \n".format(tot_time))
+                int_time = time_ini(verbose=False)
+            elif verbosity > 1:
+                msg = "{:.0f}/{:.0f}: done in {}s \n"
+                indiv_time = time_fin(int_time)
+                int_time = time_ini(verbose=False)
+                print(msg.format(tt, n_tmp, indiv_time))
+    else:
+        raise ValueError("multiprocessing mode yet to be implemented")
+        
+    if verbosity > 0:
+        print("****************************************\n")
+        msg = "{:.0f}/{:.0f} template spectra were fitted. \n"
+        print(msg.format(counter, n_tmp))
+        timing(start_time)
+        
+    return best_n_tmp(chi, scal, ext, n_dof, tmp_filelist, tmp_reader, n_best=n_best,
+                      verbose=True)
+    
+    
+def best_n_tmp(chi, scal, ext, n_dof, tmp_filelist, tmp_reader, n_best=1, 
+               verbose=False):
+    """
+    Routine returning the n best template spectra.
+    
+    Parameters
+    ----------
+    lbda_obs : numpy 1d ndarray or list
+        Wavelength of observed spectrum. If several instruments, should be 
+        ordered per instrument, not necessarily as monotonically increasing 
+        wavelength. Hereafter, n_ch = len(lbda_obs).
+
+    Returns
+    -------
+    final_tmpname: tuple of n_best str
+        Best-fit template filenames
+    final_tmp: tuple of n_best 3D numpy array
+        Best-fit template spectra (3D: lbda+spec+spec_err)
+    final_chi: 1D numpy array of length n_best
+        Best-fit template chi^2
+    final_params: 2D numpy array (2xn_best)
+        Best-fit parameters (optimal scaling and optical extinction). Note if 
+        extinction is not fitted, optimal AV will be set to 0.
+        
+    """
+    # sort from best to worst match
+    order = np.argsort(chi)
+    sort_chi = chi[order]
+    sort_scal = scal[order]
+    sort_ext = ext[order]
+    sort_ndof = n_dof[order]
+    sort_filelist = [tmp_filelist[i] for i in order]
+    
+    if verbose:
+        print("best chi: ", sort_chi[:n_best])
+        print("best scale fac: ", sort_scal[:n_best])
+        print("n_dof: ", sort_ndof[:n_best])
+    # take the n_best first ones
+    best_tmp = []
+    for n in range(n_best):
+        lbda_tmp, spec_tmp, spec_tmp_err = tmp_reader(sort_filelist[n])
+        Albdas = extinction(lbda_tmp,abs(sort_ext[n]))
+        extinc_fac = np.power(10.,-Albdas/2.5)
+        if sort_ext[n]>0:
+            final_scal = sort_scal[n]*extinc_fac
+        elif sort_ext[n]<0:
+            final_scal = sort_scal[n]/extinc_fac
+        else:
+            final_scal = sort_scal[n]
+        best_tmp.append(np.array([lbda_tmp, spec_tmp*final_scal, 
+                                  spec_tmp_err*final_scal]))
+        if verbose:
+            msg = "The best template #{:.0f} is: {} "
+            msg+="(Delta A_V={:.1f}mag)\n"
+            print(msg.format(n, sort_filelist[n], sort_ext[n]))
+            
+    best_tmpname = tuple(sort_filelist[:n_best])
+    best_tmp = tuple(best_tmp)
+    best_params = np.array([sort_scal[:n_best],sort_ext[:n_best]])
+    
+    return best_tmpname, best_tmp, sort_chi[:n_best], best_params, sort_ndof[:n_best]

--- a/vip_hci/specfit/utils_spec.py
+++ b/vip_hci/specfit/utils_spec.py
@@ -1,0 +1,452 @@
+#! /usr/bin/env python
+
+"""
+Utility functions for spectral fitting.
+"""
+
+__author__ = 'Valentin Christiaens'
+__all__ = ['akaike',
+           'blackbody',
+           'combine_spec_corrs',
+           'convert_F_units',
+           'convert_F_vs_mag',
+           'extinction',
+           'find_nearest',
+           'inject_em_line',
+           'mj_from_rj_and_logg',
+           'nrefrac']
+
+import astropy.constants as c
+import numpy as np
+from scipy.signal import gaussian
+        
+def akaike(LnL, k):
+    """
+    Computes the Akaike Information Criterion: 2k-2ln(L),
+    where k is the number of estimated parameters in the model and LnL is the 
+    max ln-likelihood for the model.
+    """
+    return 2*k-2*LnL  
+
+
+def blackbody(lbda, T): 
+    """
+    Assumes lbda is a wavelength vector in micrometers.
+    """
+    fac = 2*c.h.value*(c.c.value**2)/(np.power(lbda*1e-6,5))
+    div = (1/(np.exp((c.h.value*c.c.value)/((lbda*1e-6)*c.k_B.value*T))-1))
+    # convert from W m-3 Sr-1 to W m-2 mu-1 Sr-1 
+    conv = 1e-6
+    return fac*div*conv
+
+
+def combine_spec_corrs(arr_list):
+    """ Combines the spectral correlation matrices of different instruments 
+    into a single square matrix (required for input of spectral fit).
+    
+    Parameters
+    ----------
+    arr_list : list or tuple of numpy ndarrays
+        List/tuple containing the distinct square spectral correlation matrices 
+        OR ones (for independent photometric measurements). 
+
+    Returns
+    -------
+    combi_corr : numpy 2d ndarray
+        2d square ndarray representing the combined spectral correlation.
+        
+    """
+    n_arr = len(arr_list)
+    
+    size = 0
+    for nn in range(n_arr):
+        if isinstance(arr_list[nn],np.ndarray):
+            if arr_list[nn].ndim != 2:
+                raise TypeError("Arrays of the tuple should be 2d")
+            elif arr_list[nn].shape[0] != arr_list[nn].shape[1]:
+                raise TypeError("Arrays of the tuple should be square")
+            size+=arr_list[nn].shape[0]
+        elif arr_list[nn] == 1:
+            size+=1
+        else:
+            raise TypeError("Tuple can only have square 2d arrays or ones")
+            
+    combi_corr = np.zeros([size,size])
+    
+    size_tmp = 0
+    for nn in range(n_arr):
+        if isinstance(arr_list[nn],np.ndarray):
+            mm = arr_list[nn].shape[0]
+            combi_corr[size_tmp:size_tmp+mm,size_tmp:size_tmp+mm]=arr_list[nn]
+            size_tmp+=mm
+        elif arr_list[nn] == 1:
+            combi_corr[size_tmp,size_tmp]=1
+            size_tmp+=1      
+        
+    return combi_corr
+
+
+def convert_F_units(F, lbda, in_unit='cgs', out_unit='si'):
+    """
+    Function to convert Flux density between [ergs s^-1 cm^-2 um^-1], 
+    [W m^-2 um^-1] and [Jy].
+
+    Parameters:
+    -----------
+    F: float or 1d array
+        Flux
+    lbda: float or 1d array
+        Wavelength of the flux (in um)
+    in_unit: str, opt, {"si", "cgs", "jy", "cgsA"} 
+        Input flux units. 
+        'si': W/m^2/mu; 
+        'cgs': ergs/s/cm^2/mu
+        'jy': janskys
+        'cgsA': erg/s/cm^2/AA 
+    out_unit: str, opt {"si", "cgs", "jy"}
+        Output flux units.
+        
+    Returns:
+    --------
+    Flux in output units.
+    """
+
+    if in_unit == 'cgs':
+        new_F = (F*1e23*np.power(lbda,2))/(c.c.value*1e6) # convert to jy
+    elif in_unit == 'cgsA':
+        new_F = (F*1e27*np.power(lbda,2))/(c.c.value*1e6) # convert to jy
+    elif in_unit == 'si':
+        new_F = (F*1e26*np.power(lbda,2))/(c.c.value*1e6) # convert to jy
+    elif in_unit == "jy":
+        new_F=F
+    else:
+        msg = "in_unit not recognized, try either 'cgs', 'si' or 'jy'."
+        raise TypeError(msg)        
+    if out_unit == 'jy':
+        return new_F
+    elif out_unit == 'cgs':
+        return new_F*1e-23*c.c.value*1e6/np.power(lbda,2)
+    elif out_unit == 'si':
+        return new_F*1e-26*c.c.value*1e6/np.power(lbda,2)
+    else:
+        msg = "out_unit not recognized, try either 'cgs', 'si' or 'jy'."
+        raise TypeError(msg)  
+
+
+def convert_F_vs_mag(value, F_0=None, band='H', system='Johnson', 
+                     conversion='to_mag'):
+    """
+    Function to convert Flux density (in Jy) to magnitude in a given band, or 
+    the opposite.
+
+    Sources for zero points:
+        - TOKUNAGA chapter on IR astronomy (from Cohen 1992)
+        - UKIRT webpage: 
+        (http://www.jach.hawaii.edu/UKIRT/astronomy/calib/phot_cal/conver.html)
+        - van der Bliek et al. 1996 (ESO standard stars)
+
+    Parameters:
+    -----------
+    value: float
+        Flux or magnitude to be converted.
+    F_0: float, opt
+        Zero-point flux. If provided will take precedence over band.
+    band: str, opt
+        Band of the given flux or magnitude. Choice between: {'U','B','V', 'R', 
+        'I', 'J', 'H', 'K', "L", "L'", 'M', 'N', 'O'} 
+        (but not for all band systems).
+    system: str, opt
+        Band system. Choice between: {'Johnson;,'2MASS', 'UKIRT', 'ESO'}
+    conversion: str, opt
+        In which sense to convert: flux to mag ('to_mag') or mag to flux 
+        ('to_flux')
+    
+    Returns:
+    --------
+    Converted flux or magnitude.
+    """               
+    
+    dico_zero_pts_Jo = {'U': [0.36,1823.],
+                        'B': [0.44,4130.],
+                        'V': [0.55,3781.],
+                        'R': [0.71,2941.],
+                        'I': [0.97,2635.],
+                        'J': [1.25,1603.],
+                        'H': [1.60,1075.],
+                        'K': [2.22,667.],
+                        'L': [3.54,288.],
+                        'M': [4.80,170.],
+                        'N': [10.6,36.],
+                        'O': [21.0,9.4]}
+    dico_zero_pts_2M = {'J': [1.235,1594.],
+                        'H': [1.662,1024.],
+                        'K': [2.159,666.7]}
+    dico_zero_pts_UK = {'V': [0.5556,3540.], # TOKUNAGA (from Cohen 1992)
+                        'I': [0.9,2250.],    # UKIRT webpage
+                        'J': [1.215,1630.],  # TOKUNAGA (from Cohen 1992)
+                        'H': [1.654,1050.],  # TOKUNAGA (from Cohen 1992)
+                        'Ks': [2.157,667.],  # TOKUNAGA (from Cohen 1992)
+                        'K': [2.179,655.],   # TOKUNAGA (from Cohen 1992)                        
+                        'L': [3.547,276.],   # TOKUNAGA (from Cohen 1992)  
+                        "L'": [3.761,248.],  # TOKUNAGA (from Cohen 1992)                          
+                        'M': [4.769,160.],   # TOKUNAGA (from Cohen 1992)  
+                        '8.7': [8.756,50.],  # TOKUNAGA (from Cohen 1992)                          
+                        'N': [10.472,35.3],  # TOKUNAGA (from Cohen 1992)  
+                        '11.7': [11.653,28.6], # TOKUNAGA (from Cohen 1992)         
+                        'Q': [20.13,9.7]}      # TOKUNAGA (from Cohen 1992)
+    dico_zero_pts_ESO = {'J': [1.228,3.44e-9],  # van der Bliek 1996
+                        'H': [1.651,1.21e-9],   # van der Bliek 1996
+                        'K': [2.216,4.12e-10],  # van der Bliek 1996
+                        "L'": [3.771,5.58e-11], # van der Bliek 1996
+                        "M": [4.772,2.21e-11]}  # van der Bliek 1996 
+    
+    if F_0 is None:
+        if system == 'Johnson' and band in dico_zero_pts_Jo:
+            dico_F_0 = dico_zero_pts_Jo
+        elif system == '2MASS' and band in dico_zero_pts_2M:
+            dico_F_0 = dico_zero_pts_2M
+        elif system == 'UKIRT' and band in dico_zero_pts_UK:
+            dico_F_0 = dico_zero_pts_UK
+        elif system == 'ESO' and band in dico_zero_pts_UK:
+            dico_F_0 = dico_zero_pts_ESO                   
+        else:
+            msg = 'Combination of band name and band system not recognized.'
+            raise TypeError(msg)
+        F_0 = dico_F_0[band][1]
+        if system == 'ESO':
+            # convert from W m-2 mu-1 to Jy
+            F_0 = convert_F_units(F_0, dico_F_0[band][0], in_unit='si', 
+                                  out_unit='jy')
+    
+    if conversion == 'to_mag':
+        return -2.5*np.log10(value/F_0)
+    elif conversion == 'to_flux':
+        return F_0*np.power(10.,-value/2.5)
+    else:
+        msg = "conversion not recognized, must be 'to_mag' or 'to_flux'."
+        raise TypeError(msg)
+        
+
+def extinction(lbda, AV, RV=3.1):
+    """
+    Calculates the A(lambda) extinction for a given combination of A_V and R_V.
+    If R_V is not provided, assumes an ISM value of R_V=3.1
+    Uses the Cardelli et al. (1989) empirical formulas.
+    
+    Parameters
+    ----------
+    lbda : 1d np.ndarray
+        Array with the wavelengths (um) for which the extinction is calculated.
+    AV : float
+        Extinction (mag) in the V band.
+    RV : float, opt
+        Reddening in the V band: R_V = A_V / E(B-V)
+        
+    Returns
+    -------
+    Albda: 1d np.ndarray
+        Extinction (mag) at wavelengths lbda.
+    """
+
+    xx = 1./lbda
+    yy = xx - 1.82
+
+    a_c = np.zeros_like(xx)
+    b_c = np.zeros_like(xx)
+
+    indices = np.where(xx < 1.1)[0]
+
+    if len(indices) > 0:
+        a_c[indices] = 0.574*np.power(xx[indices], 1.61)
+        b_c[indices] = -0.527*np.power(xx[indices], 1.61)
+
+    indices = np.where(xx >= 1.1)[0]
+
+    if len(indices) > 0:
+        a_c[indices] = 1. + 0.17699*yy[indices] - 0.50447*yy[indices]**2 - \
+                       0.02427*yy[indices]**3 + 0.72085*yy[indices]**4 + \
+                       0.01979*yy[indices]**5 - 0.77530*yy[indices]**6 + \
+                       0.32999*yy[indices]**7
+
+        b_c[indices] = 1.41338*yy[indices] + 2.28305*yy[indices]**2 + \
+                       1.07233*yy[indices]**3 - 5.38434*yy[indices]**4 - \
+                       0.62251*yy[indices]**5 + 5.30260*yy[indices]**6 - \
+                       2.09002*yy[indices]**7
+
+    return AV * (a_c + b_c/RV)
+
+
+def find_nearest(array, value, output='index', constraint=None, n=1):
+    """
+    Function to find the indices, and optionally the values, of an array's n 
+    closest elements to a certain value.
+    
+    Parameters
+    ----------
+    array: 1d numpy array or list
+        Array in which to check the closest element to value.
+    value: float
+        Value for which the algorithm searches for the n closest elements in 
+        the array.
+    output: str, opt {'index','value','both' }
+        Set what is returned
+    constraint: str, opt {None, 'ceil', 'floor'}
+        If not None, will check for the closest element larger than value (ceil)
+        or closest element smaller than value (floor).
+    n: int, opt
+        Number of elements to be returned, sorted by proximity to the values.
+        Default: only the closest value is returned.
+    
+    Returns:
+    --------
+    Either:
+    1) index/indices of the closest n value(s) in the array;
+    2) the closest n value(s) in the array, 
+    3) both 1) and 2). 
+    By default, only returns the index/indices
+    
+    Possible constraints: 'ceil', 'floor', None ("ceil" will return the closest 
+    element with a value greater than 'value', "floor" the opposite)
+    """
+    if isinstance(array, np.ndarray):
+        pass
+    elif isinstance(array, list):
+        array = np.array(array)
+    else:
+        raise ValueError("Input type for array should be np.ndarray or list.")
+    
+    if constraint is None:
+        fm = np.absolute(array-value)
+        idx = fm.argsort()[:n]
+    elif constraint == 'floor' or constraint == 'ceil': 
+        indices = np.arange(len(array),dtype=np.int32)
+        if constraint == 'floor':
+            fm = -(array-value)
+        else:
+            fm = array-value
+        crop_indices = indices[np.where(fm>0)]
+        fm = fm[np.where(fm>0)]
+        idx = fm.argsort()[:n]
+        idx = crop_indices[idx]
+        if len(idx)==0:
+            msg = "No indices match the constraint ({} w.r.t {:.2f})"
+            print(msg.format(constraint,value))
+            raise ValueError("No indices match the constraint")
+    else:
+        raise ValueError("Constraint not recognised")
+
+    if n == 1:
+        idx = idx[0]
+
+    if output=='index': return idx
+    elif output=='value': return array[idx]
+    else: return array[idx], idx
+
+
+def inject_em_line(wl, flux, lbda, spec, width=None, em=True, height=0.1):
+    """
+    Injects an emission (or absorption) line in a spectrum. The line will be 
+    injected assuming a gaussian profile with either the provided FWHM (in mu) 
+    or (if not provided) set to the equivalent width of the line.
+    Height is the ratio to peak where the line width is considered. E.g. if 
+    height=10%, the width will be the full width at 10% maximum.
+    """
+    # convert ew, assuming it's in mu
+    idx_mid = find_nearest(lbda, wl)
+    
+    nch = len(lbda)
+    dlbda = (lbda[idx_mid+1]-lbda[idx_mid-1])/2
+    
+    # estimate model continuum level using adjacent channels in the spectrum
+    lbda_b0 = 0.99*lbda[idx_mid]
+    idx_b0 = find_nearest(lbda, lbda_b0, constraint='floor')-1
+    lbda_b1 = 0.995*lbda[idx_mid]
+    idx_b1 = find_nearest(lbda, lbda_b1, constraint='floor')
+    lbda_r1 = 1.01*lbda[idx_mid] 
+    idx_r1 = find_nearest(lbda, lbda_r1, constraint='ceil')+1
+    lbda_r0 = 1.005*lbda[idx_mid] 
+    idx_r0 = find_nearest(lbda, lbda_r0, constraint='ceil')
+    if idx_b0<0 or idx_r1>nch-1:
+        raise ValueError("The line is too close from the edge of the spectrum")
+    spec_b = spec[idx_b0:idx_b1+1]
+    spec_r = spec[idx_r0:idx_r1+1]
+    cont = np.median(np.concatenate((spec_b,spec_r)))
+    
+    if width is None:
+        # infer ew
+        ew = flux/cont
+        # infer gaussian profile assuming FWHM = EW
+        stddev = ew/(2*np.sqrt(2*np.log(1/height)))
+    else:
+        stddev = width/(2*np.sqrt(2*np.log(1/height)))
+        
+    win_sz = int((5*stddev)/dlbda)
+
+    if win_sz%2==0:
+        win_sz+=1
+    idx_ini = int(idx_mid - (win_sz-1)/2)
+    if idx_ini<0:
+        msg = "idx ini for line injection negative: try smaller line flux"
+        msg+= " than: {} W/m2 (surface flux)"
+        raise ValueError(msg.format(flux))
+    elif idx_ini+win_sz>len(spec):
+        msg = "idx fin for line injection larger than spec length: try smaller"
+        msg += " line flux than: {} W/m2 (surface flux)"
+        raise ValueError(msg.format(flux))
+    if win_sz<1:
+        raise ValueError("window size for line injection = {}<1".format(win_sz))
+    elif win_sz==1:
+        gaus = flux/dlbda
+    else:
+        gaus = gaussian(win_sz,stddev/dlbda)
+        # scale the gaussian to contain exactly required flux
+        dlbda_tmp = lbda[idx_ini+1:idx_ini+win_sz+1]-lbda[idx_ini:idx_ini+win_sz]
+        gaus = flux*gaus/(np.sum(gaus)*dlbda_tmp)
+
+    
+    if em:
+        spec[idx_ini:idx_ini+win_sz] += gaus
+    else:
+        spec[idx_ini:idx_ini+win_sz] -= gaus
+    
+    return spec
+    
+
+def mj_from_rj_and_logg(rp, logg):
+    """
+    Estimates a planet mass in Jupiter mass for a given radius in Jupiter 
+    radius and the log of the surface gravity. 
+    """    
+    surf_g = 1e-2 * np.power(10.,logg)  # (m s-2)
+
+    rpJ = rp*c.R_jup.value # (m)
+
+    mp = surf_g*np.power(rpJ,2)/c.G.value # (kg)
+    mp /= c.M_jup.value  # (Mjup)
+
+    return mp
+
+
+def nrefrac(wavelength, density=1.0):
+   """Calculate refractive index of air from Cauchy formula.
+
+   Input: wavelength in Angstrom, density of air in amagat (relative to STP,
+   e.g. ~10% decrease per 1000m above sea level).
+   Returns N = (n-1) * 1.e6. 
+   Credit: France Allard.
+   """
+
+   # The IAU standard for conversion from air to vacuum wavelengths is given
+   # in Morton (1991, ApJS, 77, 119). For vacuum wavelengths (VAC) in
+   # Angstroms, convert to air wavelength (AIR) via: 
+
+   #  AIR = VAC / (1.0 + 2.735182E-4 + 131.4182 / VAC^2 + 2.76249E8 / VAC^4)
+
+   try:
+       wl = np.array(wavelength)
+   except TypeError:
+       return None
+
+   wl2inv = (1e4/wl)**2
+   refracstp = 272.643 + 1.2288 * wl2inv  + 3.555e-2 * wl2inv**2
+   return density * refracstp

--- a/vip_hci/stats/bkg_proba.py
+++ b/vip_hci/stats/bkg_proba.py
@@ -1,0 +1,76 @@
+#! /usr/bin/env python
+
+"""
+Probability of a point source to be a background star.
+"""
+
+__author__ = 'V. Christiaens'
+__all__ = ['bkg_star_proba']
+
+from scipy.special import factorial    
+import numpy as np
+
+
+def bkg_star_proba(n_dens, sep, n_bkg=1, verbose=True, full_output=False):
+    """ Given an input density of background star brighter than a certain 
+    magnitude (obtained e.g. from the Besancon model or TRILEGAL), and the 
+    separation of n_bkg point source, estimate the probability of having n_bkg 
+    or more background stars in a disk with radius equal to the largest 
+    separation.
+    The probability is estimated using a spatial Poisson point process.
+
+    Parameters
+    ----------
+    n_dens : float
+        Number density of background stars in the direction of the object of 
+        interest, in arcsec^-2.
+    sep : float or numpy 1d array
+        Separation of the point sources with respect to central star, in arcsec.
+    n_bkg : int, opt
+        Number of point sources in the field, and for which the separation is
+        provided.
+    verbose: bool, opt
+        Whether to print the probabilities for 0 to n_bkg point sources.
+    full_output: bool, opt
+        Whether to also return probabilities of 0 to n_bkg-1 point sources
+
+    Returns
+    -------
+    proba : float
+        Probability between 0% and 100%.
+    [probas : np 1d array] if full_output is True
+        Probabilities of getting 0 to n_bkg-1 point sources
+
+    """
+    
+    if n_bkg < 1 or not isinstance(n_bkg,int):
+        raise TypeError("n_bkg should be a strictly positive integer.")
+    
+    if not isinstance(sep, float):
+        if isinstance(sep, np.ndarray):
+            if sep.ndim!=1 or sep.shape[0]!=n_bkg:
+                raise TypeError("if sep is a np array, its len should be n_bkg")
+            else:
+                sep = np.amax(sep)
+        else:
+            raise TypeError("sep can only be a float or a np 1d array")
+
+    B = np.pi*sep**2 
+    probas = np.zeros(n_bkg)
+    for i in range(n_bkg):
+        probas[i] = np.exp(-n_dens*B)*(n_dens*B)**i/float(factorial(i))
+        if verbose:
+            msg = "Proba of having {:.0f} bkg star in a disk of "
+            msg += "{:.1}'' radius: {:.1f}%"
+            print(msg.format(i,sep,probas[i]))
+
+    proba = 1-np.sum(probas)
+    if verbose:
+        msg = "Proba of having {:.0f} bkg star or more in a disk of "
+        msg += "{:.1}'' radius: {:.1f}%"
+        print(msg.format(n_bkg,sep,proba))
+
+    if full_output:
+        return proba, probas
+    else:
+        return proba

--- a/vip_hci/stats/clip_sigma.py
+++ b/vip_hci/stats/clip_sigma.py
@@ -11,31 +11,36 @@ __all__ = ['clip_array',
            'sigma_filter']
 
 import numpy as np
+
 from scipy.ndimage.filters import generic_filter
 from astropy.stats import median_absolute_deviation
+import warnings
+try:
+    from numba import njit
+    no_numba = False
+except ImportError:
+    msg = "Numba python bindings are missing."
+    warnings.warn(msg, ImportWarning)
+    no_numba = True
 
 
-# TODO: If possible, replace this function using
-# scipy.ndimage.filters.generic_filter and astropy.stats.sigma_clip
-def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
+def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3, 
                  verbose=False):
     """Sigma filtering of pixels in a 2d array.
     
     Parameters
     ----------
-    frame_tmp : numpy ndarray 
+    frame_tmp : numpy ndarray
         Input 2d array, image.
     bpix_map: numpy ndarray
-        Input array of the same size as frame_tmp, indicating the locations of 
+        Input array of the same size as frame_tmp, indicating the locations of
         bad/nan pixels by 1 (the rest of the array is set to 0)
     neighbor_box : int, optional
-        The side of the square window around each pixel where the sigma and 
+        The side of the square window around each pixel where the sigma and
         median are calculated.
     min_neighbors : int, optional
-        Minimum number of good neighboring pixels to be able to correct the 
+        Minimum number of good neighboring pixels to be able to correct the
         bad/nan pixels
-    verbose : bool, optional
-        Prints out the number of iterations.
         
     Returns
     -------
@@ -43,67 +48,138 @@ def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
         Output array with corrected bad/nan pixels
     
     """
-    if frame_tmp.ndim != 2:
-        raise TypeError('Input array is not a frame or 2d array')
+    if not no_numba:
+        @njit
+        def _sigma_filter_numba(frame_tmp, bpix_map, neighbor_box=3, 
+                                min_neighbors=3, verbose=False):
+            if not frame_tmp.ndim == 2:
+                raise TypeError('Input array is not a frame or 2d array')
+        
+            sz_y = frame_tmp.shape[0]  # get image y-dim
+            sz_x = frame_tmp.shape[1]  # get image x-dim
+            bp = bpix_map.copy()       # temporary bpix map; important to make a copy!
+            im = frame_tmp             # corrected image
+            nb = int(np.sum(bpix_map)) # number of bad pixels remaining
+            nit = 0                                 # number of iterations
+            while nb > 0:
+                nit +=1
+                wb = np.where(bp)                   # find bad pixels
+                gp = 1 - bp                         # temporary good pixel map
+                for n in range(nb):
+                    #0/ Determine the box around each pixel
+                    half_box = int(np.floor(neighbor_box/2.))
+                    hbox_b = min(half_box,wb[0][n])        # half size of the box at
+                                                           # the bottom of the pixel
+                    hbox_t = min(half_box,sz_y-1-wb[0][n]) # half size of the box at 
+                                                           # the top of the pixel
+                    hbox_l = min(half_box,wb[1][n])        # half size of the box to 
+                                                           # the left of the pixel
+                    hbox_r = min(half_box,sz_x-1-wb[1][n]) # half size of the box to 
+                                                           # the right of the pixel
+                    # in case we are close to an edge, we want to extend the box
+                    # in the direction opposite to the edge: 
+                    if hbox_b<hbox_t: 
+                        hbox_t += half_box-hbox_b
+                    elif hbox_t<hbox_b: 
+                        hbox_b += half_box-hbox_t
+                    if hbox_l<hbox_r: 
+                        hbox_r += half_box-hbox_l
+                    elif hbox_r<hbox_l:
+                        hbox_l += half_box-hbox_r
+                    sgp = gp[(wb[0][n]-hbox_b):(wb[0][n]+hbox_t+1),
+                             (wb[1][n]-hbox_l):(wb[1][n]+hbox_r+1)]
+                    if int(np.sum(sgp)) >= min_neighbors:
+                        sim = im[(wb[0][n]-hbox_b):(wb[0][n]+hbox_t+1),
+                                 (wb[1][n]-hbox_l):(wb[1][n]+hbox_r+1)]
+                        px_x = int(wb[0][n])
+                        px_y = int(wb[1][n])
+                        gsgp = np.where(sgp)
+                        gsim=[]
+                        for i in range(len(gsgp[0])):
+                            gsim.append(sim[gsgp[0][i],gsgp[1][i]])
+                        im[px_x,px_y] = np.median(np.array(gsim))
+                        bp[px_x,px_y] = 0
+                nb = int(np.sum(bp))
+            if verbose:
+                print('Required number of iterations in the sigma filter: ', nit)
+    
+            return im
 
-    sz_y = frame_tmp.shape[0]  # get image y-dim
-    sz_x = frame_tmp.shape[1]  # get image x-dim
-    bp = bpix_map.copy()       # temporary bpix map; important to make a copy!
-    im = frame_tmp             # corrected image
-    nb = int(np.sum(bpix_map)) # number of bad pixels remaining
-    #In each iteration, correct only the bpix with sufficient good 'neighbors'
-    nit = 0                                 # number of iterations
-    while nb > 0:
-        nit += 1
-        wb = np.where(bp)                   # find bad pixels
-        gp = 1 - bp                         # temporary good pixel map
-        for n in range(nb):
-            #0/ Determine the box around each pixel
-            half_box = np.floor(neighbor_box/2)
-            hbox_b = min(half_box, wb[0][n])       # half size of the box at the
-                                                   # bottom of the pixel
-            hbox_t = min(half_box, sz_y-1-wb[0][n])# half size of the box at the
-                                                   # top of the pixel
-            hbox_l = min(half_box, wb[1][n])       # half size of the box to the
-                                                   # left of the pixel
-            hbox_r = min(half_box, sz_x-1-wb[1][n])# half size of the box to the
-                                                   # right of the pixel
-            # but in case we are at an edge, we want to extend the box by one 
-            # row/column of pixels in the direction opposite to the edge to 
-            # have 9 px instead of 6: 
-            if half_box == 1:
-                if wb[0][n] == sz_y-1:
-                    hbox_b = hbox_b+1
-                elif wb[0][n] == 0:
-                    hbox_t = hbox_t+1
-                if wb[1][n] == sz_x-1:
-                    hbox_l = hbox_l+1
-                elif wb[1][n] == 0:
-                    hbox_r = hbox_r+1
-
-            sgp = gp[int(wb[0][n]-hbox_b): int(wb[0][n]+hbox_t+1),
-                     int(wb[1][n]-hbox_l): int(wb[1][n]+hbox_r+1)]
-            if int(np.sum(sgp)) >= min_neighbors:
-                sim = im[int(wb[0][n]-hbox_b): int(wb[0][n]+hbox_t+1),
+    # TODO: If possible, replace this function using
+    # scipy.ndimage.filters.generic_filter and astropy.stats.sigma_clip
+    def _sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
+                     verbose=False):
+        """Same description as wrapper function."""
+        
+        if frame_tmp.ndim != 2:
+            raise TypeError('Input array is not a frame or 2d array')
+    
+        sz_y = frame_tmp.shape[0]  # get image y-dim
+        sz_x = frame_tmp.shape[1]  # get image x-dim
+        bp = bpix_map.copy()       # temporary bpix map; important to make a copy!
+        im = frame_tmp             # corrected image
+        nb = int(np.sum(bpix_map)) # number of bad pixels remaining
+        #In each iteration, correct only the bpix with sufficient good 'neighbors'
+        nit = 0                                 # number of iterations
+        while nb > 0:
+            nit += 1
+            wb = np.where(bp)                   # find bad pixels
+            gp = 1 - bp                         # temporary good pixel map
+            for n in range(nb):
+                #0/ Determine the box around each pixel
+                half_box = np.floor(neighbor_box/2)
+                hbox_b = min(half_box, wb[0][n])       # half size of the box at the
+                                                       # bottom of the pixel
+                hbox_t = min(half_box, sz_y-1-wb[0][n])# half size of the box at the
+                                                       # top of the pixel
+                hbox_l = min(half_box, wb[1][n])       # half size of the box to the
+                                                       # left of the pixel
+                hbox_r = min(half_box, sz_x-1-wb[1][n])# half size of the box to the
+                                                       # right of the pixel
+                # but in case we are at an edge, we want to extend the box by one 
+                # row/column of pixels in the direction opposite to the edge to 
+                # have 9 px instead of 6: 
+                if half_box == 1:
+                    if wb[0][n] == sz_y-1:
+                        hbox_b = hbox_b+1
+                    elif wb[0][n] == 0:
+                        hbox_t = hbox_t+1
+                    if wb[1][n] == sz_x-1:
+                        hbox_l = hbox_l+1
+                    elif wb[1][n] == 0:
+                        hbox_r = hbox_r+1
+    
+                sgp = gp[int(wb[0][n]-hbox_b): int(wb[0][n]+hbox_t+1),
                          int(wb[1][n]-hbox_l): int(wb[1][n]+hbox_r+1)]
-                im[wb[0][n],wb[1][n]] = np.median(sim[np.where(sgp)])
-                bp[wb[0][n],wb[1][n]] = 0
-        nb = int(np.sum(bp))
-    if verbose:
-        print('Required number of iterations in the sigma filter: ', nit)
-    return im
+                if int(np.sum(sgp)) >= min_neighbors:
+                    sim = im[int(wb[0][n]-hbox_b): int(wb[0][n]+hbox_t+1),
+                             int(wb[1][n]-hbox_l): int(wb[1][n]+hbox_r+1)]
+                    im[wb[0][n],wb[1][n]] = np.median(sim[np.where(sgp)])
+                    bp[wb[0][n],wb[1][n]] = 0
+            nb = int(np.sum(bp))
+        if verbose:
+            print('Required number of iterations in the sigma filter: ', nit)
+        return im
 
 
-# TODO: If possible, replace this function using astropy.stats.sigma_clip
+    if no_numba:
+        return _sigma_filter(frame_tmp, bpix_map, neighbor_box=3, 
+                             min_neighbors=3, verbose=False)
+    else:
+        return _sigma_filter_numba(frame_tmp, bpix_map, neighbor_box=3, 
+                                   min_neighbors=3, verbose=False)
+
+
+
 def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
-               num_neighbor=None, mad=False):
+               num_neighbor=3, mad=False):
     """Sigma clipping for detecting outlying values in 2d array. If the
     parameter 'neighbor' is True the clipping can be performed in a local patch
     around each pixel, whose size depends on 'neighbor' parameter.
     
     Parameters
     ----------
-    array : numpy ndarray 
+    array : numpy ndarray
         Input 2d array, image.
     lower_sigma : float 
         Value for sigma, lower boundary.
@@ -111,54 +187,174 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
         Value for sigma, upper boundary.
     out_good : bool, optional
         For choosing different outputs.
-    neighbor : bool optional
+    neighbor : bool, optional
         For clipping over the median of the contiguous pixels.
     num_neighbor : int, optional
         The side of the square window around each pixel where the sigma and 
         median are calculated. 
-    mad : bool, optional
+    mad : {False, True}, bool optional
         If True, the median absolute deviation will be used instead of the 
         standard deviation.
+    min_std : float, optional
+        Min standard deviation considered for the lower and upper sigma 
+        conditions. Can be useful for frames with padded edges (e.g. SPHERE/IFS)
         
     Returns
     -------
-    good : numpy ndarray
+    good : array_like
         If out_good argument is true, returns the indices of not-outlying px.
-    bad : numpy ndarray 
+    bad : array_like 
         If out_good argument is false, returns a vector with the outlier px.
     
     """
-    if array.ndim != 2:
-        raise TypeError("Input array is not two dimensional (frame)\n")
-
-    values = array.copy()
-    if neighbor and num_neighbor:
-        median = generic_filter(array, function=np.median, 
-                                size=(num_neighbor,num_neighbor), mode="mirror")
-        if mad:
-            sigma = generic_filter(array, function=median_absolute_deviation,                                 
-                                   size=(num_neighbor,num_neighbor), 
-                                   mode="mirror")
-        else:
-            sigma = generic_filter(array, function=np.std,                                 
-                                   size=(num_neighbor,num_neighbor), 
-                                   mode="mirror")
-    else:
-        median = np.median(values)
-        sigma = values.std()
+    
+    if not no_numba:
+        @njit
+        def _clip_array_numba(array, lower_sigma, upper_sigma, out_good=False, 
+                              neighbor=False, num_neighbor=3, mad=False): 
+            if array.ndim != 2:
+                raise TypeError("Input array is not two dimensional (frame)\n")
+                
+            ny, nx = array.shape
+            bpm = array.copy()    
+            gpm = array.copy()
+            
+            if neighbor and num_neighbor:
+                for y in range(ny):
+                    for x in range(nx):
+                        #0/ Determine the box around each pixel
+                        half_box = int(np.floor(num_neighbor/2.))
+                        hbox_b = min(half_box,y)    # half size of the box at the
+                                                    # bottom of the pixel
+                        hbox_t = min(half_box,ny-y) # half size of the box at the
+                                                    # top of the pixel
+                        hbox_l = min(half_box,x)    # half size of the box to the
+                                                    # left of the pixel
+                        hbox_r = min(half_box,nx-x) # half size of the box to the
+                                                    # right of the pixel
+                        # in case we are close to an edge, we want to extend the box
+                        # in the direction opposite to the edge: 
+                        if hbox_b<hbox_t: 
+                            hbox_t += half_box-hbox_b
+                        elif hbox_t<hbox_b: 
+                            hbox_b += half_box-hbox_t
+                        if hbox_l<hbox_r: 
+                            hbox_r += half_box-hbox_l
+                        elif hbox_r<hbox_l:
+                            hbox_l += half_box-hbox_r
+                            
+                        sub_arr = array[y-hbox_b:y+hbox_t+1,
+                                        x-hbox_l:x+hbox_r+1]
+                        neighbours = sub_arr.flatten()
+                        neigh_list = []
+                        for i in range(neighbours.shape[0]):
+                            neigh_list.append(neighbours[i])
+                        neigh_list.remove(array[y,x])
+                        
+                        neigh_arr = np.array(neigh_list)
+                        median=np.median(neigh_arr)
+                        if mad:
+                            abs_diff = []
+                            for i in range(num_neighbor*num_neighbor-1):
+                                abs_diff.append(np.absolute(median-neigh_arr[i]))
+                            sigma = np.median(np.array(abs_diff))
+                        else:
+                            sigma = np.std(neigh_arr)
+                        bad1 = array[y,x] < (median - lower_sigma * sigma) 
+                        bad2 = array[y,x] > (median + upper_sigma * sigma)
+                        bpm[y,x] = bad1 | bad2
+                        gpm[y,x] = 1.-bpm[y,x]
+            else:
+                median = np.median(array)
+                sigma = np.std(array)
+                for y in range(ny):
+                    for x in range(nx):
+                        bad1 = array[y,x] < (median - lower_sigma * sigma) 
+                        bad2 = array[y,x] > (median + upper_sigma * sigma)
+                        bpm[y,x] = bad1 | bad2   
+                        gpm[y,x] = 1.-bpm[y,x]
+            
+            if out_good:
+                good = np.where(gpm)
+                return good
+            else:
+                bad = np.where(bpm)
+                return bad
+            
+    # TODO: If possible, replace this function using astropy.stats.sigma_clip
+    def _clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
+                    num_neighbor=3, mad=False):
+        """Sigma clipping for detecting outlying values in 2d array. If the
+        parameter 'neighbor' is True the clipping can be performed in a local patch
+        around each pixel, whose size depends on 'neighbor' parameter.
         
-    good1 = values > (median - lower_sigma * sigma) 
-    good2 = values < (median + upper_sigma * sigma)
-    bad1 = values < (median - lower_sigma * sigma)
-    bad2 = values > (median + upper_sigma * sigma)
+        Parameters
+        ----------
+        array : numpy ndarray 
+            Input 2d array, image.
+        lower_sigma : float 
+            Value for sigma, lower boundary.
+        upper_sigma : float 
+            Value for sigma, upper boundary.
+        out_good : bool, optional
+            For choosing different outputs.
+        neighbor : bool optional
+            For clipping over the median of the contiguous pixels.
+        num_neighbor : int, optional
+            The side of the square window around each pixel where the sigma and 
+            median are calculated. 
+        mad : bool, optional
+            If True, the median absolute deviation will be used instead of the 
+            standard deviation.
+            
+        Returns
+        -------
+        good : numpy ndarray
+            If out_good argument is true, returns the indices of not-outlying px.
+        bad : numpy ndarray 
+            If out_good argument is false, returns a vector with the outlier px.
+        
+        """
+        if array.ndim != 2:
+            raise TypeError("Input array is not two dimensional (frame)\n")
     
-    if out_good:
-        # normal px indices in both good1 and good2
-        good = np.where(good1 & good2)
-        return good
+        values = array.copy()
+        if neighbor and num_neighbor:
+            median = generic_filter(array, function=np.median, 
+                                    size=(num_neighbor,num_neighbor), mode="mirror")
+            if mad:
+                sigma = generic_filter(array, function=median_absolute_deviation,                                 
+                                       size=(num_neighbor,num_neighbor), 
+                                       mode="mirror")
+            else:
+                sigma = generic_filter(array, function=np.std,                                 
+                                       size=(num_neighbor,num_neighbor), 
+                                       mode="mirror")
+        else:
+            median = np.median(values)
+            sigma = values.std()
+            
+        good1 = values > (median - lower_sigma * sigma) 
+        good2 = values < (median + upper_sigma * sigma)
+        bad1 = values < (median - lower_sigma * sigma)
+        bad2 = values > (median + upper_sigma * sigma)
+        
+        if out_good:
+            # normal px indices in both good1 and good2
+            good = np.where(good1 & good2)
+            return good
+        else:
+            # deviating px indices in either bad1 or bad2
+            bad = np.where(bad1 | bad2)
+            return bad
+        
+
+
+    if no_numba:
+        return _clip_array(array, lower_sigma, upper_sigma, out_good=out_good, 
+                           neighbor=neighbor, num_neighbor=num_neighbor, 
+                           mad=mad)
     else:
-        # deviating px indices in either bad1 or bad2
-        bad = np.where(bad1 | bad2)
-        return bad
-    
-  
+        return _clip_array_numba(array, lower_sigma, upper_sigma, 
+                                 out_good=out_good, neighbor=neighbor, 
+                                 num_neighbor=num_neighbor, mad=mad)

--- a/vip_hci/stats/distances.py
+++ b/vip_hci/stats/distances.py
@@ -1,17 +1,20 @@
 #! /usr/bin/env python
 
 """
-Distance between images.
+Distance and correlation between images.
 """
 
-__author__ = 'Carlos Alberto Gomez Gonzalez'
-__all__ = ['cube_distance']
+__author__ = 'Carlos Alberto Gomez Gonzalez; V. Christiaens'
+__all__ = ['cube_distance',
+           'spectral_correlation']
 
+from astropy.stats import gaussian_fwhm_to_sigma
 import numpy as np
 import scipy.stats
+from scipy.optimize import curve_fit
 from matplotlib import pyplot as plt
 from skimage.measure import compare_ssim as ssim
-from ..var import get_annulus_segments
+from ..var import get_annulus_segments, get_circle
 from ..conf import vip_figsize
 
 
@@ -152,3 +155,121 @@ def cube_distance(array, frame, mode='full', dist='sad', inradius=None,
 
     return lista
 
+
+
+def spectral_correlation(array, ann_width=2, r_in=1, r_out=None, pl_xy=None,
+                         mask_r=4, fwhm=4, sp_fwhm_guess=3,full_output=False):
+    """ Computes the spectral correlation between (post-processed) IFS frames, 
+    as a function of radius, implemented as Eq. 7 of Greco & Brandt 2017. This 
+    is a crucial step for an unbias fit of a measured IFS spectrum to either 
+    synthetic or template spectra.
+    
+    Parameters
+    ----------
+    array : numpy ndarray
+        Input cube or 3d array, of dimensions n_ch x n_y x n_x; where n_y and 
+        n_x should be odd values (star should be centered on central pixel).
+    ann_width : int, optional
+        Width in pixels of the concentric annuli used to compute the spectral 
+        correlation as a function of radial separation. Greco & Brandt 2017 
+        noted no significant differences for annuli between 1 and 3 pixels 
+        width on GPI data.
+    r_in: int, optional
+        Innermost radius where the spectral correlation starts to be computed.
+    r_out: int, optional
+        Outermost radius where the spectral correlation is computed.If left as 
+        None, it will automatically be computed up to the edge of the frame. 
+    pl_xy: tuple of tuples of 2 floats, optional
+        x,y coordiantes of all companions present in the images.
+        If provided, a circle centered on the location of each
+        companion will be masked out for the spectral correlation computation.
+    mask_r: float, optional
+        if pl_xy is provided, this should also be provided. Size of the 
+        aperture around each companion (in terms of fwhm) that is discarded to 
+        not bias the spectral correlation computation.
+    fwhm: float, optional
+        if pl_xy is provided, this should also be provided. By default we  
+        consider a 2FWHM aperture mask around each companion to not bias the 
+        spectral correlation computation.
+    sp_fwhm_guess: float, optional
+        Initial guess on the spectral FWHM of all channels.
+    full_output: bool, opt
+        Whether to also output the fitted spectral FWHM for each channel.
+    Note: radii that are skipped will be filled with zeros in the output cube.
+
+    Returns
+    -------
+    sp_corr : numpy ndarray
+        3d array of spectral correlation, as a function of radius with 
+        dimensions: n_r x n_ch x n_ch, where n_r = min((n_y-1)/2,(n_x-1)/2)
+        Starts at r = 1 (not r=0) px.
+    sp_fwhm: numpy ndarray
+        (if full_output is True) 2d array containing the spectral fwhm at each 
+        radius, for each spectral channel. Dims: n_r x n_ch
+        
+    """
+
+    if not isinstance(ann_width,int) or not isinstance(r_in,int):
+        raise TypeError("Inputs should be integers")
+
+    if array.ndim != 3:
+        raise TypeError("Input array should be 3D.")
+        
+    n_ch, n_y, n_x = array.shape
+    n_r = min((n_y-1)/2.,(n_x-1)/2.)
+    if n_r%1:
+        raise TypeError("Input array y and x dimensions should be odd")
+    
+    if r_out is None:
+        r_out = n_r
+
+    test_rads = np.arange(r_in-1,r_out-1)
+    n_rad = int(np.floor(test_rads.shape[0]/ann_width))
+    
+    #n_rad = int(np.ceil(n_r/ann_width)) # effective number of annuli probed
+    
+    sp_corr = np.zeros([int(n_r),n_ch,n_ch])
+    if full_output:
+        sp_fwhm = np.zeros([int(n_r),n_ch])
+        def gauss_1fp(x, *p):
+            sigma = p[0]*gaussian_fwhm_to_sigma
+            return np.exp(-x**2/(2.*sigma**2))
+    mask_final = np.zeros_like(array[0])
+
+    if pl_xy is not None:
+        mask = np.ones_like(array[0])
+        for i in range(len(pl_xy)):
+            if not isinstance(pl_xy[i], tuple):
+                raise TypeError("Format of companions coordinates incorrect")
+            mask_i = get_circle(mask, radius=mask_r*fwhm, cy=pl_xy[i][1], cx=pl_xy[i][0], mode="mask")
+            mask_final[np.where(mask_i)] = 1
+
+    for ann in range(n_rad):
+        inner_radius = r_in+ (ann * ann_width)
+        indices = get_annulus_segments(array[0], inner_radius, ann_width)
+        yy = indices[0][0]
+        xx = indices[0][1]
+        yy_final = [yy[i] for i in range(len(indices[0][0])) if not mask_final[yy[i],xx[i]]]
+        xx_final = [xx[i] for i in range(len(indices[0][0])) if not mask_final[yy[i],xx[i]]]
+        matrix = array[:, yy_final, xx_final]  # shape (z, npx_annsegm)
+        for zi in range(n_ch):
+            for zj in range(n_ch):
+                num = np.nanmean(matrix[zi]*matrix[zj])
+                denom = np.sqrt(np.nanmean(matrix[zi]*matrix[zi])* \
+                                np.nanmean(matrix[zj]*matrix[zj]))
+                sp_corr[r_in+ann*ann_width:r_in+(ann+1)*ann_width,zi,zj] = num/denom
+            if full_output:
+                p0 = (sp_fwhm_guess,)
+                x = np.arange(n_ch)-zi
+                y = sp_corr[r_in+ann*ann_width,zi]# norm y
+                y = y-np.amin(y)
+                y = y/np.amax(y)
+                coeff, var_matrix = curve_fit(gauss_1fp, x, y, p0=p0)
+                sp_fwhm[r_in+ann*ann_width:r_in+(ann+1)*ann_width,zi] = coeff[0]
+
+                
+    if full_output:
+        return sp_corr, sp_fwhm
+    else:
+        return sp_corr
+    


### PR DESCRIPTION
- no new dependency introduced.
- one new module (specfit) for the spectral characterisation of companions in a Bayesian framework.
- new routines in existing modules:
     - speckle_noise_uncertainty (negfc), as estimated in Wertz et al. (2017);
     - bkg_star_proba (stats) which estimates the probability of a point source to be a background star provided a given stellar number density and radial separation, as in e.g. Ubeira-Gabellini et al. (2020);
     - spectral_correlation (stats) which computes the spectral correlation between spectral images of an IFS cube, as in Greco & Brandt (2017);
     - get_annular_wedge (var) which returns indices/values in an annulus with a given wedge (2 angles) constraint.
- new optional arguments in existing routines; no change in the order of mandatory arguments, but a few changes in the order of existing optional arguments for coherence throughout all VIP routines: e.g. 'plot', 'verbose' and 'debug' options are always kept as last optional arguments.
- a number of minor bug fixes in all modules;
- update/formatting of a number of docstrings;
- updated README to reflect new state of VIP. For attribution, in addition to Gomez Gonzalez et al. (2017), I also added suggested citations when specific modules are used: e.g. medsub -> Marois et al. (2006); andromeda -> Cantalloube et al. (2015), etc.
