### PR TITLE
New options, deprecation warning fixes and bad pixel correction algorithm

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,7 +78,7 @@ Tutorials, in the form of Jupyter notebooks, showcasing ``VIP``'s usage and
 other resources such as test datasets are available in the 
 ``VIP-extras`` `repository <https://github.com/vortex-exoplanet/VIP_extras>`_. 
 Alternatively, you can execute this repository on 
-`Binder <https://mybinder.org/v2/gh/vortex-exoplanet/VIP_extras/master>`_(in the tutorials directory). The first notebook for ADI processing can be visualized online with
+`Binder <https://mybinder.org/v2/gh/vortex-exoplanet/VIP_extras/master>`_(in the tutorials directory). The first (quick-start) notebook can be visualized online with
 `nbviewer <http://nbviewer.jupyter.org/github/vortex-exoplanet/VIP_extras/blob/master/tutorials/01_quickstart.ipynb>`_. 
 If you are new to the Jupyter notebook application check out the `beginner's guide
 <https://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/what_is_jupyter.html>`_.

--- a/README.rst
+++ b/README.rst
@@ -263,3 +263,6 @@ In addition, if you use one of the following modules, please also cite:
 - medsub: `Marois et al. (2006) <https://ui.adsabs.harvard.edu/abs/2006ApJ...641..556M/abstract>`_ for ADI and `Sparks and Ford (2002) <https://ui.adsabs.harvard.edu/abs/2002ApJ...578..543S/abstract>`_ for SDI;
 - negfc: `Wertz et al. (2017) <https://ui.adsabs.harvard.edu/abs/2017A%26A...598A..83W/abstract>`_;
 - pca: `Amara and Quanz (2012) <https://ui.adsabs.harvard.edu/abs/2012MNRAS.427..948A/abstract>`_ and `Soummer et al. (2012) <https://ui.adsabs.harvard.edu/abs/2012ApJ...755L..28S/abstract>`_;
+
+
+Note: The `specfit <https://github.com/VChristiaens/specfit>`_ module, previously part of VIP, has now been moved to a separate GitHub repository.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,7 @@
 -r requirements.txt
 sphinx
+nbsphinx
+pandoc
 pytest
 pytest-cov
 codecov

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ emcee==2.2.1
 nestle
 corner
 pandas
-matplotlib
+matplotlib<=3.4.3
 psutil
 pyprind
 munch

--- a/vip_hci/config/utils_conf.py
+++ b/vip_hci/config/utils_conf.py
@@ -19,6 +19,8 @@ import numpy as np
 import itertools as itt
 from inspect import getargspec
 from functools import wraps
+import multiprocessing
+multiprocessing.set_start_method('fork')
 from multiprocessing import Pool
 
 from vip_hci import __version__

--- a/vip_hci/invprob/andromeda.py
+++ b/vip_hci/invprob/andromeda.py
@@ -361,10 +361,10 @@ def andromeda(cube, oversampling_fact, angles, psf, filtering_fraction=.25,
     dmax = owa  # size of the greatest annuli, in lambda/D
     if fast:
         first_distarray = dmin + np.arange(
-            np.int(np.round(np.abs(dmean-dmin-1)) / annuli_width + 1),
+            int(np.round(np.abs(dmean-dmin-1)) / annuli_width + 1),
             dtype=float) * annuli_width
         second_distarray = dmean + dmin - 1 + np.arange(
-            np.int(np.round(dmax-dmean) / (4*annuli_width) + 1),
+            int(np.round(dmax-dmean) / (4*annuli_width) + 1),
             dtype=float) * 4*annuli_width
         distarray_lambdaonD = np.hstack([first_distarray, second_distarray])
         if iwa > fast:

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -68,12 +68,12 @@ def lnprior(param, bounds):
         return -np.inf
 
 
-def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width,
-           ncomp, aperture_radius, initial_state, cube_ref=None,
-           svd_mode='lapack', scaling='temp-mean', algo=pca_annulus,
-           delta_rot=1, fmerit='sum', imlib='vip-fft', interpolation='lanczos4', 
-           collapse='median', algo_options={}, weights=None, transmission=None, 
-           mu_sigma=True, sigma='spe+pho', debug=False):
+def lnlike(param, cube, angs, plsc, psf_norm, fwhm, annulus_width, ncomp, 
+           aperture_radius, initial_state, cube_ref=None, svd_mode='lapack', 
+           scaling='temp-mean', algo=pca_annulus, delta_rot=1, fmerit='sum', 
+           imlib='vip-fft', interpolation='lanczos4', collapse='median', 
+           algo_options={}, weights=None, transmission=None, mu_sigma=True, 
+           sigma='spe+pho', debug=False):
     """ Define the likelihood log-function.
     
     Parameters
@@ -861,6 +861,9 @@ def show_walk_plot(chain, save=False, output_dir='', **kwargs):
         discard these steps.
     save: boolean, default: False
         If True, a pdf file is created.
+    output_dir: str, optional
+        The name of the output directory which contains the output files in the 
+        case  ``save`` is True.    
     kwargs:
         Additional attributes are passed to the matplotlib plot method.
                                                         
@@ -907,7 +910,9 @@ def show_corner_plot(chain, burnin=0.5, save=False, output_dir='', **kwargs):
         The fraction of a walker chain we want to discard.
     save: boolean, default: False
         If True, a pdf file is created.
-     
+    output_dir: str, optional
+        The name of the output directory which contains the output files in the 
+        case  ``save`` is True.         
      kwargs:
         Additional attributes are passed to the corner.corner() method.
                     

--- a/vip_hci/negfc/mcmc_sampling.py
+++ b/vip_hci/negfc/mcmc_sampling.py
@@ -354,11 +354,27 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
     regardless of the position of the candidate.
     3) We extract the intensity values of all the pixels contained in a
     circular aperture centered on the initial guess.
-    4) We calculate the function of merit. The associated chi^2 is given by
-    chi^2 = sum(\|I_j\|) where j \in {1,...,N} with N the total number of pixels
-    contained in the circular aperture.
-    The steps 1) to 4) are looped. At each iteration, the candidate model
+    4) We calculate a function of merit :math:`\chi^2` (see below).
+    The steps 1) to 4) are then looped. At each iteration, the candidate model 
     parameters are defined by the emcee Affine Invariant algorithm.
+    
+    There are different possibilities for the figure of merit (step 4):
+        - mu_sigma=None; fmerit='sum' (as in Wertz et al. 2017):
+        .. math:: \chi^2 = \sum(\|I_j\|) 
+        - mu_sigma=None; fmerit='stddev' (likely more appropriate when speckle
+        noise still significant):
+        .. math:: \chi^2 = N \sigma_{I_j}(values,ddof=1)*values.size
+        - mu_sigma=True or a tuple (as in Christiaens et al. 2021, new default):
+        .. math:: \chi^2 = \sum\frac{(I_j- mu)^2}{\sigma^2}     
+            
+    where :math:`j \in {1,...,N}` with N the total number of pixels 
+    contained in the circular aperture, :math:`\sigma_{I_j}` is the standard
+    deviation of :math:`I_j` values, and :math:`\mu` is the mean pixel 
+    intensity in a truncated annulus at the radius of the companion candidate 
+    (i.e. excluding the cc region).
+    
+    See description of `mu_sigma` and `sigma` for more details on 
+    :math:`\sigma\`.
     
     Parameters
     ----------
@@ -401,8 +417,8 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
         "temp-standard" temporal mean centering plus scaling to unit variance
         is done.
     fmerit : {'sum', 'stddev'}, string optional
-        Chooses the figure of merit to be used. stddev works better for close in
-        companions sitting on top of speckle noise.
+        Chooses the figure of merit to be used. stddev works better for 
+        close-in companions sitting on top of speckle noise.
     imlib : str, optional
         Imlib used for both image rotation and sub-px shift:
         - "opencv": will use it for both;
@@ -476,7 +492,6 @@ def mcmc_negfc_sampling(cube, angs, psfn, ncomp, plsc, initial_state, fwhm=4,
         (http://digitalassets.lib.berkeley.edu/sdtr/ucb/text/305.pdf)
         - 'ac' for autocorrelation analysis 
         (https://emcee.readthedocs.io/en/stable/tutorials/autocorr/)
-        
     ac_c: float, optional
         If the convergence test is made using the auto-correlation, this is the
         value of C such that tau/N < 1/C is the condition required for tau to be
@@ -931,7 +946,7 @@ def show_corner_plot(chain, burnin=0.5, save=False, output_dir='', **kwargs):
 def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
                verbose=True, save=False, output_dir='', force=False, 
                output_file='confidence.txt', title=None, plsc=None, **kwargs):
-    """
+    r"""
     Determine the highly probable value for each model parameter, as well as
     the 1-sigma confidence interval.
     
@@ -944,7 +959,8 @@ def confidence(isamples, cfd=68.27, bins=100, gaussian_fit=False, weights=None,
     bins: int, optional
         The number of bins used to sample the posterior distributions.
     gaussian_fit: boolean, optional
-        If True, a gaussian fit is performed in order to determine (\mu,\sigma)
+        If True, a gaussian fit is performed in order to determine 
+        (:math:`\mu, \sigma`).
     weights : (n, ) numpy ndarray or None, optional
         An array of weights for each sample.
     verbose: boolean, optional

--- a/vip_hci/negfc/nested_sampling.py
+++ b/vip_hci/negfc/nested_sampling.py
@@ -244,10 +244,35 @@ def nested_negfc_sampling(init, cube, angs, plsc, psf, fwhm, annulus_width=8,
     return res
 
 
-def nested_sampling_results(ns_object, burnin=0.4, bins=None, save=False,
-                            output_dir='/', plot=False):
+def nested_sampling_results(ns_object, burnin=0.4, bins=None, cfd=68.27,
+                            save=False, output_dir='/', plot=False):
     """ Shows the results of the Nested Sampling, summary, parameters with 
     errors, walk and corner plots.
+    
+    Parameters
+    ----------
+    ns_object: numpy.array
+        The nestle object returned from `nested_spec_sampling`.
+    burnin: float, default: 0
+        The fraction of a walker we want to discard.
+    bins: int, optional
+        The number of bins used to sample the posterior distributions.
+    cfd: float, optional
+        The confidence level given in percentage.
+    save: boolean, default: False
+        If True, a pdf file is created.
+    output_dir: str, optional
+        The name of the output directory which contains the output files in the 
+        case  ``save`` is True. 
+    plot: bool, optional
+        Whether to show the plots (instead of saving them).
+                    
+    Returns
+    -------
+    final_res: numpy ndarray
+         Best-fit parameters and uncertainties (corresponding to 68% confidence
+         interval). Dimensions: nparams x 2.
+         
     """
     res = ns_object
     nsamples = res.samples.shape[0]

--- a/vip_hci/negfc/nested_sampling.py
+++ b/vip_hci/negfc/nested_sampling.py
@@ -170,13 +170,6 @@ def nested_negfc_sampling(init, cube, angs, plsc, psf, fwhm, annulus_width=8,
 
     """
 
