### PR TITLE
Bug fix PCA RDI 

### DIFF
--- a/vip_hci/pca/pca_fullfr.py
+++ b/vip_hci/pca/pca_fullfr.py
@@ -780,9 +780,9 @@ def _adi_rdi_pca(cube, cube_ref, angle_list, ncomp, scaling, mask_center_px,
     if not isinstance(ncomp, int):
         raise TypeError("`ncomp` must be an int in the ADI+RDI case")
     if ncomp > n_ref:
-        msg = 'Number of PCs too high (max PCs={}), using {} PCs, the number frames of cube reference, instead.'
+        msg = 'Number of PCs too high (max PCs={}), using {} PCs, the number frames of the reference cube, instead.'
         print(msg.format(ncomp,n_ref))
-        ncomp = min(ncomp, n_ref)
+        ncomp = n_ref
 
     if not cube_ref.ndim == 3:
         msg = 'Input reference array is not a cube or 3d array'

--- a/vip_hci/pca/pca_fullfr.py
+++ b/vip_hci/pca/pca_fullfr.py
@@ -774,14 +774,15 @@ def _adi_rdi_pca(cube, cube_ref, angle_list, ncomp, scaling, mask_center_px,
     """ Handles the ADI+RDI post-processing.
     """
     n, y, x = cube.shape
-
+    n_ref, y_ref, x_ref = cube_ref.shape 
     angle_list = check_pa_vector(angle_list)
+
     if not isinstance(ncomp, int):
         raise TypeError("`ncomp` must be an int in the ADI+RDI case")
-    if ncomp > n:
-        ncomp = min(ncomp, n)
-        msg = 'Number of PCs too high (max PCs={}), using {} PCs instead.'
-        print(msg.format(n, ncomp))
+    if ncomp > n_ref:
+        msg = 'Number of PCs too high (max PCs={}), using {} PCs, the number frames of cube reference, instead.'
+        print(msg.format(ncomp,n_ref))
+        ncomp = min(ncomp, n_ref)
 
     if not cube_ref.ndim == 3:
         msg = 'Input reference array is not a cube or 3d array'


### PR DESCRIPTION
The maximum number of PCA components in PCA RDI is currently set to the number of frames of the science cube. This should be set to the number of frames of the reference cube.