### PR TITLE
Fix for opencv implicit dependencies within VIP

### DIFF
--- a/docs/source/vip_hci.specfit.rst
+++ b/docs/source/vip_hci.specfit.rst
@@ -1,5 +1,5 @@
 vip\_hci.specfit package
-====================
+========================
 
 .. automodule:: vip_hci.specfit
     :members:
@@ -34,7 +34,7 @@ vip\_hci.specfit.model\_resampling module
     :show-inheritance:
 
 vip\_hci.specfit.template\_lib module
-------------------------------------
+-------------------------------------
 
 .. automodule:: vip_hci.specfit.template_lib
     :members:
@@ -42,7 +42,7 @@ vip\_hci.specfit.template\_lib module
     :show-inheritance:
 
 vip\_hci.specfit.utils\_spec module
-------------------------------
+-----------------------------------
 
 .. automodule:: vip_hci.specfit.utils_spec
     :members:

--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -30,7 +30,7 @@ def contrast_curve(cube, angle_list, psf_template, fwhm, pxscale, starphot,
                    algo, sigma=5, nbranch=1, theta=0, inner_rad=1,
                    wedge=(0,360), fc_snr=100, student=True, transmission=None,
                    smooth=True, interp_order=2, plot=True, dpi=100,
-                   imlib='opencv', interpolation='Lanczos4', debug=False, 
+                   imlib='opencv', interpolation='lanczos4', debug=False, 
                    verbose=True, full_output=False, save_plot=None, 
                    object_name=None, frame_size=None, fix_y_lim=(), 
                    figsize=(8, 4), **algo_dict):