-    # If companion flux is too low MCMC will not converge. Solution: scale up 
-    # the intensities in the cube after injecting the negfc.
-    if init[2] < 100:
-        scale_fac = 100./init[2]
-    else:
-        scale_fac = 1
-
     def prior_transform(x):
         """
         Computes the transformation from the unit distribution `[0, 1]` to 
@@ -228,7 +221,7 @@ def nested_negfc_sampling(init, cube, angs, plsc, psf, fwhm, annulus_width=8,
                       cube_ref=cube_ref, svd_mode=svd_mode, scaling=scaling,
                       algo=algo, delta_rot=delta_rot, fmerit='sum', ncomp=ncomp, 
                       collapse=collapse, algo_options=algo_options, 
-                      weights=weights, scale_fac=scale_fac)
+                      weights=weights)
 
     # -------------------------------------------------------------------------
     if verbose:  start = time_ini()

--- a/vip_hci/negfc/simplex_fmerit.py
+++ b/vip_hci/negfc/simplex_fmerit.py
@@ -23,11 +23,12 @@ def chisquare(modelParameters, cube, angs, plsc, psfs_norm, fwhm, annulus_width,
               algo=pca_annulus, delta_rot=1, imlib='vip-fft', 
               interpolation='lanczos4', algo_options={}, transmission=None, 
               mu_sigma=None, weights=None, force_rPA=False, debug=False):
-    """
-    Calculate the reduced chi2:
-    \chi^2_r = \frac{1}{N-3}\sum_{j=1}^{N} |I_j|,
+    r"""
+    Calculate the reduced :math:`\chi^2`:
+    .. math:: \chi^2_r = \frac{1}{N-3}\sum_{j=1}^{N} |I_j|,
     where N is the number of pixels within a circular aperture centered on the 
-    first estimate of the planet position, and I_j the j-th pixel intensity.
+    first estimate of the planet position, and :math:`I_j` the j-th pixel 
+    intensity.
     
     Parameters
     ----------    
@@ -551,10 +552,10 @@ def get_mu_and_sigma(cube, angs, ncomp, annulus_width, aperture_radius, fwhm,
         raise TypeError("Wedge should have exactly 2 values")
         
     
-    indices = get_annular_wedge(pca_res, radius_int, 2*fwhm, #annulus_width, 
+    indices = get_annular_wedge(pca_res, radius_int, 2*fwhm,
                                 wedge=wedge)
     yy, xx = indices
-    indices_inv = get_annular_wedge(pca_res_inv, radius_int, 2*fwhm, #annulus_width, 
+    indices_inv = get_annular_wedge(pca_res_inv, radius_int, 2*fwhm,
                                     wedge=wedge)
     yyi, xxi = indices_inv
     all_res = np.concatenate((pca_res[yy, xx], pca_res_inv[yyi, xxi]))

--- a/vip_hci/negfc/simplex_optim.py
+++ b/vip_hci/negfc/simplex_optim.py
@@ -122,8 +122,8 @@ def firstguess_from_coord(planet, center, cube, angs, PLSC, psf, fwhm,
     if f_range is not None:    
         n = f_range.shape[0]
     else:
-        n = 100
-        f_range = np.linspace(0, 5000, n)
+        n = 30
+        f_range = np.geomspace(1e-1, 1e4, n)
     
     chi2r = []
     if verbose:

--- a/vip_hci/negfc/utils_mcmc.py
+++ b/vip_hci/negfc/utils_mcmc.py
@@ -20,8 +20,9 @@ warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
 def gelman_rubin(x):
-    """
-    Determine the Gelman-Rubin \hat{R} statistical test between Markov chains.
+    r"""
+    Determine the Gelman-Rubin :math:`\hat{R}` statistical test between Markov 
+    chains.
     
     Parameters
     ----------
@@ -32,7 +33,7 @@ def gelman_rubin(x):
     Returns
     -------
     out: float
-        The Gelman-Rubin \hat{R}.
+        The Gelman-Rubin :math:`\hat{R}`.
 
     Example
     -------
@@ -75,10 +76,10 @@ def gelman_rubin(x):
 
 
 def gelman_rubin_from_chain(chain, burnin):
-    """ Pack the MCMC chain and determine the Gelman-Rubin \hat{R} statistical
-    test. In other words, two sub-sets are extracted from the chain (burnin
-    parts are taken into account) and the Gelman-Rubin statistical test is
-    performed.
+    r""" Pack the MCMC chain and determine the Gelman-Rubin :math:`\hat{R}` 
+    statistical test. In other words, two sub-sets are extracted from the chain 
+    (burnin parts are taken into account) and the Gelman-Rubin statistical test 
+    is performed.
     
     Parameters
     ----------
@@ -90,7 +91,7 @@ def gelman_rubin_from_chain(chain, burnin):
     Returns
     -------
     out: float
-        The Gelman-Rubin \hat{R}.
+        The Gelman-Rubin :math:`\hat{R}`.
         
     """
     dim = chain.shape[2]

--- a/vip_hci/preproc/badpixremoval.py
+++ b/vip_hci/preproc/badpixremoval.py
@@ -679,8 +679,8 @@ def cube_fix_badpix_clump(array, bpm_mask=None, cy=None, cx=None, fwhm=4.,
             for i in range(n_z):
                 if verbose: print('************Frame # ', i,' *************')
                 obj_tmp[i], bpix_map_cumul[i] = bp_removal_2d(obj_tmp[i], cy[i], 
-                                                              cx[i], fwhm[i], sig, 
-                                                              protect_psf,  
+                                                              cx[i], fwhm[i], 
+                                                              sig, protect_psf,  
                                                               min_thr, 
                                                               half_res_y,
                                                               verbose)

--- a/vip_hci/preproc/badpixremoval.py
+++ b/vip_hci/preproc/badpixremoval.py
@@ -112,7 +112,7 @@ def frame_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
         bpm_mask = np.zeros_like(frame)
         bpm_mask[ind] = 1
         if protect_mask:
-            cir = disk((cy, cx), radius)
+            cir = disk((cy, cx), radius, shape=bpm_mask.shape)
             bpm_mask[cir] = 0
         bpm_mask = bpm_mask.astype('bool')
 
@@ -254,7 +254,7 @@ def cube_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
             bpm_mask = np.zeros_like(array[0])
             bpm_mask[ind] = 1
             if protect_mask:
-                cir = disk((cy, cx), radius)
+                cir = disk((cy, cx), radius, shape=bpm_mask.shape)
                 bpm_mask[cir] = 0
             bpm_mask = bpm_mask.astype('bool')
     

--- a/vip_hci/preproc/badpixremoval.py
+++ b/vip_hci/preproc/badpixremoval.py
@@ -33,45 +33,58 @@ except ImportError:
     no_numba = True
 
 def frame_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
-                              size=5, protect_mask=False, radius=30,
-                              verbose=True):
+                              size=5, protect_mask=False, radius=30, cxy=None,
+                              mad=True, verbose=True, full_output=False):
     """ Corrects the bad pixels, marked in the bad pixel mask. The bad pixel is
-     replaced by the median of the adjacent pixels. This function is very fast
-     but works only with isolated (sparse) pixels.
+    replaced by the median of the adjacent pixels. This function is very fast
+    but works only with isolated (sparse) pixels.
 
-     Parameters
-     ----------
-     array : numpy ndarray
-         Input 2d array.
-     bpm_mask : numpy ndarray, optional
-         Input bad pixel map. Zeros frame where the bad pixels have a value of
-         1. If None is provided a bad pixel map will be created using
-         sigma clip statistics. 
-     sigma_clip : int, optional
-         In case no bad pixel mask is provided all the pixels above and below
-         sigma_clip*STDDEV will be marked as bad.
-     num_neig : int, optional
-         The side of the square window around each pixel where the sigma clipped
-         statistics are calculated (STDDEV and MEDIAN). If the value is equal to
-         0 then the statistics are computed in the whole frame.
-     size : odd int, optional
-         The size the box (size x size) of adjacent pixels for the median
-         filter.
-     protect_mask : bool, optional
-         If True a circular aperture at the center of the frames will be
-         protected from any operation. With this we protect the star and
-         vicinity.
-     radius : int, optional
-         Radius of the circular aperture (at the center of the frames) for the
-         protection mask.
-     verbose : bool, optional
-         If True additional information will be printed.
-
-     Return
-     ------
-     frame : numpy ndarray
-         Frame with bad pixels corrected.
-     """
+    Parameters
+    ----------
+    array : numpy ndarray
+        Input 2d array.
+    bpm_mask : numpy ndarray, optional
+        Input bad pixel map. Zeros frame where the bad pixels have a value of
+        1. If None is provided a bad pixel map will be created using
+        sigma clip statistics. 
+    sigma_clip : int, optional
+        In case no bad pixel mask is provided all the pixels above and below
+        sigma_clip*STDDEV will be marked as bad.
+    num_neig : int, optional
+        The side of the square window around each pixel where the sigma clipped
+        statistics are calculated (STDDEV and MEDIAN). If the value is equal to
+        0 then the statistics are computed in the whole frame.
+    size : odd int, optional
+        The size the box (size x size) of adjacent pixels for the median
+        filter.
+    protect_mask : bool, optional
+        If True a circular aperture at the center of the frames will be
+        protected from any operation. With this we protect the star and
+        vicinity.
+    radius : int, optional
+        Radius of the circular aperture (at the center of the frames) for the
+        protection mask.
+    cxy: None or tuple
+        If protect_mask is True, this is the location of the star centroid in
+        the images. If None, assumes the star is already centered. If a tuple,
+        the location of the star is assumed to be the same in all frames of the 
+        cube.
+    mad : {False, True}, bool optional
+        If True, the median absolute deviation will be used instead of the 
+        standard deviation.  
+    verbose : bool, optional
+        If True additional information will be printed.
+    full_output: bool, {False,True}, optional
+        Whether to return as well the cube of bad pixel maps and the cube of 
+        defined annuli.
+        
+    Return
+    ------
+    frame : numpy ndarray
+        Frame with bad pixels corrected.
+    bpm_mask: 2d array
+        The bad pixel map
+    """
     if array.ndim != 2:
         raise TypeError('Array is not a 2d array or single frame')
     if size % 2 == 0:
@@ -88,10 +101,14 @@ def frame_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
         neigh = False
 
     frame = array.copy()
-    cy, cx = frame_center(frame)
+    if cxy is None:
+        cy, cx = frame_center(frame)
+    else:
+        cx, cy = cxy
+        
     if bpm_mask is None:
         ind = clip_array(frame, sigma_clip, sigma_clip, neighbor=neigh,
-                         num_neighbor=num_neig, mad=True)
+                         num_neighbor=num_neig, mad=mad)
         bpm_mask = np.zeros_like(frame)
         bpm_mask[ind] = 1
         if protect_mask:
@@ -108,12 +125,17 @@ def frame_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
         msg = "/nDone replacing {} bad pixels using the median of neighbors"
         print(msg.format(count_bp))
         timing(start)
-    return array_out
+        
+    if full_output:
+        return array_out, bpm_mask
+    else:
+        return array_out
 
 
 def cube_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5, 
                              size=5, frame_by_frame=False, protect_mask=False, 
-                             radius=30, verbose=True):
+                             radius=30, cxy=None, mad=True, verbose=True, 
+                             full_output=False):
     """ Corrects the bad pixels, marked in the bad pixel mask. The bad pixel is 
     replaced by the median of the adjacent pixels. This function is very fast
     but works only with isolated (sparse) pixels. 
@@ -140,19 +162,31 @@ def cube_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
         is set to False; the bad pixels are computed on the mean frame of the 
         stack (faster but not necessarily optimal).
     protect_mask : bool, optional
