### PR TITLE
Bug fix for skimage version => 0.18 and improvement in fake disk models 

### DIFF
--- a/vip_hci/metrics/dust_distribution.py
+++ b/vip_hci/metrics/dust_distribution.py
@@ -3,6 +3,7 @@
 Created on Wed May  6 17:07:00 2015
 """
 import numpy as np
+from scipy.optimize import newton
 
 _author__ = 'Julien Milli'
 
@@ -12,7 +13,7 @@ class Dust_distribution(object):
     """
     def __init__(self,density_dico={'name':'2PowerLaws', 'ain':5, 'aout':-5,
                                     'a':60, 'e':0, 'ksi0':1., 'gamma':2.,
-                                    'beta':1.,'amin':0.}):
+                                    'beta':1.,'amin':0.,'dens_at_r0':1.}):
         """ 
         Constructor for the Dust_distribution class.
         
@@ -75,9 +76,10 @@ class Dust_distribution(object):
 class DustEllipticalDistribution2PowerLaws:
     """
     """
-    def __init__(self, accuracy=5.e-3, density_dico={'ain':5,'aout':-5,
-                                                     'a':60,'e':0,'ksi0':1.,
-                                                     'gamma':2.,'beta':1.,'amin':0.}):
+    def __init__(self, accuracy=5.e-3, density_dico={'ain':5,'aout':-5,\
+                                                     'a':60,'e':0,'ksi0':1.,\
+                                                     'gamma':2.,'beta':1.,\
+                                                     'amin':0.,'dens_at_r0':1.}):
         """ 
         Constructor for the Dust_distribution class.
         
@@ -123,9 +125,13 @@ class DustEllipticalDistribution2PowerLaws:
         if 'amin' not in density_dico.keys():
             amin = 0.
         else:
-            amin = density_dico['amin']            
+            amin = density_dico['amin']   
+        if 'dens_at_r0' not in density_dico.keys():
+            dens_at_r0=1.
+        else:
+            dens_at_r0=density_dico['dens_at_r0']
         self.set_vertical_density(ksi0=ksi0, gamma=gamma, beta=beta)
-        self.set_radial_density(ain=ain, aout=aout, a=a, e=e,amin=amin)
+        self.set_radial_density(ain=ain, aout=aout, a=a, e=e,amin=amin,dens_at_r0=dens_at_r0)
 
     def set_vertical_density(self, ksi0=1., gamma=2., beta=1.):
         """ 
@@ -157,7 +163,7 @@ class DustEllipticalDistribution2PowerLaws:
         self.beta = float(beta)
         self.zmax = ksi0*(-np.log(self.accuracy))**(1./gamma)
 
-    def set_radial_density(self, ain=5., aout=-5., a=60., e=0.,amin=0.):
+    def set_radial_density(self, ain=5., aout=-5., a=60., e=0.,amin=0.,dens_at_r0=1.):
         """ 
         Sets the parameters of the radial density function
 
@@ -199,6 +205,10 @@ class DustEllipticalDistribution2PowerLaws:
             raise ValueError('Warning the minimum radius a is negative')
             print('amin was changed from {0:6.2f} to 0.'.format(amin))
             amin = 0. 
+        if dens_at_r0 <0:
+            raise ValueError('Warning the reference dust density at r0 is negative')
+            print('It was changed from {0:6.2f} to 1.'.format(dens_at_r0))
+            dens_at_r0 = 1.  
         self.ain = float(ain)
         self.aout = float(aout)
         self.a = float(a)
@@ -206,6 +216,7 @@ class DustEllipticalDistribution2PowerLaws:
         self.p = self.a*(1-self.e**2)
         self.amin = float(amin)
         self.pmin = self.amin*(1-self.e**2) ## we assume the inner hole is also elliptic (convention)
+        self.dens_at_r0 = float(dens_at_r0)
         try:
             # maximum distance of integration, AU
             self.rmax = self.a*self.accuracy**(1/self.aout)
