### PR TITLE
Depreciation issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,22 @@ def resource(*args):
 
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
 reqs = parse_requirements(resource('requirements.txt'), session=PipSession)
-requirements = [str(ir.requirement) for ir in reqs]    
+
+try:
+    requirements = [str(ir.requirement) for ir in reqs]
+except:
+    requirements = [str(ir.req) for ir in reqs]
+
+##requirements = [str(ir.requirement) for ir in reqs]    
 
 reqs_dev = parse_requirements(resource('requirements-dev.txt'), 
                               session=PipSession)
-requirements_dev = [str(ir.requirement) for ir in reqs_dev]    
+##requirements_dev = [str(ir.requirement) for ir in reqs_dev]    
+
+try:
+    requirements_dev = [str(ir.requirement) for ir in reqs_dev]
+except:
+    requirements_dev = [str(ir.req) for ir in reqs_dev]
 
 with open(resource('README.rst')) as readme_file:
     README = readme_file.read()

--- a/setup.py
+++ b/setup.py
@@ -46,18 +46,13 @@ def resource(*args):
 
 # parse_requirements() returns generator of pip.req.InstallRequirement objects
 reqs = parse_requirements(resource('requirements.txt'), session=PipSession)
-
 try:
     requirements = [str(ir.requirement) for ir in reqs]
 except:
     requirements = [str(ir.req) for ir in reqs]
 
-##requirements = [str(ir.requirement) for ir in reqs]    
-
 reqs_dev = parse_requirements(resource('requirements-dev.txt'), 
                               session=PipSession)
-##requirements_dev = [str(ir.requirement) for ir in reqs_dev]    
-
 try:
     requirements_dev = [str(ir.requirement) for ir in reqs_dev]
 except:

--- a/vip_hci/preproc/recentering.py
+++ b/vip_hci/preproc/recentering.py
@@ -1232,7 +1232,7 @@ def cube_recenter_dft_upsampling(array, center_fr1=None, negative=False,
         res = pool_map(nproc, _shift_dft, array_rec, array,
                        iterable(range(1, n_frames)), upsample_factor, mask,
                        interpolation, imlib, border_mode)
-        res = np.array(res)
+        res = np.array(res, dtype=object)
 
         y[1:] = res[:, 0]
         x[1:] = res[:, 1]


### PR DESCRIPTION
One issue on setup.py similar to : 
https://stackoverflow.com/questions/62114945/attributeerror-parsedrequirement-object-has-no-attribute-req

And a depreciation issue on recentering.py due to inhomogeneous array unsupported by np.array without specifications.
This was causing a bug on  notebook https://github.com/vortex-exoplanet/VIP_extras/blob/master/tutorials/02_preproc.ipynb
On the 2.1.3 and 2.1.4 sections.