-        If True a circular aperture at the center of the frames will be 
-        protected from any operation. With this we protect the star and its
-        vicinity.
+        If True a circular aperture, centered on cxy, will be protected from 
+        any operation. With this we protect the star and its vicinity.
     radius : int, optional 
-        Radius of the circular aperture (at the center of the frames) for the 
-        protection mask.
+        Radius of the circular aperture for the protection mask.
+    cxy: None, tuple or 2d numpy ndarray
+        If protect_mask is True, this is the location of the star centroid in
+        the images. If None, assumes the star is already centered. If a tuple,
+        the location of the star is assumed to be the same in all frames of the 
+        cube. If a (n_frames x 2) ndarray, it should contain the xy location of 
+        the star in each frame.
+    mad : {False, True}, bool optional
+        If True, the median absolute deviation will be used instead of the 
+        standard deviation.  
     verbose : bool, optional
         If True additional information will be printed.
-    
+    full_output: bool, {False,True}, optional
+        Whether to return as well the cube of bad pixel maps and the cube of 
+        defined annuli.
+        
     Return
     ------
     array_out : numpy ndarray
         Cube with bad pixels corrected.
+    bpm_mask: 2d or 3d array
+        The bad pixel map or the cube of bpix maps
     """
     if array.ndim != 3:
         raise TypeError('Array is not a 3d array or cube')
@@ -169,27 +203,54 @@ def cube_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
     else:
         neigh = False
     
-    cy, cx = frame_center(array[0])
+    nz = array.shape[0]
+        
+    if cxy is None:
+        cy, cx = frame_center(array[0])
+    elif isinstance(cxy, tuple):
+        cx, cy = cxy
+    elif isinstance(cxy, np.ndarray):
+        if cxy.shape[0] != nz or cxy.shape[1] != 2 or cxy.ndim != 2:
+            raise ValueError("cxy does not have right shape")
+        elif not frame_by_frame:
+            msg = "cxy must be a tuple or None if not in frame_by_frame mode"
+            raise ValueError(msg)
+        else:
+            cx = cxy[:,0]
+            cy = cxy[:,1]
+
+            
     array_out = array.copy()
+    if full_output:
+        bpm_mask = array_out.copy()
     n_frames = array.shape[0]
     count_bp = 0
     if frame_by_frame:
+        if np.isscalar(cx):
+            cx = [cx]*nz
+            cy = [cy]*nz
         for i in Progressbar(range(n_frames), desc="processing frames"):
-            array_out[i] = frame_fix_badpix_isolated(array[i], bpm_mask=bpm_mask, 
+            res = frame_fix_badpix_isolated(array[i], bpm_mask=bpm_mask, 
                                                     sigma_clip=sigma_clip, 
                                                     num_neig=num_neig,
                                                     size=size, 
                                                     protect_mask=protect_mask, 
                                                     radius=radius,
-                                                    verbose=False,
-                                                    debug=False)
+                                                    verbose=False, 
+                                                    cxy=(cx[i],cy[i]),
+                                                    full_output=full_output)
+            if full_output:
+                array_out[i] = res[0]
+                bpm_mask[i] = res[1]
+            else:
+                array_out[i] = res
             if verbose:                                       
                 bpm = np.where(array_out[i]!=array[i])   
                 count_bp+=np.sum(np.ones_like(array_out[i])[bpm])                                   
     else:                                                
         if bpm_mask is None:
             ind = clip_array(np.mean(array, axis=0), sigma_clip, sigma_clip,
-                             neighbor=neigh, num_neighbor=num_neig, mad=True)
+                             neighbor=neigh, num_neighbor=num_neig, mad=mad)
             bpm_mask = np.zeros_like(array[0])
             bpm_mask[ind] = 1
             if protect_mask:
@@ -205,10 +266,14 @@ def cube_fix_badpix_isolated(array, bpm_mask=None, sigma_clip=3, num_neig=5,
                 count_bp+=np.sum(bpm_mask)  
             
     if verbose: 
-        msg = "/nDone replacing {} bad pixels using the median of neighbors"
+        msg = "Done replacing {} bad pixels using the median of neighbors"
         print(msg.format(count_bp))
         timing(start)
-    return array_out
+        
+    if full_output:
+        return array_out, bpm_mask
+    else:
+        return array_out
 
 
 def cube_fix_badpix_annuli(array, fwhm, cy=None, cx=None, sig=5., 
@@ -272,10 +337,13 @@ def cube_fix_badpix_annuli(array, fwhm, cy=None, cx=None, sig=5.,
 
     Returns:
     --------
-    obj_tmp: 2d or 3d array; the bad pixel corrected frame/cube.
+    obj_tmp: 2d or 3d array
+        The bad pixel corrected frame/cube.
     If full_output is set to True, it returns as well:
-    bpix_map: 2d or 3d array; the bad pixel map or the cube of bpix maps
-    ann_frame_cumul: 2 or 3d array; the cube of defined annuli
+    bpix_map: 2d or 3d array
+        The bad pixel map or the cube of bpix maps
+    ann_frame_cumul: 2 or 3d array
+        The cube of defined annuli
     """
 
     obj_tmp = array.copy()