@@ -236,23 +247,41 @@ class DustEllipticalDistribution2PowerLaws:
         Input:
             - pxInAu (optional): the pixel size in au
         """
+        def rad_density(r):
+            return np.sqrt(2/(np.power(r/self.a,-2*self.ain) +
+                       np.power(r/self.a,-2*self.aout)))
+        half_max_density = lambda r:rad_density(r)/rad_density(self.apeak)-1./2.            
+        a_plus_hwhm = newton(half_max_density,self.apeak*1.02)
+        a_minus_hwhm = newton(half_max_density,self.apeak*0.98)            
         if pxInAu is not None:
             msg = 'Reference semi-major axis: {0:.1f}au or {1:.1f}px'
             print(msg.format(self.a,self.a/pxInAu))
             msg2 = 'Semi-major axis at maximum dust density: {0:.1f}au or ' \
                    '{1:.1f}px (same as ref sma if ain=-aout)'
             print(msg2.format(self.apeak,self.apeak/pxInAu))
-            msg3 = 'Ellipse p parameter: {0:.1f}au or {1:.1f}px'
-            print(msg3.format(self.p,self.p/pxInAu))
+            msg3 = 'Semi-major axis at half max dust density: {0:.1f}au or ' \
+                    '{1:.1f}px for the inner edge ' \
+                    '/ {2:.1f}au or {3:.1f}px for the outer edge, with a FWHM of ' \
+                    '{4:.1f}au or {5:.1f}px'
+            print(msg3.format(a_minus_hwhm,a_minus_hwhm/pxInAu,a_plus_hwhm,\
+                              a_plus_hwhm/pxInAu,a_plus_hwhm-a_minus_hwhm,\
+                                  (a_plus_hwhm-a_minus_hwhm)/pxInAu))
+            msg4 = 'Ellipse p parameter: {0:.1f}au or {1:.1f}px'
+            print(msg4.format(self.p,self.p/pxInAu))
         else:
             print('Reference semi-major axis: {0:.1f}au'.format(self.a))
             msg = 'Semi-major axis at maximum dust density: {0:.1f}au (same ' \
                   'as ref sma if ain=-aout)'
             print(msg.format(self.apeak))
+            msg3 = 'Semi-major axis at half max dust density: {0:.1f}au ' \
+                    '/ {1:.1f}au for the inner/outer edge, or a FWHM of ' \
+                    '{2:.1f}au'
+            print(msg3.format(a_minus_hwhm,a_plus_hwhm,a_plus_hwhm-a_minus_hwhm))
             print('Ellipse p parameter: {0:.1f}au'.format(self.p))
         print('Ellipticity: {0:.3f}'.format(self.e))
         print('Inner slope: {0:.2f}'.format(self.ain))
         print('Outer slope: {0:.2f}'.format(self.aout))
+        print('Density at the reference semi-major axis: {0:4.3e} (arbitrary unit'.format(self.dens_at_r0))
         if self.amin>0:
             print('Minimum radius (sma): {0:.2f}au'.format(self.amin))        
         if pxInAu is not None:
@@ -283,7 +312,7 @@ class DustEllipticalDistribution2PowerLaws:
         radial_ratio = r/(self.p/(1-self.e*costheta))
         den = (np.power(radial_ratio, -2*self.ain) +
                np.power(radial_ratio,-2*self.aout))
-        radial_density_term = np.sqrt(2./den)
+        radial_density_term = np.sqrt(2./den)*self.dens_at_r0
         if self.pmin>0:
              radial_density_term[r/(self.pmin/(1-self.e*costheta)) <= 1]=0
         den2 = (self.ksi0*np.power(radial_ratio,self.beta))

--- a/vip_hci/metrics/scattered_light_disk.py
+++ b/vip_hci/metrics/scattered_light_disk.py
@@ -22,7 +22,8 @@ class ScatteredLightDisk(object):
     def __init__(self, nx=200, ny=200, distance=50., itilt=60., omega=0.,
                  pxInArcsec=0.01225, pa=0., flux_max=None,
                  density_dico={'name': '2PowerLaws', 'ain':5, 'aout':-5,
-                               'a':40, 'e':0, 'ksi0':1., 'gamma':2., 'beta':1.},
+                               'a':40, 'e':0, 'ksi0':1., 'gamma':2., 'beta':1.,\
+                                'dens_at_r0':1.},
                  spf_dico={'name':'HG', 'g':0., 'polar':False}, xdo=0., ydo=0.):
         """
         Constructor of the Scattered_light_disk object, taking in input the 

--- a/vip_hci/pca/pca_fullfr.py
+++ b/vip_hci/pca/pca_fullfr.py
@@ -744,19 +744,19 @@ def _adi_rdi_pca(cube, cube_ref, angle_list, ncomp, scaling, mask_center_px,
     """ Handles the ADI+RDI post-processing.
     """
     n, y, x = cube.shape
-
+    n_ref, y_ref, x_ref = cube_ref.shape
     angle_list = check_pa_vector(angle_list)
     if not isinstance(ncomp, int):
         raise TypeError("`ncomp` must be an int in the ADI+RDI case")
-    if ncomp > n:
-        ncomp = min(ncomp, n)
+    if ncomp > n_ref:
+        ncomp = min(ncomp, n_ref)
         msg = 'Number of PCs too high (max PCs={}), using {} PCs instead.'
         print(msg.format(n, ncomp))
 
     if not cube_ref.ndim == 3:
         msg = 'Input reference array is not a cube or 3d array'
         raise ValueError(msg)
-    if not cube_ref.shape[1] == y:
+    if not y_ref == y and x_ref == x:
         msg = 'Reference and target frames have different shape'
         raise TypeError(msg)
 
@@ -867,7 +867,7 @@ def _project_subtract(cube, cube_ref, ncomp, scaling, mask_center_px,
 
     elif isinstance(ncomp, float):
         if not 1 > ncomp > 0:
-            raise ValueError("when `ncomp` if float, it mus lie in the "
+            raise ValueError("when `ncomp` if float, it must lie in the "
                              "interval (0,1]")
 
         svdecomp = SVDecomposer(cube, mode='fullfr', svd_mode=svd_mode,

--- a/vip_hci/stats/distances.py
+++ b/vip_hci/stats/distances.py
@@ -10,7 +10,12 @@ __all__ = ['cube_distance']
 import numpy as np
 import scipy.stats
 from matplotlib import pyplot as plt
-from skimage.measure import compare_ssim as ssim
+try:
+    # before skimage version '0.18' the function is skimage.measure.compare_ssim
+    from skimage.measure import compare_ssim as ssim
+except:
+    # for skimage version '0.18' or above the function is skimage.metrics.structural_similarity
+    from skimage.metrics import structural_similarity as ssim    
 from ..var import get_annulus_segments
 from ..conf import vip_figsize
 


### PR DESCRIPTION
This pull request suggest 2 changes:
- a change to fix a problem with version of skimage >= 0.18 where skimage.measure.compare_ssim has disappeared and was replaced by skimage.metrics.structural_similarity
- a minor improvement for dust modelling 