--- a/vip_hci/metrics/snr_source.py
+++ b/vip_hci/metrics/snr_source.py
@@ -108,7 +108,7 @@ def snrmap(array, fwhm, approximated=False, plot=False, known_sources=None,
             coords = [(int(x), int(y)) for (x, y) in zip(xx, yy)]
             res = pool_map(nproc, _snr_approx, array, iterable(coords), fwhm,
                            cy, cx)
-            res = np.array(res)
+            res = np.array(res, dtype=object)
             yy = res[:, 0]
             xx = res[:, 1]
             snr_value = res[:, 2]
@@ -118,7 +118,7 @@ def snrmap(array, fwhm, approximated=False, plot=False, known_sources=None,
         else:
             res = pool_map(nproc, snr, array, iterable(coords), fwhm, True,
                            array2, use2alone, exclude_negative_lobes)
-            res = np.array(res)
+            res = np.array(res, dtype=object)
             yy = res[:, 0]
             xx = res[:, 1]
             snr_value = res[:, -1]
@@ -172,7 +172,7 @@ def snrmap(array, fwhm, approximated=False, plot=False, known_sources=None,
             res = pool_map(nproc, snr, arr_masked_sources, iterable(coor_ann),
                            fwhm, True, array2, use2alone, 
                            exclude_negative_lobes)
-            res = np.array(res)
+            res = np.array(res, dtype=object)
             yy_res = res[:, 0]
             xx_res = res[:, 1]
             snr_value = res[:, 4]
@@ -183,7 +183,7 @@ def snrmap(array, fwhm, approximated=False, plot=False, known_sources=None,
         coor_rest = [(x, y) for (x, y) in zip(xx, yy) if (x, y) not in coor_ann]
         res = pool_map(nproc, snr, array, iterable(coor_rest), fwhm, True,
                        array2, use2alone, exclude_negative_lobes)
-        res = np.array(res)
+        res = np.array(res, dtype=object)
         yy_res = res[:, 0]
         xx_res = res[:, 1]
         snr_value = res[:, 4]

--- a/vip_hci/metrics/snr_source.py
+++ b/vip_hci/metrics/snr_source.py
@@ -230,8 +230,10 @@ def snr(array, source_xy, fwhm, full_output=False, array2=None, use2alone=False,
 
         * possibility to provide a second array (e.g. obtained with opposite
         derotation angles) to have more apertures for noise estimation
+        
         * possibility to exclude negative ADI lobes directly adjacent to the
         tested xy location, to not bias the noise estimate
+        
         * possibility to use only the second array for the noise estimation
         (useful for images containing a lot of disk/extended signals).
         

--- a/vip_hci/metrics/stim.py
+++ b/vip_hci/metrics/stim.py
@@ -17,13 +17,12 @@ from ..var import get_circle
 
 
 def compute_stim_map(cube_der):
-    """
-    Computes the STIM detection map.
+    """ Computes the STIM detection map.
 
     Parameters
     ----------
     cube_der : 3d numpy ndarray
-        Input de-rotated cube, e.g. output 'residuals_cube_' from
+        Input de-rotated cube, e.g. ``residuals_cube_`` output from
         ``vip_hci.pca.pca``.
 
     Returns
@@ -39,10 +38,9 @@ def compute_stim_map(cube_der):
     return get_circle(detection_map, int(np.round(n/2.)))
 
 
-def compute_inverse_stim_map(cube, angle_list, imlib='opencv', 
+def compute_inverse_stim_map(cube, angle_list, imlib='opencv',
                              interpolation='lanczos4'):
-    """
-    Computes the STIM detection map.
+    """ Computes the inverse STIM detection map.
 
     Parameters
     ----------

--- a/vip_hci/metrics/stim.py
+++ b/vip_hci/metrics/stim.py
@@ -39,7 +39,8 @@ def compute_stim_map(cube_der):
     return get_circle(detection_map, int(np.round(n/2.)))
 
 
-def compute_inverse_stim_map(cube, angle_list):
+def compute_inverse_stim_map(cube, angle_list, imlib='opencv', 
+                             interpolation='lanczos4'):
     """
     Computes the STIM detection map.
 
@@ -49,14 +50,19 @@ def compute_inverse_stim_map(cube, angle_list):
         Non de-rotated residuals from reduction algorithm, eg. output residuals
         from ``vip_hci.pca.pca``.
     angle_list : numpy ndarray, 1d
-        Corresponding parallactic angle for each frame.    
-
+        Corresponding parallactic angle for each frame.  
+    imlib: str, opt
+        See description of vip_hci.preproc.frame_derotate()
+    interpolation: str, opt
+        See description of vip_hci.preproc.frame_derotate()
+        
     Returns
     -------
     inverse_stim_map : 2d ndarray
         Inverse STIM detection map.
     """
     t, n, _ = cube.shape
-    cube_inv_der = cube_derotate(cube, -angle_list)
+    cube_inv_der = cube_derotate(cube, -angle_list, imlib=imlib, 
+                                 interpolation=interpolation)
     inverse_stim_map = compute_stim_map(cube_inv_der)
     return inverse_stim_map

--- a/vip_hci/negfc/simplex_fmerit.py
+++ b/vip_hci/negfc/simplex_fmerit.py
@@ -10,7 +10,7 @@ __all__ = []
 import numpy as np
 from hciplot import plot_frames
 from skimage.draw import disk
-from ..metrics import cube_inject_companions, snr
+from ..metrics import cube_inject_companions
 from ..var import (frame_center, get_annular_wedge, cube_filter_highpass, dist,
                    get_circle)
 from ..pca import pca_annulus, pca_annular, pca

--- a/vip_hci/negfc/speckle_noise.py
+++ b/vip_hci/negfc/speckle_noise.py
@@ -205,7 +205,7 @@ def speckle_noise_uncertainty(cube, p_true, angle_range, derot_angles, algo,
                    cube_pf, psfn, derot_angles, r_true, f_true, plsc, fwhm,
                    aperture_radius, cube_ref, fmerit, algo, algo_options, 
                    transmission, mu_sigma, weights, force_rPA, simplex_options, 
-                   verbose=verbose)
+                   imlib, interpolation, verbose=verbose)
     residuals = np.array(res)
     
     if indep_ap: # do opposite angles
@@ -213,7 +213,8 @@ def speckle_noise_uncertainty(cube, p_true, angle_range, derot_angles, algo,
                        iterable(angle_range), cube_pf, psfn, -derot_angles, 
                        r_true, f_true, plsc, fwhm, aperture_radius, cube_ref, 
                        fmerit, algo, algo_options, transmission, mu_sigma, 
-                       weights, force_rPA, simplex_options, verbose=verbose)
+                       weights, force_rPA, simplex_options, imlib, 
+                       interpolation, verbose=verbose)
         residuals2 = np.array(res)
         residuals = np.concatenate((residuals,residuals2))
         
@@ -273,8 +274,8 @@ def speckle_noise_uncertainty(cube, p_true, angle_range, derot_angles, algo,
 def _estimate_speckle_one_angle(angle, cube_pf, psfn, angs, r_true, f_true, 
                                 plsc, fwhm, aperture_radius, cube_ref, fmerit, 
                                 algo, algo_options, transmission, mu_sigma, 
-                                weights, force_rPA, simplex_options, 
-                                verbose=True):
+                                weights, force_rPA, simplex_options, imlib,
+                                interpolation, verbose=True):
                          
     if verbose:
         print('Process is running for angle: {:.2f}'.format(angle))
@@ -282,7 +283,8 @@ def _estimate_speckle_one_angle(angle, cube_pf, psfn, angs, r_true, f_true,
     cube_fc = cube_inject_companions(cube_pf, psfn, angs, flevel=f_true, 
                                      plsc=plsc, rad_dists=[r_true], 
                                      n_branches=1, theta=angle, 
-                                     transmission=transmission, verbose=False)
+                                     transmission=transmission, imlib=imlib,
+                                     interpolation=interpolation, verbose=False)
     
     ncomp = algo_options.get('ncomp', None)
     annulus_width = algo_options.get('annulus_width', int(fwhm))
@@ -291,7 +293,8 @@ def _estimate_speckle_one_angle(angle, cube_pf, psfn, angs, r_true, f_true,
                                      plsc, ncomp, fwhm, annulus_width, 
                                      aperture_radius, cube_ref=cube_ref,
                                      fmerit=fmerit, algo=algo, 
-                                     algo_options=algo_options,
+                                     algo_options=algo_options, imlib=imlib,
+                                     interpolation=interpolation, 
                                      transmission=transmission, 
                                      mu_sigma=mu_sigma, weights=weights, 
                                      force_rPA=force_rPA, 

--- a/vip_hci/pca/utils_pca.py
+++ b/vip_hci/pca/utils_pca.py
@@ -240,8 +240,8 @@ def pca_grid(cube, angle_list, fwhm=None, range_pcs=None, source_xy=None,
             res = [snr(frame, (x_, y_), fwhm, plot=False, verbose=False,
                        full_output=True)
                    for y_, x_ in zip(yy, xx)]
-            snr_pixels = np.array(res)[:, -1]
-            fluxes = np.array(res)[:, 2]
+            snr_pixels = np.array(res, dtype=object)[:, -1]
+            fluxes = np.array(res, dtype=object)[:, 2]
             argm = np.argmax(snr_pixels)
             # integrated fluxes for the max snr
             return np.max(snr_pixels), fluxes[argm]
@@ -250,7 +250,7 @@ def pca_grid(cube, angle_list, fwhm=None, range_pcs=None, source_xy=None,
             res = snr(frame, (x, y), fwhm, plot=False, verbose=False,
                       full_output=True)
             snrpx = res[-1]
-            fluxpx = np.array(res)[2]
+            fluxpx = np.array(res, dtype=object)[2]
             # integrated fluxes for the given px
             return snrpx, fluxpx
 
@@ -259,8 +259,8 @@ def pca_grid(cube, angle_list, fwhm=None, range_pcs=None, source_xy=None,
             res = [snr(frame, (x_, y_), fwhm, plot=False, verbose=False,
                        full_output=True) for y_, x_
                    in zip(yy, xx)]
-            snr_pixels = np.array(res)[:, -1]
-            fluxes = np.array(res)[:, 2]
+            snr_pixels = np.array(res, dtype=object)[:, -1]
+            fluxes = np.array(res, dtype=object)[:, 2]
             # mean of the integrated fluxes (shifting the aperture)
             return np.mean(snr_pixels), np.mean(fluxes)
 
@@ -707,7 +707,8 @@ def _compute_stim_map(cube_der):
     return get_circle(detection_map, int(np.round(n/2.)))
 
 
-def _compute_inverse_stim_map(cube, angle_list):
+def _compute_inverse_stim_map(cube, angle_list, imlib='opencv',
+                              interpolation='lanczos4'):
     """
     Computes the inverse STIM detection map, i.e. obtained with opposite 
     derotation angles.
@@ -721,14 +722,19 @@ def _compute_inverse_stim_map(cube, angle_list):
         Non de-rotated residuals from reduction algorithm, eg. output residuals
         from ``vip_hci.pca.pca``.
     angle_list : numpy ndarray, 1d
-        Corresponding parallactic angle for each frame.    
-
+        Corresponding parallactic angle for each frame.   
+    imlib: str, opt
+        See description of vip_hci.preproc.frame_rotate
+    interpolation: str, opt
+        See description of vip_hci.preproc.frame_rotate
+        
     Returns
     -------
     inverse_stim_map : 2d ndarray
         Inverse STIM detection map.
     """
     t, n, _ = cube.shape
-    cube_inv_der = cube_derotate(cube, -angle_list)
+    cube_inv_der = cube_derotate(cube, -angle_list, imlib=imlib,
+                                 interpolation=interpolation)
     inverse_stim_map = _compute_stim_map(cube_inv_der)
     return inverse_stim_map

--- a/vip_hci/preproc/recentering.py
+++ b/vip_hci/preproc/recentering.py
@@ -1526,14 +1526,12 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
             mask_tmp = frame_crop(mask, subframesize)
         else:
             mask_tmp = mask
-        _, y_shift, x_shift = cube_recenter_dft_upsampling(cube_stret, 
-                                                           (ceny, cenx), 
-                                                           fwhm=fwhm, 
-                                                           subi_size=None,
-                                                           full_output=True, 
-                                                           verbose=False,
-                                                           plot=False,
-                                                           mask=mask_tmp)
+        res = cube_recenter_dft_upsampling(cube_stret, (ceny, cenx), fwhm=fwhm, 
+                                           subi_size=None, full_output=True, 
+                                           verbose=False, plot=False,
+                                           mask=mask_tmp, imlib=imlib,
+                                           interpolation=interpolation)
+        _, y_shift, x_shift = res
         sqsum_shifts = np.sum(np.sqrt(y_shift ** 2 + x_shift ** 2))
         print('Square sum of shift vecs: ' + str(sqsum_shifts))
 

--- a/vip_hci/specfit/__init__.py
+++ b/vip_hci/specfit/__init__.py
@@ -1,10 +1,11 @@
 """
-Subpackage ``specfit`` has helping functions such as:
+Subpackage ``specfit`` has helping functions for the analysis of (low-res) 
+spectra, including:
 
-- spectral fitting
-- mcmc sampling of model parameter space
-- best fit search within a template libraty
-- utility functions for the spectral fit
+- fitting of input spectra to models and templates;
+- mcmc sampling of model parameter space;
+- best fit search within a template library;
+- utility functions for the spectral fit.
 """
 
 from .chi import *

--- a/vip_hci/specfit/mcmc_sampling_spec.py
+++ b/vip_hci/specfit/mcmc_sampling_spec.py
@@ -1,9 +1,9 @@
 #! /usr/bin/env python
 
 """
-Module with the MCMC (``emcee``) sampling for model spectra parameter estimation.
+Module with the MCMC (``emcee``) sampling for model spectra parameter 
+estimation.
 """
-
 
 __author__ = 'V. Christiaens, O. Wertz, Carlos Alberto Gomez Gonzalez'
 __all__ = ['mcmc_spec_sampling',

--- a/vip_hci/vip_ds9.py
+++ b/vip_hci/vip_ds9.py
@@ -142,7 +142,7 @@ class Ds9Window(object):
         for i, array in enumerate(arrays):
             if i == 0:
                 self.create_frame()
-                if isinstance(array, Dataset) or array.ndim==3:
+                if isinstance(array, Dataset):
                     self.window.set_np2arr(array.cube)
                 if isinstance(array, Frame):
                     self.window.set_np2arr(array.image)
@@ -150,7 +150,7 @@ class Ds9Window(object):
                     self.window.set_np2arr(array)
             else:
                 self.window.set('frame new')
-                if isinstance(array, Dataset) or array.ndim==3:
+                if isinstance(array, Dataset):
                     self.window.set_np2arr(array.cube)
                 if isinstance(array, Frame):
                     self.window.set_np2arr(array.image)


### PR DESCRIPTION
- Fix for ``opencv`` implicit dependencies in throughput, contrast curve, speckle noise estimation, cube recentering via speckles, STIM and inverse STIM map functions.
- Added dtype=object for ragged arrays to avoid deprecation warnings (in ``snr`` and ``utils_pca`` functions).
- Fix for 3D numpy arrays opened through vip_ds9.