@@ -485,7 +553,7 @@ def cube_fix_badpix_annuli(array, fwhm, cy=None, cx=None, sig=5.,
 
 def cube_fix_badpix_clump(array, bpm_mask=None, cy=None, cx=None, fwhm=4., 
                           sig=4., protect_psf=True, verbose=True, 
-                          half_res_y=False, min_thr=None, max_nit=15, 
+                          half_res_y=False, min_thr=None, max_nit=15, mad=True,
                           full_output=False):
     """
     Function to identify and correct clumps of bad pixels. Very fast when a bad 
@@ -531,16 +599,21 @@ def cube_fix_badpix_clump(array, bpm_mask=None, cy=None, cx=None, fwhm=4.,
         there are always 2 rows of pixels with exactly the same values.
         The algorithm will just consider every other row (hence making it
         twice faster), then apply the bad pixel correction on all rows.
-    min_thr: float or None, opt
-        If provided, corresponds to a minimum absolute threshold below which
-        pixels are not considered bad (can be used to avoid the identification
-        of bad pixels within noise).
+    min_thr: float, tuple or None, opt
+        If a float is provided, corresponds to a minimum absolute threshold 
+        below which pixels are not considered bad (can be used to avoid the 
+        identification of bad pixels within noise).
+        If a tuple of 2 values, corresponds to the range of values within which 
+        not to consider a pixel as bad. (e.g. (-0.1, 10.)).
     max_nit: float, optional
         Maximum number of iterations on a frame to correct bpix. Typically, it 
         should be set to less than ny/2 or nx/2. This is a mean of precaution in
         case the algorithm gets stuck with 2 neighbouring pixels considered bpix
         alternately on two consecutively iterations hence leading to an infinite
         loop (very very rare case).
+    mad : {False, True}, bool optional
+        If True, the median absolute deviation will be used instead of the 
+        standard deviation.
     full_output: bool, {False,True}, optional
         Whether to return as well the cube of bad pixel maps and the cube of 
         defined annuli.
@@ -561,7 +634,7 @@ def cube_fix_badpix_clump(array, bpm_mask=None, cy=None, cx=None, fwhm=4.,
             raise TypeError("Bad pixel map has wrong y/x dimensions.")
 
     def bp_removal_2d(obj_tmp, cy, cx, fwhm, sig, protect_psf, min_thr, 
-                      half_res_y, verbose):    
+                      half_res_y, mad, verbose):    
         n_x = obj_tmp.shape[1]
         n_y = obj_tmp.shape[0]
 
@@ -598,14 +671,25 @@ def cube_fix_badpix_clump(array, bpm_mask=None, cy=None, cx=None, fwhm=4.,
 
         #3/ Create a bad pixel map, by detecting them with clip_array
         bp=clip_array(obj_tmp, sig, sig, out_good=False, neighbor=True,
-                      num_neighbor=neighbor_box, mad=True, 
+                      num_neighbor=neighbor_box, mad=mad, 
                       half_res_y=half_res_y)
         bpix_map = np.zeros_like(obj_tmp)  
-        bpix_map[bp] = 1              
+        bpix_map[bp] = 1
+        if min_thr is not None:
+            if np.isscalar(min_thr):
+                min_thr = (-min_thr, min_thr)
+            elif not isinstance(min_thr, tuple):
+                msg = "if provided, min_thr should be float or tuple"
+                raise ValueError(msg)
+            else:
+                if len(min_thr) != 2:
+                   msg = "if min_thr is a tuple, it should have 2 elements"
+                   raise ValueError(msg) 
+            cond1 = obj_tmp>min_thr[0]
+            cond2 = obj_tmp<min_thr[1]
+            bpix_map[np.where(cond1 & cond2)] = 0
         nbpix_tot = np.sum(bpix_map)
         bpix_map[circl_new] = 0
-        if min_thr is not None:
-            bpix_map[np.where(np.abs(obj_tmp)<min_thr)] = 0
         nbpix_tbc = np.sum(bpix_map)
         bpix_map_cumul = np.zeros_like(bpix_map)
         bpix_map_cumul[:] = bpix_map[:]
@@ -621,14 +705,16 @@ def cube_fix_badpix_clump(array, bpm_mask=None, cy=None, cx=None, fwhm=4.,
                                    min_neighbors=nneig, half_res_y=half_res_y, 
                                    verbose=verbose)
             bp=clip_array(obj_tmp, sig, sig, out_good=False, neighbor=True,
-                          num_neighbor=neighbor_box, mad=True, 
+                          num_neighbor=neighbor_box, mad=mad, 
                           half_res_y=half_res_y)
             bpix_map = np.zeros_like(obj_tmp)  
             bpix_map[bp] = 1
+            if min_thr is not None:
+                cond1 = obj_tmp>min_thr[0]
+                cond2 = obj_tmp<min_thr[1]
+                bpix_map[np.where(cond1 & cond2)] = 0
             nbpix_tot = np.sum(bpix_map)
             bpix_map[circl_new] = 0
-            if min_thr is not None:
-                bpix_map[np.where(np.abs(obj_tmp)<min_thr)] = 0
             nbpix_tbc = np.sum(bpix_map)
             bpix_map_cumul = bpix_map_cumul+bpix_map
 
@@ -655,7 +741,7 @@ def cube_fix_badpix_clump(array, bpm_mask=None, cy=None, cx=None, fwhm=4.,
                 cx = cen[0,1]
             obj_tmp, bpix_map_cumul = bp_removal_2d(obj_tmp, cy, cx, fwhm, sig, 
                                                     protect_psf, min_thr, 
-                                                    half_res_y, verbose)
+                                                    half_res_y, mad, verbose)
         else:
             fwhm_round = int(round(fwhm))
             fwhm_round = fwhm_round+1-(fwhm_round%2) # make it odd
@@ -684,7 +770,7 @@ def cube_fix_badpix_clump(array, bpm_mask=None, cy=None, cx=None, fwhm=4.,
                                                               cx[i], fwhm[i], 
                                                               sig, protect_psf,  
                                                               min_thr, 
-                                                              half_res_y,
+                                                              half_res_y, mad,
                                                               verbose)
         else:
             if isinstance(fwhm, (float,int)):
@@ -846,9 +932,16 @@ def cube_fix_badpix_with_kernel(array, bpm_mask, mode='gauss', fwhm=4.,
             for y in range(nny):
                 new_obj_tmp[y] = array[y//2]
             return new_obj_tmp
-        obj_tmp = unsquash_v(obj_tmp)
+        if ndims == 2:
+            obj_tmp = unsquash_v(obj_tmp)
+        else:
+            new_obj_tmp = []
+            for z in range(nz):
+                new_obj_tmp.append(unsquash_v(obj_tmp[z]))
+            obj_tmp = np.array(new_obj_tmp)
     
     return obj_tmp
+
     
     
 def find_outliers(frame, sig_dist, in_bpix=None, stddev=None, neighbor_box=3,

--- a/vip_hci/preproc/cosmetics.py
+++ b/vip_hci/preproc/cosmetics.py
@@ -319,7 +319,8 @@ def cube_correct_nan(cube, neighbor_box=3, min_neighbors=3, verbose=False,
         nnanpix = int(np.sum(nan_map))
         # Correct nan with iterative sigma filter
         obj_tmp = sigma_filter(obj_tmp, nan_map, neighbor_box=neighbor_box,
-                               min_neighbors=min_neighbors, verbose=verbose)
+                               min_neighbors=min_neighbors, verbose=verbose,
+                               half_res_y=half_res_y)
         if half_res_y:
             frame = obj_tmp
             n_y = 2 * n_y

--- a/vip_hci/preproc/cosmetics.py
+++ b/vip_hci/preproc/cosmetics.py
@@ -16,8 +16,10 @@ __all__ = ['cube_crop_frames',
            'approx_stellar_position']
 
 
+from multiprocessing import cpu_count
 import numpy as np
 from astropy.stats import sigma_clipped_stats
+from ..config.utils_conf import pool_map, iterable
 from ..stats import sigma_filter
 from ..var import frame_center, get_square
 
@@ -270,7 +272,7 @@ def frame_remove_stripes(array):
 
 
 def cube_correct_nan(cube, neighbor_box=3, min_neighbors=3, verbose=False,
-                     half_res_y=False):
+                     half_res_y=False, nproc=1):
     """Sigma filtering of nan pixels in a whole frame or cube. Tested on
     SINFONI data.
 
@@ -291,45 +293,15 @@ def cube_correct_nan(cube, neighbor_box=3, min_neighbors=3, verbose=False,
         is twice less angular resolution vertically than horizontally (e.g.
         SINFONI data). The algorithm goes twice faster if this option is
         rightfully set to True.
+    nproc: None or int, optional
+        Number of CPUs for multiprocessing (only used for 3D input). If None, 
+        will automatically set it to half the available number of CPUs.
 
     Returns
     -------
     obj_tmp : numpy ndarray
         Output cube with corrected nan pixels in each frame
     """
-    def nan_corr_2d(obj_tmp):
-        n_x = obj_tmp.shape[1]
-        n_y = obj_tmp.shape[0]
-
-        if half_res_y:
-            if n_y % 2 != 0:
-                raise ValueError("The input frames do not have an even number "
-                                 "of rows. Hence, you should probably not be "
-                                 "using the option half_res_y = True.")
-            n_y = int(n_y / 2)
-            frame = obj_tmp
-            obj_tmp = np.zeros([n_y, n_x])
-            for yy in range(n_y):
-                obj_tmp[yy] = frame[2 * yy]
-
-        # tuple with the 2D indices of each nan value of the frame
-        nan_indices = np.where(np.isnan(obj_tmp))
-        nan_map = np.zeros_like(obj_tmp)
-        nan_map[nan_indices] = 1
-        nnanpix = int(np.sum(nan_map))
-        # Correct nan with iterative sigma filter
-        obj_tmp = sigma_filter(obj_tmp, nan_map, neighbor_box=neighbor_box,
-                               min_neighbors=min_neighbors, verbose=verbose,
-                               half_res_y=half_res_y)
-        if half_res_y:
-            frame = obj_tmp
-            n_y = 2 * n_y
-            obj_tmp = np.zeros([n_y, n_x])
-            for yy in range(n_y):
-                obj_tmp[yy] = frame[int(yy / 2)]
-
-        return obj_tmp, nnanpix
-    ############################################################################
 
     obj_tmp = cube.copy()
 
@@ -351,18 +323,69 @@ def cube_correct_nan(cube, neighbor_box=3, min_neighbors=3, verbose=False,
             print("{} NaN pixels were corrected".format(nnanpix))
 
     elif ndims == 3:
+        if nproc is None:
+            nproc = cpu_count()//2
         n_z = obj_tmp.shape[0]
-        for zz in range(n_z):
-            obj_tmp[zz], nnanpix = nan_corr_2d(obj_tmp[zz])
+        if nproc == 1:
+            for zz in range(n_z):
+                obj_tmp[zz], nnanpix = nan_corr_2d(obj_tmp[zz], neighbor_box,
+                                                   min_neighbors, half_res_y, 
+                                                   verbose, True)
+                if verbose:
+                    msg = "In channel {}, {} NaN pixels were corrected"
+                    print(msg.format(zz, nnanpix))
+        else:
             if verbose:
-                msg = "In channel {}, {} NaN pixels were corrected"
-                print(msg.format(zz, nnanpix))
+                msg = "Correcting NaNs in multiprocessing..."
+                print(msg)
+            res = pool_map(nproc, nan_corr_2d, iterable(obj_tmp), neighbor_box,
+                           min_neighbors, half_res_y, verbose, False) 
+            obj_tmp = np.array(res, dtype=object)
 
     if verbose:
         print('All nan pixels are corrected.')
 
     return obj_tmp
 
+
+def nan_corr_2d(obj_tmp, neighbor_box, min_neighbors, half_res_y, verbose,
+                full_output=True):
+    
+    n_x = obj_tmp.shape[1]
+    n_y = obj_tmp.shape[0]
+
+    if half_res_y:
+        if n_y % 2 != 0:
+            raise ValueError("The input frames do not have an even number "
+                             "of rows. Hence, you should probably not be "
+                             "using the option half_res_y = True.")
+        n_y = int(n_y / 2)
+        frame = obj_tmp
+        obj_tmp = np.zeros([n_y, n_x])
+        for yy in range(n_y):
+            obj_tmp[yy] = frame[2 * yy]
+
+    # tuple with the 2D indices of each nan value of the frame
+    nan_indices = np.where(np.isnan(obj_tmp))
+    nan_map = np.zeros_like(obj_tmp)
+    nan_map[nan_indices] = 1
+    nnanpix = int(np.sum(nan_map))
+    # Correct nan with iterative sigma filter
+    obj_tmp = sigma_filter(obj_tmp, nan_map, neighbor_box=neighbor_box,
+                           min_neighbors=min_neighbors, verbose=verbose,
+                           half_res_y=half_res_y)
+    if half_res_y:
+        frame = obj_tmp
+        n_y = 2 * n_y
+        obj_tmp = np.zeros([n_y, n_x])
+        for yy in range(n_y):
+            obj_tmp[yy] = frame[int(yy / 2)]
+
+    if full_output:
+        return obj_tmp, nnanpix
+    else:
+        return obj_tmp
+    
 
 def approx_stellar_position(cube, fwhm, return_test=False, verbose=False):
     """FIND THE APPROX COORDS OF THE STAR IN EACH CHANNEL (even the ones

--- a/vip_hci/preproc/recentering.py
+++ b/vip_hci/preproc/recentering.py
@@ -836,7 +836,7 @@ def cube_recenter_dft_upsampling(array, center_fr1=None, negative=False,
     mask: 2D np.ndarray, optional
         Binary mask indicating where the cross-correlation should be calculated
         in the images. If provided, should be the same size as array frames.
-        [Note: only ysed uf version of skimage >= 0.18.0]
+        [Note: only used if version of skimage >= 0.18.0]
     full_output : bool, optional
         Whether to return 2 1d arrays of shifts along with the recentered cube
         or not.
@@ -937,7 +937,7 @@ def cube_recenter_dft_upsampling(array, center_fr1=None, negative=False,
         x[0] = 0
         y[0] = 0
 
-    # Finding the shifts with DTF upsampling of each frame wrt the first
+    # Finding the shifts with DFT upsampling of each frame wrt the first
     
     if nproc == 1:
         for i in Progressbar(range(1, n_frames), desc="frames", verbose=verbose):
@@ -947,7 +947,7 @@ def cube_recenter_dft_upsampling(array, center_fr1=None, negative=False,
     elif nproc > 1: 
         res = pool_map(nproc, _shift_dft, array_rec, array,
                        iterable(range(1, n_frames)),
-                       upsample_factor, interpolation, imlib)
+                       upsample_factor, mask, interpolation, imlib)
         res = np.array(res)
         
         y[1:] = res[:,0]

--- a/vip_hci/preproc/recentering.py
+++ b/vip_hci/preproc/recentering.py
@@ -168,7 +168,7 @@ def frame_shift(array, shift_y, shift_x, imlib='vip-fft',
 
 
 def cube_shift(cube, shift_y, shift_x, imlib='vip-fft', 
-               interpolation='lanczos4'):
+               interpolation='lanczos4', border_mode='reflect'):
     """ Shifts the X-Y coordinates of a cube or 3D array by x and y values.
 
     Parameters
@@ -182,7 +182,9 @@ def cube_shift(cube, shift_y, shift_x, imlib='vip-fft',
         See the documentation of the ``vip_hci.preproc.frame_shift`` function.
     interpolation : str, optional
         See the documentation of the ``vip_hci.preproc.frame_shift`` function.
-
+    border_mode : str, optional
+        See the documentation of the ``vip_hci.preproc.frame_shift`` function.
+        
     Returns
     -------
     cube_out : numpy ndarray, 3d
@@ -200,13 +202,14 @@ def cube_shift(cube, shift_y, shift_x, imlib='vip-fft',
 
     for i in range(cube.shape[0]):
         cube_out[i] = frame_shift(cube[i], shift_y[i], shift_x[i], imlib,
-                                  interpolation)
+                                  interpolation, border_mode)
     return cube_out
 
 
 def frame_center_satspots(array, xy, subi_size=19, sigfactor=6, shift=False,
                           imlib='vip-fft', interpolation='lanczos4',
-                          fit_type='moff', debug=False, verbose=True):
+                          fit_type='moff', border_mode='reflect', debug=False, 
+                          verbose=True):
     """ Finds the center of a frame with waffle/satellite spots (e.g. for
     VLT/SPHERE). The method used to determine the center is by centroiding the
     4 spots via a 2d Gaussian fit and finding the intersection of the
@@ -240,6 +243,14 @@ def frame_center_satspots(array, xy, subi_size=19, sigfactor=6, shift=False,
         See the documentation of the ``vip_hci.preproc.frame_shift`` function.
     fit_type: str, optional {'gaus','moff'}
         Type of 2d fit to infer the centroid of the satellite spots.
+    border_mode : {'reflect', 'nearest', 'constant', 'mirror', 'wrap'}
+        Points outside the boundaries of the input are filled accordingly.
+        With 'reflect', the input is extended by reflecting about the edge of
+        the last pixel. With 'nearest', the input is extended by replicating the
+        last pixel. With 'constant', the input is extended by filling all values
+        beyond the edge with zeros. With 'mirror', the input is extended by
+        reflecting about the center of the last pixel. With 'wrap', the input is
+        extended by wrapping around to the opposite edge. Default is 'reflect'.
     debug : bool, optional
         If True debug information is printed and plotted.
     verbose : bool, optional
@@ -376,7 +387,8 @@ def frame_center_satspots(array, xy, subi_size=19, sigfactor=6, shift=False,
 
             if shift:
                 array_rec = frame_shift(array, shifty, shiftx, imlib=imlib,
-                                        interpolation=interpolation)
+                                        interpolation=interpolation,
+                                        border_mode=border_mode)
                 return array_rec, shifty, shiftx, centy, centx
             else:
                 return shifty, shiftx
@@ -388,8 +400,8 @@ def frame_center_satspots(array, xy, subi_size=19, sigfactor=6, shift=False,
 
 
 def cube_recenter_satspots(array, xy, subi_size=19, sigfactor=6, plot=True,
-                           fit_type='moff', lbda=None, debug=False, verbose=True, 
-                           full_output=False):
+                           fit_type='moff', lbda=None, border_mode='constant', 
+                           debug=False, verbose=True, full_output=False):
     """ Function analog to frame_center_satspots but for image sequences. It
     actually will call frame_center_satspots for each image in the cube. The
     function also returns the shifted images (not recommended to use when the
@@ -426,6 +438,14 @@ def cube_recenter_satspots(array, xy, subi_size=19, sigfactor=6, plot=True,
     lbda: 1d array or list, opt
         Wavelength vector. If provided, the subimages will be scaled accordingly 
         to follow the motion of the satellite spots.
+    border_mode : {'reflect', 'nearest', 'constant', 'mirror', 'wrap'}
+        Points outside the boundaries of the input are filled accordingly.
+        With 'reflect', the input is extended by reflecting about the edge of
+        the last pixel. With 'nearest', the input is extended by replicating the
+        last pixel. With 'constant', the input is extended by filling all values
+        beyond the edge with zeros. With 'mirror', the input is extended by
+        reflecting about the center of the last pixel. With 'wrap', the input is
+        extended by wrapping around to the opposite edge. Default is 'reflect'.
     debug : bool, optional
         If True debug information is printed and plotted (fit and residuals,
         intersections and shifts). This has to be used carefully as it can
@@ -477,7 +497,8 @@ def cube_recenter_satspots(array, xy, subi_size=19, sigfactor=6, plot=True,
     for i in Progressbar(range(n_frames), verbose=verbose):
         res = frame_center_satspots(array[i], final_xy[i], debug=debug, shift=True,
                                     subi_size=subi_size, sigfactor=sigfactor,
-                                    fit_type=fit_type, verbose=False)
+                                    fit_type=fit_type, verbose=False,
+                                    border_mode=border_mode)
         array_rec.append(res[0])
         shift_y[i] = res[1]
         shift_x[i] = res[2]
@@ -523,8 +544,7 @@ def cube_recenter_satspots(array, xy, subi_size=19, sigfactor=6, plot=True,
 
 def frame_center_radon(array, cropsize=None, hsize=0.4, step=0.01,
                        mask_center=None, nproc=None, satspots_cfg=None,
-                       full_output=False, verbose=True, 
-                       plot=True, debug=False):
+                       full_output=False, verbose=True, plot=True, debug=False):
     """ Finding the center of a broadband (co-added) frame with speckles and
     satellite spots elongated towards the star (center). We use the radon
     transform implementation from scikit-image.
@@ -725,7 +745,8 @@ def _radon_costf(frame, cent, radint, coords, satspots_cfg=None):
 
 
 def cube_recenter_radon(array, full_output=False, verbose=True, imlib='vip-fft',
-                        interpolation='lanczos4', **kwargs):
+                        interpolation='lanczos4', border_mode='reflect', 
+                        **kwargs):
     """ Recenters a cube looping through its frames and calling the
     ``frame_center_radon`` function.
 
@@ -741,22 +762,18 @@ def cube_recenter_radon(array, full_output=False, verbose=True, imlib='vip-fft',
         See the documentation of the ``vip_hci.preproc.frame_shift`` function.
     interpolation : str, optional
         See the documentation of the ``vip_hci.preproc.frame_shift`` function.
-    cropsize : odd int, optional
-        Size in pixels of the cropped central area of the input array that will
-        be used. It should be large enough to contain the satellite spots.
-    hsize : float, optional
-        Size of the box for the grid search. The frame is shifted to each
-        direction from the center in a hsize length with a given step.
-    step : float, optional
-        The step of the coordinates change.
-    mask_center : None or int, optional
-        If None the central area of the frame is kept. If int a centered zero
-        mask will be applied to the frame. By default the center isn't masked.
-    nproc : int, optional
-        Number of processes for parallel computing. If None the number of
-        processes will be set to cpu_count()/2.
-    debug : bool, optional
-        Whether to print and plot intermediate info from ``frame_center_radon``.
+    border_mode : {'reflect', 'nearest', 'constant', 'mirror', 'wrap'}
+        Points outside the boundaries of the input are filled accordingly.
+        With 'reflect', the input is extended by reflecting about the edge of
+        the last pixel. With 'nearest', the input is extended by replicating the
+        last pixel. With 'constant', the input is extended by filling all values
+        beyond the edge with zeros. With 'mirror', the input is extended by
+        reflecting about the center of the last pixel. With 'wrap', the input is
+        extended by wrapping around to the opposite edge. Default is 'reflect'.
+    kwargs:
+        Additional optional parameters from vip_hci.preproc.frame_center_radon
+        function, such as cropsize, hsize, step, satspots_cfg, mask_center, 
+        nproc or debug.
 
 
     Returns
@@ -781,7 +798,8 @@ def cube_recenter_radon(array, full_output=False, verbose=True, imlib='vip-fft',
         y[i], x[i] = frame_center_radon(array[i], verbose=False, plot=False,
                                         **kwargs)
         array_rec[i] = frame_shift(array[i], y[i], x[i], imlib=imlib,
-                                   interpolation=interpolation)
+                                   interpolation=interpolation, 
+                                   border_mode=border_mode)
 
     if verbose:
         timing(start_time)
@@ -795,9 +813,9 @@ def cube_recenter_radon(array, full_output=False, verbose=True, imlib='vip-fft',
 def cube_recenter_dft_upsampling(array, center_fr1=None, negative=False,
                                  fwhm=4, subi_size=None, upsample_factor=100,
                                  imlib='vip-fft', interpolation='lanczos4',
-                                 mask=None, full_output=False, verbose=True, 
-                                 nproc=1, save_shifts=False, debug=False, 
-                                 plot=True):
+                                 mask=None, border_mode='reflect', 
+                                 full_output=False, verbose=True, nproc=1, 
+                                 save_shifts=False, debug=False, plot=True):
     """ Recenters a cube of frames using the DFT upsampling method as
     proposed in Guizar et al. 2008 and implemented in the
     ``register_translation`` function from scikit-image.
@@ -837,6 +855,14 @@ def cube_recenter_dft_upsampling(array, center_fr1=None, negative=False,
         Binary mask indicating where the cross-correlation should be calculated
         in the images. If provided, should be the same size as array frames.
         [Note: only used if version of skimage >= 0.18.0]
+    border_mode : {'reflect', 'nearest', 'constant', 'mirror', 'wrap'}
+        Points outside the boundaries of the input are filled accordingly.
+        With 'reflect', the input is extended by reflecting about the edge of
+        the last pixel. With 'nearest', the input is extended by replicating the
+        last pixel. With 'constant', the input is extended by filling all values
+        beyond the edge with zeros. With 'mirror', the input is extended by
+        reflecting about the center of the last pixel. With 'wrap', the input is
+        extended by wrapping around to the opposite edge. Default is 'reflect'.
     full_output : bool, optional
         Whether to return 2 1d arrays of shifts along with the recentered cube
         or not.
@@ -943,11 +969,12 @@ def cube_recenter_dft_upsampling(array, center_fr1=None, negative=False,
         for i in Progressbar(range(1, n_frames), desc="frames", verbose=verbose):
             y[i], x[i], array_rec[i] = _shift_dft(array_rec, array, i,
                                                   upsample_factor, mask,
-                                                  interpolation, imlib)
+                                                  interpolation, imlib,
+                                                  border_mode)
     elif nproc > 1: 
-        res = pool_map(nproc, _shift_dft, array_rec, array,
-                       iterable(range(1, n_frames)),
-                       upsample_factor, mask, interpolation, imlib)
+        res = pool_map(nproc, _shift_dft, array_rec, array, 
+                       iterable(range(1, n_frames)), upsample_factor, mask,
+                       interpolation, imlib, border_mode)
         res = np.array(res)
         
         y[1:] = res[:,0]
@@ -990,7 +1017,7 @@ def cube_recenter_dft_upsampling(array, center_fr1=None, negative=False,
 
 
 def _shift_dft(array_rec, array, frnum, upsample_factor, mask, interpolation, 
-               imlib):
+               imlib, border_mode):
     """
     function used in recenter_dft_unsampling
     """
@@ -1003,7 +1030,8 @@ def _shift_dft(array_rec, array, frnum, upsample_factor, mask, interpolation,
                              upsample_factor=upsample_factor)
     y_i, x_i = shift_yx
     array_rec_i = frame_shift(array[frnum], shift_y=y_i, shift_x=x_i,
-                              imlib=imlib, interpolation=interpolation)
+                              imlib=imlib, interpolation=interpolation,
+                              border_mode=border_mode)
     return y_i, x_i, array_rec_i    
 
 
@@ -1011,8 +1039,9 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
                         nproc=1, imlib='vip-fft', interpolation='lanczos4',
                         offset=None, negative=False, threshold=False, 
                         sigfactor=2, fix_neg=False, params_2g=None, 
-                        save_shifts=False, full_output=False, verbose=True, 
-                        debug=False, plot=True):
+                        border_mode='reflect', save_shifts=False, 
+                        full_output=False, verbose=True, debug=False, 
+                        plot=True):
     """ Recenters the frames of a cube. The shifts are found by fitting a 2d
     Gaussian or Moffat to a subimage centered at ``xy``. This assumes the frames
     don't have too large shifts (>5px). The frames are shifted using the
@@ -1073,6 +1102,14 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
     sigfactor: float, optional
         If thresholding is performed, set the the threshold in terms of 
         gaussian sigma in the subimage (will depend on your cropping size).
+    border_mode : {'reflect', 'nearest', 'constant', 'mirror', 'wrap'}
+        Points outside the boundaries of the input are filled accordingly.
+        With 'reflect', the input is extended by reflecting about the edge of
+        the last pixel. With 'nearest', the input is extended by replicating the
+        last pixel. With 'constant', the input is extended by filling all values
+        beyond the edge with zeros. With 'mirror', the input is extended by
+        reflecting about the center of the last pixel. With 'wrap', the input is
+        extended by wrapping around to the opposite edge. Default is 'reflect'.
     save_shifts : bool, optional
         Whether to save the shifts to a file in disk.
     full_output : bool, optional
@@ -1198,20 +1235,13 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
             print("\nShifts in X and Y")
             print(x[i], y[i])
         array_rec[i] = frame_shift(array[i], y[i], x[i], imlib=imlib,
-                                          interpolation=interpolation)
+                                          interpolation=interpolation,
+                                          border_mode=border_mode)
 
     if verbose:
         timing(start_time)
 
     if plot:
-        plt.figure(figsize=vip_figsize)
-        plt.plot(y, 'o-', label='shifts in y', alpha=0.5)
-        plt.plot(x, 'o-', label='shifts in x', alpha=0.5)
-        plt.legend(loc='best')
-        plt.grid('on', alpha=0.2)
-        plt.ylabel('Pixels')
-        plt.xlabel('Frame number')
-
         plt.figure(figsize=vip_figsize)
         b = int(np.sqrt(n_frames))
         la = 'Histogram'
@@ -1225,6 +1255,14 @@ def cube_recenter_2dfit(array, xy=None, fwhm=4, subi_size=5, model='gauss',
         plt.legend(loc='best')
         plt.ylabel('Bin counts')
         plt.xlabel('Pixels')
+
+        plt.figure(figsize=vip_figsize)
+        plt.plot(y, 'o-', label='shifts in y', alpha=0.5)
+        plt.plot(x, 'o-', label='shifts in x', alpha=0.5)
+        plt.legend(loc='best')
+        plt.grid('on', alpha=0.2)
+        plt.ylabel('Pixels')
+        plt.xlabel('Frame number')
 
     if save_shifts:
         np.savetxt('recent_gauss_shifts.txt', np.transpose([y, x]), fmt='%f')
@@ -1341,8 +1379,8 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
                                fwhm=4, debug=False, recenter_median=False,
                                fit_type='gaus', negative=True, crop=True,
                                subframesize=21, mask=None, imlib='vip-fft', 
-                               interpolation='lanczos4', plot=True, 
-                               full_output=False):
+                               interpolation='lanczos4', border_mode='reflect',
+                               plot=True, full_output=False):
     """ Registers frames based on the median speckle pattern. Optionally centers
     based on the position of the vortex null in the median frame. Images are
     filtered to isolate speckle spatial frequencies.
@@ -1388,6 +1426,14 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
         Image processing library to use.
     interpolation : str, optional
         Interpolation method to use.
+    border_mode : {'reflect', 'nearest', 'constant', 'mirror', 'wrap'}
+        Points outside the boundaries of the input are filled accordingly.
+        With 'reflect', the input is extended by reflecting about the edge of
+        the last pixel. With 'nearest', the input is extended by replicating the
+        last pixel. With 'constant', the input is extended by filling all values
+        beyond the edge with zeros. With 'mirror', the input is extended by
+        reflecting about the center of the last pixel. With 'wrap', the input is
+        extended by wrapping around to the opposite edge. Default is 'reflect'.
     plot : bool, optional
         If True, the shifts are plotted.
     full_ouput: bool, optional
@@ -1517,7 +1563,8 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
             
             alignment_cube[0] = frame_shift(alignment_cube[0, :, :], yshift,
                                             xshift, imlib=imlib,
-                                            interpolation=interpolation)
+                                            interpolation=interpolation,
+                                            border_mode=border_mode)
 
         # center the cube with stretched values
         cube_stret = np.log10((np.abs(alignment_cube) + 1) ** gammaval)
@@ -1537,7 +1584,8 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
         for j in range(1, n_frames):
             alignment_cube[j] = frame_shift(alignment_cube[j], y_shift[j],
                                             x_shift[j], imlib=imlib,
-                                            interpolation=interpolation)
+                                            interpolation=interpolation,
+                                            border_mode=border_mode)
 
         cum_y_shifts += y_shift
         cum_x_shifts += x_shift
@@ -1548,7 +1596,8 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
     for i in range(n):
         cube_reg_sci[i] = frame_shift(cube_sci[i], cum_y_shifts_sci[i],
                                       cum_x_shifts_sci[i], imlib=imlib,
-                                      interpolation=interpolation)
+                                      interpolation=interpolation,
+                                      border_mode=border_mode)
 
     if plot:
         plt.figure(figsize=vip_figsize)
@@ -1575,7 +1624,8 @@ def cube_recenter_via_speckles(cube_sci, cube_ref=None, alignment_iter=5,
         for i in range(nref):
             cube_reg_ref[i] = frame_shift(cube_ref[i], cum_y_shifts_ref[i],
                                           cum_x_shifts_ref[i], imlib=imlib,
-                                          interpolation=interpolation)
+                                          interpolation=interpolation,
+                                          border_mode=border_mode)
 
     if ref_star:
         if full_output:

--- a/vip_hci/preproc/rescaling.py
+++ b/vip_hci/preproc/rescaling.py
@@ -761,7 +761,7 @@ def find_scal_vector(cube, lbdas, fluxes, mask=None, nfp=2, fm="stddev",
             flux_fac = flux_scal
         else:
             p_ini = (scal_vec_ini[z],flux_scal)
-            solu = minimize(_chisquare_scal_2fp, p_ini, args=(cube_tmp, mask, fm),
+            solu = minimize(_chisquare_scal_2fp, p_ini, args=(cube_tmp,mask,fm),
                             method='Nelder-Mead', options=simplex_options, 
                             **kwargs)      
             scal_fac, flux_fac =  solu.x
@@ -845,11 +845,13 @@ def _find_indices_sdi(wl, dist, index_ref, fwhm, delta_sep=1, nframes=None,
 
 
 def _chisquare_scal(modelParameters, cube, flux_fac=1, mask=None, fm='sum'):
-    """
-    Calculate the reduced chi2:
-    \chi^2_r = \frac{1}{N-3}\sum_{j=1}^{N} |I_j|,
-    where N is the number of pixels within a circular aperture centered on the 
-    first estimate of the planet position, and I_j the j-th pixel intensity.
+    r"""
+    Calculate the reduced math:`\chi^2`:
+    .. math:: \chi^2_r = \frac{1}{N-3}\sum_{j=1}^{N} |I_j|,
+    where N is the number of pixels in the image (or mask if provided), and 
+    :math:`I_j` the j-th pixel intensity, considering one free parameter: the 
+    physical scaling factor between images of the cube, for a given
+    input flux scaling factor.
     
     Parameters
     ----------    
@@ -857,6 +859,8 @@ def _chisquare_scal(modelParameters, cube, flux_fac=1, mask=None, fm='sum'):
         The model parameters, typically (scal_fac, flux_fac).
     cube: numpy.array
         The cube of fits images expressed as a numpy.array.
+    flux_fac:     
+        
     mask: 2D-array, opt
         Binary mask, with ones where the residual intensities should be 
         evaluated. If None is provided, the whole field is used.
@@ -895,11 +899,12 @@ def _chisquare_scal(modelParameters, cube, flux_fac=1, mask=None, fm='sum'):
     return chi
 
 def _chisquare_scal_2fp(modelParameters, cube, mask=None, fm='sum'):
-    """
-    Calculate the reduced chi2:
-    \chi^2_r = \frac{1}{N-3}\sum_{j=1}^{N} |I_j|,
+    r"""
+    Calculate the reduced :math:`\chi^2`:
+    .. math:: \chi^2_r = \frac{1}{N-3}\sum_{j=1}^{N} |I_j|,
     where N is the number of pixels within a circular aperture centered on the 
-    first estimate of the planet position, and I_j the j-th pixel intensity.
+    first estimate of the planet position, and :math:`I_j` the j-th pixel 
+    intensity. Two free parameters: physical and flux scaling factors.
     
     Parameters
     ----------    

--- a/vip_hci/preproc/rescaling.py
+++ b/vip_hci/preproc/rescaling.py
@@ -979,7 +979,7 @@ def scale_fft(array, scale, ori_dim=False):
     dim = array.shape[0] # even square
     dtype = array.dtype.kind
 
-    kd_array = np.arange(dim/2 + 1, dtype=np.int)
+    kd_array = np.arange(dim/2 + 1, dtype=int)
     
     # scaling factor chosen as *close* as possible to N''/N', where: 
     #   N' = N + 2*KD (N': dim after FT)
@@ -988,11 +988,11 @@ def scale_fft(array, scale, ori_dim=False):
     #   => KF = (N"-N)/2 = round(N'*sc/2 - N/2) 
     #         = round(N/2*(sc-1) + KD*sc)
     # We call yy=N/2*(sc-1) +KD*sc   
-    yy = dim/2 * (scale - 1) + kd_array.astype(np.float)*scale
+    yy = dim/2 * (scale - 1) + kd_array.astype(float)*scale
     
     # We minimize the difference between the `ideal' N" and its closest 
     # integer value by minimizing |yy-int(yy)|.
-    kf_array = np.round(yy).astype(np.int)
+    kf_array = np.round(yy).astype(int)
     tmp = np.abs(yy-kf_array)
     imin = np.nanargmin(tmp)
 

--- a/vip_hci/psfsub/pca_local.py
+++ b/vip_hci/psfsub/pca_local.py
@@ -134,9 +134,8 @@ def pca_annular(cube, angle_list, cube_ref=None, scale_list=None, radius_int=0,
     min_frames_lib : int, optional
         Minimum number of frames in the PCA reference library.
     max_frames_lib : int, optional
-        Maximum number of frames in the PCA reference library for annuli beyond
-        10*FWHM. The more distant/decorrelated frames are removed from the
-        library.
+        Maximum number of frames in the PCA reference library. The more 
+        distant/decorrelated frames are removed from the library.
     tol : float, optional
         Stopping criterion for choosing the number of PCs when ``ncomp``
         is None. Lower values will lead to smaller residuals and more PCs.

--- a/vip_hci/stats/clip_sigma.py
+++ b/vip_hci/stats/clip_sigma.py
@@ -206,8 +206,9 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
     neighbor : bool, optional
         For clipping over the median of the contiguous pixels.
     num_neighbor : int, optional
-        The side of the square window around each pixel where the sigma and 
-        median are calculated. 
+        The side of the window around each pixel where the sigma and
+        median are calculated. If half_res_y, this is the horizontal side (the
+        vertical side will be twice smaller).
     mad : {False, True}, bool optional
         If True, the median absolute deviation will be used instead of the 
         standard deviation.
@@ -329,8 +330,9 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
         neighbor : bool optional
             For clipping over the median of the contiguous pixels.
         num_neighbor : int, optional
-            The side of the square window around each pixel where the sigma and 
-            median are calculated. 
+            The side of the window around each pixel where the sigma and
+            median are calculated. If half_res_y, this is the horizontal side (the
+            vertical side will be twice smaller).
         mad : bool, optional
             If True, the median absolute deviation will be used instead of the 
             standard deviation.

--- a/vip_hci/stats/clip_sigma.py
+++ b/vip_hci/stats/clip_sigma.py
@@ -274,9 +274,12 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
                                         x-hbox_l:x+hbox_r+1]
                         neighbours = sub_arr.flatten()
                         neigh_list = []
+                        remove_itself=True
                         for i in range(neighbours.shape[0]):
-                            neigh_list.append(neighbours[i])
-                        neigh_list.remove(array[y,x])
+                            if neighbours[i] == array[y,x] and remove_itself:
+                                remove_itself=False
+                            else:
+                                neigh_list.append(neighbours[i])
                         
                         neigh_arr = np.array(neigh_list)
                         median=np.median(neigh_arr)

--- a/vip_hci/stats/clip_sigma.py
+++ b/vip_hci/stats/clip_sigma.py
@@ -25,7 +25,7 @@ except ImportError:
 
 
 def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3, 
-                 verbose=False):
+                 half_res_y=False, verbose=False):
     """Sigma filtering of pixels in a 2d array.
     
     Parameters
@@ -36,11 +36,18 @@ def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
         Input array of the same size as frame_tmp, indicating the locations of
         bad/nan pixels by 1 (the rest of the array is set to 0)
     neighbor_box : int, optional
-        The side of the square window around each pixel where the sigma and
-        median are calculated.
+        The side of the window around each pixel where the sigma and
+        median are calculated. If half_res_y, this is the vertical side (the
+        horizontal side will be twice larger).
     min_neighbors : int, optional
         Minimum number of good neighboring pixels to be able to correct the
         bad/nan pixels
+    half_res_y: bool, optional
+        Whether the input data have every couple of 2 rows identical, i.e. there
+        is twice less angular resolution vertically than horizontally (e.g.
+        SINFONI data). 
+    verbose: bool, optional
+        Whether to print more information while running.
         
     Returns
     -------
@@ -51,7 +58,8 @@ def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
     if not no_numba:
         @njit
         def _sigma_filter_numba(frame_tmp, bpix_map, neighbor_box=3, 
-                                min_neighbors=3, verbose=False):
+                                min_neighbors=3, half_res_y=False, 
+                                verbose=False):
             if not frame_tmp.ndim == 2:
                 raise TypeError('Input array is not a frame or 2d array')
         
@@ -67,25 +75,29 @@ def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
                 gp = 1 - bp                         # temporary good pixel map
                 for n in range(nb):
                     #0/ Determine the box around each pixel
-                    half_box = int(np.floor(neighbor_box/2.))
-                    hbox_b = min(half_box,wb[0][n])        # half size of the box at
+                    half_box_y = int(np.floor(neighbor_box/2.))
+                    if half_res_y:
+                        half_box_x = int(np.floor(neighbor_box/2.))
+                    else:
+                        half_box_x = half_box_y
+                    hbox_b = min(half_box_y,wb[0][n])        # half size of the box at
                                                            # the bottom of the pixel
-                    hbox_t = min(half_box,sz_y-1-wb[0][n]) # half size of the box at 
+                    hbox_t = min(half_box_y,sz_y-1-wb[0][n]) # half size of the box at 
                                                            # the top of the pixel
-                    hbox_l = min(half_box,wb[1][n])        # half size of the box to 
+                    hbox_l = min(half_box_x,wb[1][n])        # half size of the box to 
                                                            # the left of the pixel
-                    hbox_r = min(half_box,sz_x-1-wb[1][n]) # half size of the box to 
+                    hbox_r = min(half_box_x,sz_x-1-wb[1][n]) # half size of the box to 
                                                            # the right of the pixel
                     # in case we are close to an edge, we want to extend the box
                     # in the direction opposite to the edge: 
                     if hbox_b<hbox_t: 
-                        hbox_t += half_box-hbox_b
+                        hbox_t += half_box_y-hbox_b
                     elif hbox_t<hbox_b: 
-                        hbox_b += half_box-hbox_t
+                        hbox_b += half_box_y-hbox_t
                     if hbox_l<hbox_r: 
-                        hbox_r += half_box-hbox_l
+                        hbox_r += half_box_x-hbox_l
                     elif hbox_r<hbox_l:
-                        hbox_l += half_box-hbox_r
+                        hbox_l += half_box_x-hbox_r
                     sgp = gp[(wb[0][n]-hbox_b):(wb[0][n]+hbox_t+1),
                              (wb[1][n]-hbox_l):(wb[1][n]+hbox_r+1)]
                     if int(np.sum(sgp)) >= min_neighbors:
@@ -107,8 +119,8 @@ def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
 
     # TODO: If possible, replace this function using
     # scipy.ndimage.filters.generic_filter and astropy.stats.sigma_clip
-    def _sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
-                     verbose=False):
+    def _sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3, 
+                      half_res_y=False, verbose=False):
         """Same description as wrapper function."""
         
         if frame_tmp.ndim != 2:
@@ -127,19 +139,23 @@ def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
             gp = 1 - bp                         # temporary good pixel map
             for n in range(nb):
                 #0/ Determine the box around each pixel
-                half_box = np.floor(neighbor_box/2)
-                hbox_b = min(half_box, wb[0][n])       # half size of the box at the
+                half_box_y = int(np.floor(neighbor_box/2.))
+                if half_res_y:
+                    half_box_x = int(np.floor(neighbor_box/2.))
+                else:
+                    half_box_x = half_box_y
+                hbox_b = min(half_box_y, wb[0][n])       # half size of the box at the
                                                        # bottom of the pixel
-                hbox_t = min(half_box, sz_y-1-wb[0][n])# half size of the box at the
+                hbox_t = min(half_box_y, sz_y-1-wb[0][n])# half size of the box at the
                                                        # top of the pixel
-                hbox_l = min(half_box, wb[1][n])       # half size of the box to the
+                hbox_l = min(half_box_x, wb[1][n])       # half size of the box to the
                                                        # left of the pixel
-                hbox_r = min(half_box, sz_x-1-wb[1][n])# half size of the box to the
+                hbox_r = min(half_box_x, sz_x-1-wb[1][n])# half size of the box to the
                                                        # right of the pixel
-                # but in case we are at an edge, we want to extend the box by one 
-                # row/column of pixels in the direction opposite to the edge to 
-                # have 9 px instead of 6: 
-                if half_box == 1:
+                # but in case we are at an edge with min size box, we want to 
+                # extend the box by one row/column of pixels in the direction 
+                # opposite to the edge: 
+                if half_box_y == 1:
                     if wb[0][n] == sz_y-1:
                         hbox_b = hbox_b+1
                     elif wb[0][n] == 0:
@@ -172,7 +188,7 @@ def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
 
 
 def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
-               num_neighbor=3, mad=False):
+               num_neighbor=3, mad=False, half_res_y=False):
     """Sigma clipping for detecting outlying values in 2d array. If the
     parameter 'neighbor' is True the clipping can be performed in a local patch
     around each pixel, whose size depends on 'neighbor' parameter.
@@ -198,6 +214,10 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
     min_std : float, optional
         Min standard deviation considered for the lower and upper sigma 
         conditions. Can be useful for frames with padded edges (e.g. SPHERE/IFS)
+    half_res_y: bool, optional
+        Whether the input data have every couple of 2 rows identical, i.e. there
+        is twice less angular resolution vertically than horizontally (e.g.
+        SINFONI data). 
         
     Returns
     -------
@@ -211,7 +231,8 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
     if not no_numba:
         @njit
         def _clip_array_numba(array, lower_sigma, upper_sigma, out_good=False, 
-                              neighbor=False, num_neighbor=3, mad=False): 
+                              neighbor=False, num_neighbor=3, mad=False,
+                              half_res_y=False): 
             if array.ndim != 2:
                 raise TypeError("Input array is not two dimensional (frame)\n")
                 
@@ -223,25 +244,30 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
                 for y in range(ny):
                     for x in range(nx):
                         #0/ Determine the box around each pixel
-                        half_box = int(np.floor(num_neighbor/2.))
-                        hbox_b = min(half_box,y)    # half size of the box at the
+                    #0/ Determine the box around each pixel
+                        half_box_y = int(np.floor(num_neighbor/2.))
+                        if half_res_y:
+                            half_box_x = int(np.floor(num_neighbor/2.))
+                        else:
+                            half_box_x = half_box_y
+                        hbox_b = min(half_box_y,y)    # half size of the box at the
                                                     # bottom of the pixel
-                        hbox_t = min(half_box,ny-y) # half size of the box at the
+                        hbox_t = min(half_box_y,ny-y) # half size of the box at the
                                                     # top of the pixel
-                        hbox_l = min(half_box,x)    # half size of the box to the
+                        hbox_l = min(half_box_x,x)    # half size of the box to the
                                                     # left of the pixel
-                        hbox_r = min(half_box,nx-x) # half size of the box to the
+                        hbox_r = min(half_box_x,nx-x) # half size of the box to the
                                                     # right of the pixel
                         # in case we are close to an edge, we want to extend the box
                         # in the direction opposite to the edge: 
                         if hbox_b<hbox_t: 
-                            hbox_t += half_box-hbox_b
+                            hbox_t += half_box_y-hbox_b
                         elif hbox_t<hbox_b: 
-                            hbox_b += half_box-hbox_t
+                            hbox_b += half_box_y-hbox_t
                         if hbox_l<hbox_r: 
-                            hbox_r += half_box-hbox_l
+                            hbox_r += half_box_x-hbox_l
                         elif hbox_r<hbox_l:
-                            hbox_l += half_box-hbox_r
+                            hbox_l += half_box_x-hbox_r
                             
                         sub_arr = array[y-hbox_b:y+hbox_t+1,
                                         x-hbox_l:x+hbox_r+1]
@@ -282,8 +308,10 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
                 return bad
             
     # TODO: If possible, replace this function using astropy.stats.sigma_clip
-    def _clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
-                    num_neighbor=3, mad=False):
+    def _clip_array(array, lower_sigma, upper_sigma, out_good=False, 
+                    neighbor=False, num_neighbor=3, mad=False, 
+                    half_res_y=False):
+        
         """Sigma clipping for detecting outlying values in 2d array. If the
         parameter 'neighbor' is True the clipping can be performed in a local patch
         around each pixel, whose size depends on 'neighbor' parameter.
@@ -306,6 +334,10 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
         mad : bool, optional
             If True, the median absolute deviation will be used instead of the 
             standard deviation.
+        half_res_y: bool, optional
+            Whether the input data have every couple of 2 rows identical, i.e. there
+            is twice less angular resolution vertically than horizontally (e.g.
+            SINFONI data). 
             
         Returns
         -------
@@ -320,15 +352,21 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
     
         values = array.copy()
         if neighbor and num_neighbor:
+            num_neighbor_y = num_neighbor
+            if half_res_y:
+                num_neighbor_x = int(2*num_neighbor)
+            else:
+                num_neighbor_x = num_neighbor
             median = generic_filter(array, function=np.median, 
-                                    size=(num_neighbor,num_neighbor), mode="mirror")
+                                    size=(num_neighbor_y,num_neighbor_x),
+                                    mode="mirror")
             if mad:
                 sigma = generic_filter(array, function=median_absolute_deviation,                                 
-                                       size=(num_neighbor,num_neighbor), 
+                                       size=(num_neighbor_y,num_neighbor_x), 
                                        mode="mirror")
             else:
                 sigma = generic_filter(array, function=np.std,                                 
-                                       size=(num_neighbor,num_neighbor), 
+                                       size=(num_neighbor_y,num_neighbor_x), 
                                        mode="mirror")
         else:
             median = np.median(values)
@@ -353,8 +391,9 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
     if no_numba:
         return _clip_array(array, lower_sigma, upper_sigma, out_good=out_good, 
                            neighbor=neighbor, num_neighbor=num_neighbor, 
-                           mad=mad)
+                           mad=mad, half_res_y=half_res_y)
     else:
         return _clip_array_numba(array, lower_sigma, upper_sigma, 
                                  out_good=out_good, neighbor=neighbor, 
-                                 num_neighbor=num_neighbor, mad=mad)
+                                 num_neighbor=num_neighbor, mad=mad, 
+                                 half_res_y=half_res_y)

--- a/vip_hci/stats/clip_sigma.py
+++ b/vip_hci/stats/clip_sigma.py
@@ -37,8 +37,8 @@ def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
         bad/nan pixels by 1 (the rest of the array is set to 0)
     neighbor_box : int, optional
         The side of the window around each pixel where the sigma and
-        median are calculated. If half_res_y, this is the vertical side (the
-        horizontal side will be twice larger).
+        median are calculated. If half_res_y, this is the horizontal side (the
+        vertical side will be twice smaller).
     min_neighbors : int, optional
         Minimum number of good neighboring pixels to be able to correct the
         bad/nan pixels
@@ -75,11 +75,11 @@ def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
                 gp = 1 - bp                         # temporary good pixel map
                 for n in range(nb):
                     #0/ Determine the box around each pixel
-                    half_box_y = int(np.floor(neighbor_box/2.))
+                    half_box_x = int(np.floor(neighbor_box/2.))
                     if half_res_y:
-                        half_box_x = int(np.floor(neighbor_box/2.))
+                        half_box_y = max(1,int(half_box_x/2))
                     else:
-                        half_box_x = half_box_y
+                        half_box_y = half_box_x
                     hbox_b = min(half_box_y,wb[0][n])        # half size of the box at
                                                            # the bottom of the pixel
                     hbox_t = min(half_box_y,sz_y-1-wb[0][n]) # half size of the box at 
@@ -139,11 +139,11 @@ def sigma_filter(frame_tmp, bpix_map, neighbor_box=3, min_neighbors=3,
             gp = 1 - bp                         # temporary good pixel map
             for n in range(nb):
                 #0/ Determine the box around each pixel
-                half_box_y = int(np.floor(neighbor_box/2.))
+                half_box_x = int(np.floor(neighbor_box/2.))
                 if half_res_y:
-                    half_box_x = int(np.floor(neighbor_box/2.))
+                    half_box_y = max(1,int(half_box_x/2))
                 else:
-                    half_box_x = half_box_y
+                    half_box_y = half_box_x
                 hbox_b = min(half_box_y, wb[0][n])       # half size of the box at the
                                                        # bottom of the pixel
                 hbox_t = min(half_box_y, sz_y-1-wb[0][n])# half size of the box at the
@@ -245,11 +245,11 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
                     for x in range(nx):
                         #0/ Determine the box around each pixel
                     #0/ Determine the box around each pixel
-                        half_box_y = int(np.floor(num_neighbor/2.))
+                        half_box_x = int(np.floor(num_neighbor/2.))
                         if half_res_y:
-                            half_box_x = int(np.floor(num_neighbor/2.))
+                            half_box_y = max(1,int(half_box_x/2))
                         else:
-                            half_box_x = half_box_y
+                            half_box_y = half_box_x
                         hbox_b = min(half_box_y,y)    # half size of the box at the
                                                     # bottom of the pixel
                         hbox_t = min(half_box_y,ny-y) # half size of the box at the
@@ -352,11 +352,11 @@ def clip_array(array, lower_sigma, upper_sigma, out_good=False, neighbor=False,
     
         values = array.copy()
         if neighbor and num_neighbor:
-            num_neighbor_y = num_neighbor
+            num_neighbor_x = num_neighbor
             if half_res_y:
-                num_neighbor_x = int(2*num_neighbor)
+                num_neighbor_y = max(int(num_neighbor/2),1)
             else:
-                num_neighbor_x = num_neighbor
+                num_neighbor_y = num_neighbor
             median = generic_filter(array, function=np.median, 
                                     size=(num_neighbor_y,num_neighbor_x),
                                     mode="mirror")

--- a/vip_hci/var/coords.py
+++ b/vip_hci/var/coords.py
@@ -188,11 +188,11 @@ def pol_to_cart(r, theta, r_err=0, theta_err=0, cx=0, cy=0,
 
 
 def pol_to_eq(r, t, rError=0, tError=0, astro_convention=False, plot=False):
-    """ 
-    Converts a position (r,t) given in polar coordinates into \delta RA and 
-    \delta DEC (equatorial coordinates), with error propagation. 
-    Note: regardless of the assumption on input angle t (see astro_convention),
-    the output RA is counted positive towards left.
+    r""" 
+    Converts a position (r,t) given in polar coordinates into :math:`\Delta` RA 
+    and :math:`\Delta` DEC (equatorial coordinates), with error propagation. 
+    Note: regardless of the assumption on input angle t (see description for
+    `astro_convention`), the output RA is counted positive towards left.
 
     Parameters
     ----------

--- a/vip_hci/var/filters.py
+++ b/vip_hci/var/filters.py
@@ -151,7 +151,7 @@ def ifft(array):
 
 def frame_filter_highpass(array, mode, median_size=5, kernel_size=5,
                           fwhm_size=5, btw_cutoff=0.2, btw_order=2,
-                          hann_cutoff=5, psf=None, gauss_mode='conv', 
+                          hann_cutoff=5, psf=None, conv_mode='conv', 
                           mask=None):
     """
     High-pass filtering of input frame depending on parameter ``mode``.
@@ -198,7 +198,7 @@ def frame_filter_highpass(array, mode, median_size=5, kernel_size=5,
     psf: numpy ndarray, optional
         Input normalised and centered psf, 2d frame. Should be provided if 
         mode is set to 'psf'.
-    gauss_mode : {'conv', 'convfft'}, str optional
+    conv_mode : {'conv', 'convfft'}, str optional
         'conv' uses the multidimensional gaussian filter from scipy.ndimage and
         'convfft' uses the fft convolution with a 2d Gaussian kernel.
     mask: numpy ndarray, optional
@@ -331,7 +331,7 @@ def frame_filter_highpass(array, mode, median_size=5, kernel_size=5,
     elif mode == 'gauss-subt':
         # Subtracting the low_pass filtered (median) image from the image itself
         gaussed = frame_filter_lowpass(array, 'gauss', fwhm_size=fwhm_size,
-                                       gauss_mode=gauss_mode, mask=mask)
+                                       conv_mode=conv_mode, mask=mask)
         filtered = array - gaussed
 
     elif mode == 'psf-subt':
@@ -506,7 +506,7 @@ def frame_filter_lowpass(array, mode='gauss', median_size=5, fwhm_size=5,
 
 
 def cube_filter_lowpass(array, mode='gauss', median_size=5, fwhm_size=5,
-                        gauss_mode='conv', kernel_sz=None, verbose=True, 
+                        conv_mode='conv', kernel_sz=None, verbose=True, 
                         psf=None, mask=None, iterate=True, **kwargs):
     """
     Apply ``frame_filter_lowpass`` to the frames of a 3d or 4d cube.
@@ -521,7 +521,7 @@ def cube_filter_lowpass(array, mode='gauss', median_size=5, fwhm_size=5,
         See the documentation of the ``frame_filter_lowpass`` function.
     fwhm_size : float, optional
         See the documentation of the ``frame_filter_lowpass`` function.
-    gauss_mode : str, optional
+    conv_mode : str, optional
         See the documentation of the ``frame_filter_lowpass`` function.
     kernel_sz: int, optional
         See the documentation of the ``frame_filter_lowpass`` function.
@@ -554,7 +554,7 @@ def cube_filter_lowpass(array, mode='gauss', median_size=5, fwhm_size=5,
     if array.ndim == 3:
         for i in Progressbar(range(array.shape[0]), verbose=verbose):
             array_out[i] = frame_filter_lowpass(array[i], mode, median_size,
-                                                fwhm_size, gauss_mode, 
+                                                fwhm_size, conv_mode, 
                                                 kernel_sz, psf, mask, iterate, 
                                                 **kwargs)
     elif array.ndim == 4:
@@ -562,7 +562,7 @@ def cube_filter_lowpass(array, mode='gauss', median_size=5, fwhm_size=5,
             for lam in range(array.shape[0]):
                 array_out[lam][i] = frame_filter_lowpass(array[lam][i], mode,
                                                          median_size, fwhm_size,
-                                                         gauss_mode, kernel_sz, 
+                                                         conv_mode, kernel_sz, 
                                                          psf, mask, iterate, 
                                                          **kwargs)
     else:

--- a/vip_hci/var/fit_2d.py
+++ b/vip_hci/var/fit_2d.py
@@ -14,7 +14,12 @@ __all__ = ['create_synth_psf',
 
 import numpy as np
 import pandas as pd
-import photutils
+try:
+    # for photutils version >= '0.3' use photutils.centroids.centroid_com
+    from photutils.centroids import centroid_com as cen_com
+except:
+    # for photutils version < '0.3' use photutils.centroid_com
+    import photutils.centroid_com as cen_com
 from hciplot import plot_frames
 from astropy.modeling import models, fitting
 from astropy.stats import (gaussian_sigma_to_fwhm, gaussian_fwhm_to_sigma,
@@ -216,7 +221,7 @@ def fit_2dgaussian(array, crop=False, cent=None, cropsize=15, fwhmx=4, fwhmy=4,
 
     # Creating the 2D Gaussian model
     init_amplitude = np.ptp(psf_subimage)
-    xcom, ycom = photutils.centroid_com(psf_subimage)
+    xcom, ycom = cen_com(psf_subimage)
     gauss = models.Gaussian2D(amplitude=init_amplitude, theta=theta,
                               x_mean=xcom, y_mean=ycom,
                               x_stddev=fwhmx * gaussian_fwhm_to_sigma,
@@ -350,7 +355,7 @@ def fit_2dmoffat(array, crop=False, cent=None, cropsize=15, fwhm=4,
 
     # Creating the 2D Moffat model
     init_amplitude = np.ptp(psf_subimage)
-    xcom, ycom = photutils.centroid_com(psf_subimage)
+    xcom, ycom = cen_com(psf_subimage)
     moffat = models.Moffat2D(amplitude=init_amplitude, x_0=xcom, y_0=ycom,
                              gamma=fwhm / 2., alpha=1)
     # Levenberg-Marquardt algorithm
@@ -479,7 +484,7 @@ def fit_2dairydisk(array, crop=False, cent=None, cropsize=15, fwhm=4,
 
     # Creating the 2d Airy disk model
     init_amplitude = np.ptp(psf_subimage)
-    xcom, ycom = photutils.centroid_com(psf_subimage)
+    xcom, ycom = cen_com(psf_subimage)
     diam_1st_zero = (fwhm * 2.44) / 1.028
     airy = models.AiryDisk2D(amplitude=init_amplitude, x_0=xcom, y_0=ycom,
                              radius=diam_1st_zero/2.)
@@ -652,7 +657,7 @@ def fit_2d2gaussian(array, crop=False, cent=None, cropsize=15, fwhm_neg=4,
 
     # Creating the 2D Gaussian model
     init_amplitude = np.ptp(psf_subimage)
-    #xcom, ycom = photutils.centroid_com(psf_subimage)
+    #xcom, ycom = cen_com(psf_subimage)
     ycom, xcom = frame_center(psf_subimage)
     fix_dico_pos = {'theta':True}
     bounds_dico_pos = {'amplitude':[0.8*init_amplitude,1.2*init_amplitude],


### PR DESCRIPTION
- New bad pixel correction algorithm based on kernel-interpolation;
- Updated `write_fits` to also allow for multiple-extension fits files to be written;
- Added border_mode option to all recentering functions;
- `half_res_y` option added to sigma clipping algorithms (i.e. adapted to some image-slicer IFUs);
- Photutils and numpy deprecation warning fixes;
- Routine descriptions adapted for compatibility with sphinx documentation;
- Updated matplotlib version requirement to avoid bug with the latest mpl version (as of 02/2022);
- Default start method for multiprocessing set manually to 'fork', since it was changed to 'spawn' as default starting from python 3.8 (leading to bugs in all routines using multiprocessing);
- Updated default flux range explored by grid search negfc.