### PR TITLE
Remove strenum optional dependancy

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,4 @@ flake8
 flake8-bandit
 flake8-docstrings
 autopep8
-StrEnum
 ratelimit

--- a/vip_hci/invprob/andromeda.py
+++ b/vip_hci/invprob/andromeda.py
@@ -24,7 +24,8 @@ __all__ = ["andromeda", "AndroParams"]
 
 import numpy as np
 from dataclasses import dataclass
-from strenum import LowercaseStrEnum as LowEnum
+from enum import Enum
+
 from typing import Union
 
 from ..var.filters import frame_filter_highpass, cube_filter_highpass
@@ -155,7 +156,7 @@ class AndroParams:
     min_sep: float = 0.5
     annuli_width: float = 1.0
     roa: float = 2
-    opt_method: LowEnum = OptMethod.LSQ
+    opt_method: Enum = OptMethod.LSQ
     nsmooth_snr: int = 18
     iwa: float = None
     owa: float = None

--- a/vip_hci/invprob/fmmf.py
+++ b/vip_hci/invprob/fmmf.py
@@ -61,7 +61,7 @@ from multiprocessing import cpu_count
 from dataclasses import dataclass, field
 import numpy as np
 import numpy.linalg as la
-from strenum import LowercaseStrEnum as LowEnum
+from enum import Enum
 from skimage.draw import disk
 from ..var import get_annulus_segments, frame_center
 from ..preproc import frame_crop, cube_crop_frames, cube_derotate
@@ -106,7 +106,7 @@ class FMMFParams:
     model: string, optional
         Selected PSF-subtraction technique for the computation of the FMMF
         detection map. FMMF work either with KLIP or LOCI. Default is 'KLIP'.
-    var: LowerCaseStrEnum, see `vip_hci.var.paramenum.VarEstim`
+    var: Enum, see `vip_hci.var.paramenum.VarEstim`
         Model used for the residual noise variance estimation used in the
         matched filtering (maximum likelihood estimation of the flux and SNR).
     param: dict, optional
@@ -126,10 +126,10 @@ class FMMFParams:
     crop: int, optional
         Part of the PSF template considered in the estimation of the FMMF
         detection map. Default is 5.
-    imlib : LowerCaseStrEnum, see `vip_hci.var.paramenum.Imlib`
+    imlib : Enum, see `vip_hci.var.paramenum.Imlib`
         Parameter used for the derotation of the residual cube. See the
         documentation of the ``vip_hci.preproc.frame_rotate`` function.
-    interpolation : LowerCaseStrEnum, see `vip_hci.var.paramenum.Interpolation`
+    interpolation : Enum, see `vip_hci.var.paramenum.Interpolation`
         Parameter used for the derotation of the residual cube. See the
         documentation of the ``vip_hci.preproc.frame_rotate`` function.
     nproc : int or None, optional
@@ -148,13 +148,13 @@ class FMMFParams:
     min_r: int = None
     max_r: int = None
     model: str = "KLIP"
-    var: LowEnum = VarEstim.FR
+    var: Enum = VarEstim.FR
     param: dict = field(
         default_factory=lambda: {"ncomp": 20, "tolerance": 5e-3, "delta_rot": 0.5}
     )
     crop: int = 5
-    imlib: LowEnum = Imlib.VIPFFT
-    interpolation: LowEnum = Interpolation.LANCZOS4
+    imlib: Enum = Imlib.VIPFFT
+    interpolation: Enum = Interpolation.LANCZOS4
     nproc: int = 1
     verbose: bool = True
 

--- a/vip_hci/objects/pppca.py
+++ b/vip_hci/objects/pppca.py
@@ -160,7 +160,7 @@ class PPPCA(PostProc, PCAParams, PCAAnnParams):
 
         Parameters
         ----------
-        runmode : LowerCaseStrEnum, see ``vip_hci.var.paramenum.Runmode``
+        runmode : Enum, see ``vip_hci.var.paramenum.Runmode``
             Mode of execution for the PCA.
         dataset : Dataset, optional
             Dataset to process. If not provided, ``self.dataset`` is used (as

--- a/vip_hci/psfsub/framediff.py
+++ b/vip_hci/psfsub/framediff.py
@@ -9,7 +9,7 @@ import pandas as pn
 from hciplot import plot_frames
 from multiprocessing import cpu_count
 from dataclasses import dataclass
-from strenum import LowercaseStrEnum as LowEnum
+from enum import Enum
 from sklearn.metrics import pairwise_distances
 from ..var import get_annulus_segments
 from ..var.object_utils import setup_parameters, separate_kwargs_dict
@@ -77,16 +77,16 @@ class FrameDiffParams:
     cube: np.ndarray = None
     angle_list: np.ndarray = None
     fwhm: float = 4
-    metric: LowEnum = Metric.MANHATTAN
+    metric: Enum = Metric.MANHATTAN
     dist_threshold: int = 50
     n_similar: int = None
     delta_rot: int = 0.5
     radius_int: int = 2
     asize: int = 4
     ncomp: int = None
-    imlib: LowEnum = Imlib.VIPFFT
-    interpolation: LowEnum = Interpolation.LANCZOS4
-    collapse: LowEnum = Collapse.MEDIAN
+    imlib: Enum = Imlib.VIPFFT
+    interpolation: Enum = Interpolation.LANCZOS4
+    collapse: Enum = Collapse.MEDIAN
     nproc: int = 1
     verbose: bool = True
     debug: bool = False

--- a/vip_hci/psfsub/llsg.py
+++ b/vip_hci/psfsub/llsg.py
@@ -22,7 +22,7 @@ from scipy.linalg import qr
 from multiprocessing import cpu_count
 from astropy.stats import median_absolute_deviation
 from dataclasses import dataclass
-from strenum import LowercaseStrEnum as LowEnum
+
 from ..config import time_ini, timing
 from ..preproc import cube_derotate, cube_collapse
 from ..var import get_annulus_segments, cube_filter_highpass
@@ -54,9 +54,9 @@ class LLSGParams:
     low_rank_ref :
         If True the first estimation of the L component is obtained from the
         remaining segments in the same annulus.
-    low_rank_mode : LowerCaseStrEnum, see `vip_hci.var.paramenum.LowRankMode`
+    low_rank_mode : Enum, see `vip_hci.var.paramenum.LowRankMode`
         Sets the method of solving the L update.
-    auto_rank_mode : LowerCaseStrEnum, see `vip_hci.var.paramenum.AutoRankMode`
+    auto_rank_mode : Enum, see `vip_hci.var.paramenum.AutoRankMode`
         If ``rank`` is None, then ``auto_rank_mode`` sets the way that the
         ``rank`` is determined: the noise minimization or the cumulative
         explained variance ratio (when 'svd' is used).
@@ -66,7 +66,7 @@ class LLSGParams:
     cevr : float, optional
         Float value in the range [0,1] for selecting the cumulative explained
         variance ratio to choose the rank automatically (if ``rank`` is None).
-    thresh_mode : LowerCaseStrEnum, see `vip_hci.var.paramenum.ThreshMode`
+    thresh_mode : Enum, see `vip_hci.var.paramenum.ThreshMode`
         Sets the type of thresholding.
     nproc : None or int, optional
         Number of processes for parallel computing. If None the number of
@@ -91,7 +91,7 @@ class LLSGParams:
         first with the mode ``median-subt`` and a large window, and then with
         ``laplacian-conv`` and a kernel size equal to ``high_pass``. 5 is an
         optimal value when ``fwhm`` is ~4.
-    collapse : LowerCaseStrEnum, see `vip_hci.var.paramenum.Collapse`
+    collapse : Enum, see `vip_hci.var.paramenum.Collapse`
         Sets the way of collapsing the frames for producing a final image.
     full_output: bool, optional
         Whether to return the final median combined image only or with other
@@ -109,11 +109,11 @@ class LLSGParams:
     thresh: float = 1
     max_iter: int = 10
     low_rank_ref: bool = False
-    low_rank_mode: LowEnum = LowRankMode.SVD
-    auto_rank_mode: LowEnum = AutoRankMode.NOISE
+    low_rank_mode: Enum = LowRankMode.SVD
+    auto_rank_mode: Enum = AutoRankMode.NOISE
     residuals_tol: float = 1e-1
     cevr: float = 0.9
-    thresh_mode: LowEnum = ThreshMode.SOFT
+    thresh_mode: Enum = ThreshMode.SOFT
     nproc: int = 1
     asize: int = None
     n_segments: int = 4
@@ -121,7 +121,7 @@ class LLSGParams:
     radius_int: int = None
     random_seed: int = None
     high_pass: int = None
-    collapse: LowEnum = Collapse.MEDIAN
+    collapse: Enum = Collapse.MEDIAN
     full_output: bool = False
     verbose: bool = True
     debug: bool = False

--- a/vip_hci/psfsub/llsg.py
+++ b/vip_hci/psfsub/llsg.py
@@ -22,7 +22,7 @@ from scipy.linalg import qr
 from multiprocessing import cpu_count
 from astropy.stats import median_absolute_deviation
 from dataclasses import dataclass
-
+from enum import Enum
 from ..config import time_ini, timing
 from ..preproc import cube_derotate, cube_collapse
 from ..var import get_annulus_segments, cube_filter_highpass

--- a/vip_hci/psfsub/loci.py
+++ b/vip_hci/psfsub/loci.py
@@ -22,7 +22,7 @@ import pandas as pn
 from multiprocessing import cpu_count
 from sklearn.metrics import pairwise_distances
 from dataclasses import dataclass
-from strenum import LowercaseStrEnum as LowEnum
+from enum import Enum
 from typing import Tuple, Union
 from ..var import get_annulus_segments
 from ..var.object_utils import setup_parameters, separate_kwargs_dict
@@ -55,7 +55,7 @@ class LOCIParams:
         e.g. with ``vip_hci.preproc.find_scal_vector``).
     fwhm : float, optional
         Size of the FHWM in pixels. Default is 4.
-    metric : LowerCaseStrEnum, see `vip_hci.var.paramenum.Metric`
+    metric : Enum, see `vip_hci.var.paramenum.Metric`
         Distance metric to be used ('cityblock', 'cosine', 'euclidean', 'l1',
         'l2', 'manhattan', 'correlation', etc). It uses the scikit-learn
         function ``sklearn.metrics.pairwise.pairwise_distances`` (check its
@@ -87,7 +87,7 @@ class LOCIParams:
         Number of processes for parallel computing. If None the number of
         processes will be set to cpu_count()/2. By default the algorithm works
         in single-process mode.
-    solver : LowerCaseStrEnum, see `vip_hci.var.paramenum.Solver`
+    solver : Enum, see `vip_hci.var.paramenum.Solver`
         Choosing the solver of the least squares problem. ``lstsq`` uses the
         standard scipy least squares solver. ``nnls`` uses the scipy
         non-negative least-squares solver.
@@ -102,7 +102,7 @@ class LOCIParams:
         similar to LOCI. The optimization segments share the same inner radius,
         mean angular position and angular width as their corresponding
         subtraction segments.
-    adimsdi : LowerCaseStrEnum, see `vip_hci.var.paramenum.Adimsdi`
+    adimsdi : Enum, see `vip_hci.var.paramenum.Adimsdi`
         Changes the way the 4d cubes (ADI+mSDI) are processed.
 
         ``skipadi``: the multi-spectral frames are rescaled wrt the largest
@@ -113,11 +113,11 @@ class LOCIParams:
         (as in the ``skipadi`` case). Then the residuals are processed again in
         an ADI fashion.
 
-    imlib : LowerCaseStrEnum, see `vip_hci.var.paramenum.Imlib`
+    imlib : Enum, see `vip_hci.var.paramenum.Imlib`
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
-    interpolation : LowerCaseStrEnum, see `vip_hci.var.paramenum.Interpolation`
+    interpolation : Enum, see `vip_hci.var.paramenum.Interpolation`
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
-    collapse : LowerCaseStrEnum, see `vip_hci.var.paramenum.Collapse`
+    collapse : Enum, see `vip_hci.var.paramenum.Collapse`
         Sets the way of collapsing the frames for producing a final image.
     verbose: bool, optional
         If True prints info to stdout.
@@ -130,7 +130,7 @@ class LOCIParams:
     angle_list: np.ndarray = None
     scale_list: np.ndarray = None
     fwhm: float = 4
-    metric: LowEnum = Metric.MANHATTAN
+    metric: Enum = Metric.MANHATTAN
     dist_threshold: int = 100
     delta_rot: Union[float, Tuple[float]] = (0.1, 1)
     delta_sep: Union[float, Tuple[float]] = (0.1, 1)
@@ -138,13 +138,13 @@ class LOCIParams:
     asize: int = 4
     n_segments: int = 4
     nproc: int = 1
-    solver: LowEnum = Solver.LSTSQ
+    solver: Enum = Solver.LSTSQ
     tol: float = 1e-2
     optim_scale_fact: float = 2
-    adimsdi: LowEnum = Adimsdi.SKIPADI
-    imlib: LowEnum = Imlib.VIPFFT
-    interpolation: LowEnum = Interpolation.LANCZOS4
-    collapse: LowEnum = Collapse.MEDIAN
+    adimsdi: Enum = Adimsdi.SKIPADI
+    imlib: Enum = Imlib.VIPFFT
+    interpolation: Enum = Interpolation.LANCZOS4
+    collapse: Enum = Collapse.MEDIAN
     verbose: bool = True
     full_output: bool = False
 

--- a/vip_hci/psfsub/medsub.py
+++ b/vip_hci/psfsub/medsub.py
@@ -36,8 +36,8 @@ __all__ = ["median_sub", "MedsubParams"]
 import numpy as np
 from multiprocessing import cpu_count
 from dataclasses import dataclass
+from enum import Enum
 from typing import Tuple, Union
-from strenum import LowercaseStrEnum as LowEnum
 from ..config import time_ini, timing
 from ..var import get_annulus_segments, mask_circle
 from ..var.paramenum import Imlib, Interpolation, Collapse
@@ -102,11 +102,11 @@ class MedsubParams:
     sdi_only: bool, optional
         In the case of IFS data (ADI+SDI), whether to perform median-SDI, or
         median-ASDI (default).
-    imlib : LowerCaseStrEnum, see `vip_hci.var.paramenum.Imlib`
+    imlib : Enum, see `vip_hci.var.paramenum.Imlib`
         See the documentation of ``vip_hci.preproc.frame_rotate``.
-    interpolation : LowerCaseStrEnum, see `vip_hci.var.paramenum.Interpolation`
+    interpolation : Enum, see `vip_hci.var.paramenum.Interpolation`
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
-    collapse : LowerCaseStrEnum, see `vip_hci.var.paramenum.Collapse`
+    collapse : Enum, see `vip_hci.var.paramenum.Collapse`
         Sets how temporal residual frames should be combined to produce an
         ADI image.
     nproc : None or int, optional
@@ -132,9 +132,9 @@ class MedsubParams:
     mode: str = "fullfr"
     nframes: int = 4
     sdi_only: bool = False
-    imlib: LowEnum = Imlib.VIPFFT
-    interpolation: LowEnum = Interpolation.LANCZOS4
-    collapse: LowEnum = Collapse.MEDIAN
+    imlib: Enum = Imlib.VIPFFT
+    interpolation: Enum = Interpolation.LANCZOS4
+    collapse: Enum = Collapse.MEDIAN
     nproc: int = 1
     full_output: bool = False
     verbose: bool = True

--- a/vip_hci/psfsub/nmf_fullfr.py
+++ b/vip_hci/psfsub/nmf_fullfr.py
@@ -18,7 +18,7 @@ __all__ = ["nmf", "NMFParams"]
 import numpy as np
 from sklearn.decomposition import NMF
 from dataclasses import dataclass, field
-from strenum import LowercaseStrEnum as LowEnum
+from enum import Enum
 from typing import Tuple
 from ..preproc import cube_derotate, cube_collapse
 from ..preproc.derotation import _compute_pa_thresh, _find_indices_adi
@@ -51,7 +51,7 @@ class NMFParams:
     ncomp : int, optional
         How many components are used as for low-rank approximation of the
         datacube.
-    scaling : LowerCaseStrEnum, see `vip_hci.var.paramenum.Scaling`
+    scaling : Enum, see `vip_hci.var.paramenum.Scaling`
         With None, no scaling is performed on the input data before SVD. With
         "temp-mean" then temporal px-wise mean subtraction is done, with
         "spat-mean" then the spatial mean is subtracted, with "temp-standard"
@@ -76,20 +76,20 @@ class NMFParams:
         Default is 1 (excludes 1xFHWM on each side of the considered frame).
     fwhm : float, optional
         Known size of the FHWM in pixels to be used. Default value is 4.
-    init_svd: LowerCaseStrEnum, see `vip_hci.var.paramenum.Initsvd`
+    init_svd: Enum, see `vip_hci.var.paramenum.Initsvd`
         Method used to initialize the iterative procedure to find H and W.
         'nndsvd': non-negative double SVD recommended for sparseness
         'nndsvda': NNDSVD where zeros are filled with the average of cube;
         recommended when sparsity is not desired
         'random': random initial non-negative matrix
-    collapse : LowerCaseStrEnum, see `vip_hci.var.paramenum.Collapse`
+    collapse : Enum, see `vip_hci.var.paramenum.Collapse`
         Sets the way of collapsing the frames for producing a final image.
     full_output: boolean, optional
         Whether to return the final median combined image only or with other
         intermediate arrays.
     verbose : {True, False}, bool optional
         If True prints intermediate info and timing.
-    handle_neg: LowerCaseStrEnum, see `vip_hci.var.paramenum.HandleNeg`
+    handle_neg: Enum, see `vip_hci.var.paramenum.HandleNeg`
         Determines how to handle negative values: mask them, set them to zero,
         or subtract the minimum value in the arrays. Note: 'mask' or 'null'
         may leave significant artefacts after derotation of residual cube
@@ -104,19 +104,19 @@ class NMFParams:
     angle_list: np.ndarray = None
     cube_ref: np.ndarray = None
     ncomp: int = 1
-    scaling: LowEnum = None
+    scaling: Enum = None
     max_iter: int = 10000
     random_state: int = None
     mask_center_px: int = None
     source_xy: Tuple[int] = None
     delta_rot: float = 1
     fwhm: float = 4
-    init_svd: LowEnum = Initsvd.NNDSVD
-    collapse: LowEnum = Collapse.MEDIAN
+    init_svd: Enum = Initsvd.NNDSVD
+    collapse: Enum = Collapse.MEDIAN
     full_output: bool = False
     verbose: bool = True
     cube_sig: np.ndarray = None
-    handle_neg: LowEnum = HandleNeg.MASK
+    handle_neg: Enum = HandleNeg.MASK
     nmf_args: dict = field(default_factory=lambda: {})
 
 

--- a/vip_hci/psfsub/nmf_local.py
+++ b/vip_hci/psfsub/nmf_local.py
@@ -12,7 +12,7 @@ from multiprocessing import cpu_count
 from sklearn.decomposition import NMF
 from dataclasses import dataclass, field
 from typing import Tuple, List, Union
-from strenum import LowercaseStrEnum as LowEnum
+from enum import Enum
 from ..preproc import cube_derotate, cube_collapse, check_pa_vector
 from ..preproc.derotation import _find_indices_adi, _define_annuli
 from ..var import get_annulus_segments, matrix_scaling
@@ -123,20 +123,20 @@ class NMFAnnParams:
     n_segments: int = 1
     delta_rot: Union[float, Tuple[float]] = (0.1, 1)
     ncomp: int = 1
-    init_svd: LowEnum = Initsvd.NNDSVD
+    init_svd: Enum = Initsvd.NNDSVD
     nproc: int = 1
     min_frames_lib: int = 2
     max_frames_lib: int = 200
-    scaling: LowEnum = None
-    imlib: LowEnum = Imlib.VIPFFT
-    interpolation: LowEnum = Interpolation.LANCZOS4
-    collapse: LowEnum = Collapse.MEDIAN
+    scaling: Enum = None
+    imlib: Enum = Imlib.VIPFFT
+    interpolation: Enum = Interpolation.LANCZOS4
+    collapse: Enum = Collapse.MEDIAN
     full_output: bool = False
     verbose: bool = True
     theta_init: float = 0
     weights: List = None
     cube_sig: np.ndarray = None
-    handle_neg: LowEnum = HandleNeg.MASK
+    handle_neg: Enum = HandleNeg.MASK
     max_iter: int = 1000
     random_state: int = None
     nmf_args: dict = field(default_factory=lambda: {})

--- a/vip_hci/psfsub/pca_fullfr.py
+++ b/vip_hci/psfsub/pca_fullfr.py
@@ -46,7 +46,7 @@ import numpy as np
 from multiprocessing import cpu_count
 from typing import Tuple, Union
 from dataclasses import dataclass
-from strenum import LowercaseStrEnum as LowEnum
+from enum import Enum
 from .svd import svd_wrapper, SVDecomposer
 from .utils_pca import pca_incremental, pca_grid
 from ..var.paramenum import SvdMode, Adimsdi, Interpolation, Imlib, Collapse
@@ -149,9 +149,9 @@ class PCAParams:
         None then the second PCA stage is skipped and the residuals are
         de-rotated and combined).
 
-    svd_mode : LowerCaseStrEnum, see `vip_hci.var.paramenum.SvdMode`
+    svd_mode : Enum, see `vip_hci.var.paramenum.SvdMode`
         Switch for the SVD method/library to be used.
-    scaling : LowerCaseStrEnum, see `vip_hci.var.paramenum.Scaling`
+    scaling : Enum, see `vip_hci.var.paramenum.Scaling`
         Pixel-wise scaling mode using ``sklearn.preprocessing.scale``
         function. If set to None, the input matrix is left untouched.
     mask_center_px : None or int
@@ -169,7 +169,7 @@ class PCAParams:
     fwhm : float, list or 1d numpy array, optional
         Known size of the FHWM in pixels to be used. Default value is 4.
         Can be a list or 1d numpy array for a 4d input cube with no scale_list.
-    adimsdi : LowerCaseStrEnum, see `vip_hci.var.paramenum.Adimsdi`
+    adimsdi : Enum, see `vip_hci.var.paramenum.Adimsdi`
         Changes the way the 4d cubes (ADI+mSDI) are processed. Basically it
         determines whether a single or double pass PCA is going to be computed.
     crop_ifs: bool, optional
@@ -177,16 +177,16 @@ class PCAParams:
         rescaling in wavelength. This is recommended for large FOVs such as the
         one of SPHERE, but can remove significant amount of information close to
         the edge of small FOVs (e.g. SINFONI).
-    imlib : LowerCaseStrEnum, see `vip_hci.var.paramenum.Imlib`
+    imlib : Enum, see `vip_hci.var.paramenum.Imlib`
         See the documentation of ``vip_hci.preproc.frame_rotate``.
-    imlib2 : LowerCaseStrEnum, see `vip_hci.var.paramenum.Imlib`
+    imlib2 : Enum, see `vip_hci.var.paramenum.Imlib`
         See the documentation of ``vip_hci.preproc.cube_rescaling_wavelengths``.
-    interpolation : LowerCaseStrEnum, see `vip_hci.var.paramenum.Interpolation`
+    interpolation : Enum, see `vip_hci.var.paramenum.Interpolation`
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
-    collapse : LowerCaseStrEnum, see `vip_hci.var.paramenum.Collapse`
+    collapse : Enum, see `vip_hci.var.paramenum.Collapse`
         Sets how temporal residual frames should be combined to produce an
         ADI image.
-    collapse_ifs : LowerCaseStrEnum, see `vip_hci.var.paramenum.Collapse`
+    collapse_ifs : Enum, see `vip_hci.var.paramenum.Collapse`
         Sets how spectral residual frames should be combined to produce an
         mSDI image.
     ifs_collapse_range: str 'all' or tuple of 2 int
@@ -230,19 +230,19 @@ class PCAParams:
     cube_ref: np.ndarray = None
     scale_list: np.ndarray = None
     ncomp: Union[Tuple, float, int] = 1
-    svd_mode: LowEnum = SvdMode.LAPACK
-    scaling: LowEnum = None
+    svd_mode: Enum = SvdMode.LAPACK
+    scaling: Enum = None
     mask_center_px: int = None
     source_xy: Tuple[int] = None
     delta_rot: int = None
     fwhm: float = 4
-    adimsdi: LowEnum = Adimsdi.SINGLE
+    adimsdi: Enum = Adimsdi.SINGLE
     crop_ifs: bool = True
-    imlib: LowEnum = Imlib.VIPFFT
-    imlib2: LowEnum = Imlib.VIPFFT
-    interpolation: LowEnum = Interpolation.LANCZOS4
-    collapse: LowEnum = Collapse.MEDIAN
-    collapse_ifs: LowEnum = Collapse.MEAN
+    imlib: Enum = Imlib.VIPFFT
+    imlib2: Enum = Imlib.VIPFFT
+    interpolation: Enum = Interpolation.LANCZOS4
+    collapse: Enum = Collapse.MEDIAN
+    collapse_ifs: Enum = Collapse.MEAN
     ifs_collapse_range: Union[str, Tuple[int]] = "all"
     mask_rdi: np.ndarray = None
     check_memory: bool = True

--- a/vip_hci/psfsub/pca_local.py
+++ b/vip_hci/psfsub/pca_local.py
@@ -19,7 +19,7 @@ __all__ = ["pca_annular", "PCAAnnParams"]
 import numpy as np
 from multiprocessing import cpu_count
 from typing import Tuple, List, Union
-from strenum import LowercaseStrEnum as LowEnum
+from enum import Enum
 from dataclasses import dataclass
 from ..preproc import cube_derotate, cube_collapse, check_pa_vector, check_scal_vector
 from ..preproc import cube_rescaling_wavelengths as scwave
@@ -101,7 +101,7 @@ class PCAAnnParams:
         second PCA stage is skipped and the residuals are de-rotated and
         combined.
 
-    svd_mode : LowerCaseStrEnum, see `vip_hci.var.paramenum.SvdMode`
+    svd_mode : Enum, see `vip_hci.var.paramenum.SvdMode`
         Switch for the SVD method/library to be used.
     nproc : None or int, optional
         Number of processes for parallel computing. If None the number of
@@ -114,16 +114,16 @@ class PCAAnnParams:
     tol : float, optional
         Stopping criterion for choosing the number of PCs when ``ncomp``
         is None. Lower values will lead to smaller residuals and more PCs.
-    scaling : LowerCaseStrEnum, see `vip_hci.var.paramenum.Scaling`
+    scaling : Enum, see `vip_hci.var.paramenum.Scaling`
         Pixel-wise scaling mode using ``sklearn.preprocessing.scale``
         function. If set to None, the input matrix is left untouched.
-    imlib : LowerCaseStrEnum, see `vip_hci.var.paramenum.Imlib`
+    imlib : Enum, see `vip_hci.var.paramenum.Imlib`
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
-    interpolation :  LowerCaseStrEnum, see `vip_hci.var.paramenum.Interpolation`
+    interpolation :  Enum, see `vip_hci.var.paramenum.Interpolation`
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.
-    collapse : LowerCaseStrEnum, see `vip_hci.var.paramenum.Collapse`
+    collapse : Enum, see `vip_hci.var.paramenum.Collapse`
         Sets the way of collapsing the frames for producing a final image.
-    collapse_ifs : LowerCaseStrEnum, see `vip_hci.var.paramenum.Collapse`
+    collapse_ifs : Enum, see `vip_hci.var.paramenum.Collapse`
         Sets how spectral residual frames should be combined to produce an
         mSDI image.
     ifs_collapse_range: str 'all' or tuple of 2 int
@@ -156,16 +156,16 @@ class PCAAnnParams:
     delta_rot: Union[float, Tuple[float]] = (0.1, 1)
     delta_sep: Union[float, Tuple[float]] = (0.1, 1)
     ncomp: Union[int, Tuple, np.ndarray, AUTO] = 1
-    svd_mode: LowEnum = SvdMode.LAPACK
+    svd_mode: Enum = SvdMode.LAPACK
     nproc: int = 1
     min_frames_lib: int = 2
     max_frames_lib: int = 200
     tol: float = 1e-1
-    scaling: LowEnum = None
-    imlib: LowEnum = Imlib.VIPFFT
-    interpolation: LowEnum = Interpolation.LANCZOS4
-    collapse: LowEnum = Collapse.MEDIAN
-    collapse_ifs: LowEnum = Collapse.MEAN
+    scaling: Enum = None
+    imlib: Enum = Imlib.VIPFFT
+    interpolation: Enum = Interpolation.LANCZOS4
+    collapse: Enum = Collapse.MEDIAN
+    collapse_ifs: Enum = Collapse.MEAN
     ifs_collapse_range: Union["all", Tuple[int]] = "all"
     theta_init: int = 0
     weights: np.ndarray = None

--- a/vip_hci/var/paramenum.py
+++ b/vip_hci/var/paramenum.py
@@ -1,11 +1,9 @@
 """Module containing enums for parameters of HCI algorithms."""
 from enum import auto
-
-from strenum import KebabCaseStrEnum as KebEnum
-from strenum import LowercaseStrEnum as LowEnum
+from enum import Enum
 
 
-class SvdMode(LowEnum):
+class SvdMode(Enum):
     """
     Define the various modes to use with SVD in PCA as constant strings.
 
@@ -44,19 +42,19 @@ class SvdMode(LowEnum):
 
     """
 
-    LAPACK = auto()
-    ARPACK = auto()
-    EIGEN = auto()
-    RANDSVD = auto()
-    CUPY = auto()
-    EIGENCUPY = auto()
-    RANDCUPY = auto()
-    PYTORCH = auto()
-    EIGENPYTORCH = auto()
-    RANDPYTORCH = auto()
+    LAPACK = "lapack"
+    ARPACK = "arpack"
+    EIGEN = "eigen"
+    RANDSVD = "randsvd"
+    CUPY = "cupy"
+    EIGENCUPY = "eigencupy"
+    RANDCUPY = "randcupy"
+    PYTORCH = "pytorch"
+    EIGENPYTORCH = "eigenpytorch"
+    RANDPYTORCH = "randpytorch"
 
 
-class Scaling(LowEnum):
+class Scaling(Enum):
     """
     Define modes for the pixel-wise scaling.
 
@@ -79,7 +77,7 @@ class Scaling(LowEnum):
     SPATSTANDARD = "spat-standard"
 
 
-class Adimsdi(LowEnum):
+class Adimsdi(Enum):
     """
     Define modes for processing ADI+mSDI cubes through PCA.
 
@@ -97,13 +95,13 @@ class Adimsdi(LowEnum):
     subtracted on each spectral cube separately.
     """
 
-    DOUBLE = auto()
-    SINGLE = auto()
-    SKIPADI = auto()
+    DOUBLE = "double"
+    SINGLE = "single"
+    SKIPADI = "skipadi"
 
 
 # TODO: document all modes
-class Imlib(LowEnum):
+class Imlib(Enum):
     """
     Define modes for image transformations to be used.
 
@@ -118,14 +116,14 @@ class Imlib(LowEnum):
     * ̀``VIPFFT``: uses VIP FFT based rotation method.
     """
 
-    OPENCV = auto()
-    SKIMAGE = auto()
-    NDIMAGE = auto()
+    OPENCV = "opencv"
+    SKIMAGE = "skimage"
+    NDIMAGE = "ndimage"
     VIPFFT = "vip-fft"
 
 
 # TODO: document all modes
-class Interpolation(LowEnum):
+class Interpolation(Enum):
     """
     Define modes for interpolation.
 
@@ -146,17 +144,17 @@ class Interpolation(LowEnum):
     * ̀``LANCZOS4`` : slowest and most accurate. Default for OpenCV.
     """
 
-    NEARNEIG = auto()
-    BILINEAR = auto()
-    BIQUADRATIC = auto()
-    BICUBIC = auto()
-    BIQUARTIC = auto()
-    BIQUINTIC = auto()
-    LANCZOS4 = auto()
+    NEARNEIG = "nearneig"
+    BILINEAR = "bilinear"
+    BIQUADRATIC = "biquadratic"
+    BICUBIC = "bicubic"
+    BIQUARTIC = "biquartic"
+    BIQUINTIC = "biquintic"
+    LANCZOS4 = "lanczos4"
 
 
 # TODO: document all modes
-class Collapse(LowEnum):
+class Collapse(Enum):
     """
     Define modes for spectral/temporal residuals frames combining.
 
@@ -171,64 +169,64 @@ class Collapse(LowEnum):
     * ̀``TRIMMEAN``
     """
 
-    MEDIAN = auto()
-    MEAN = auto()
-    SUM = auto()
-    TRIMMEAN = auto()
+    MEDIAN = "median"
+    MEAN = "mean"
+    SUM = "sum"
+    TRIMMEAN = "trimmean"
 
 
-class ReturnList(LowEnum):
+class ReturnList(Enum):
     """List of all possible modes of classic PCA."""
 
-    ADIMSDI_DOUBLE = auto()
-    ADIMSDI_SINGLE_NO_GRID = auto()
-    ADIMSDI_SINGLE_GRID_NO_SOURCE = auto()
-    ADIMSDI_SINGLE_GRID_SOURCE = auto()
-    ADI_FULLFRAME_GRID = auto()
-    ADI_FULLFRAME_STANDARD = auto()
-    ADI_INCREMENTAL_BATCH = auto()
-    PCA_GRID_SN = auto()
-    PCA_ROT_THRESH = auto()
+    ADIMSDI_DOUBLE = "adimsdi_double"
+    ADIMSDI_SINGLE_NO_GRID = "adimsdi_single_no_grid"
+    ADIMSDI_SINGLE_GRID_NO_SOURCE = "adimsdi_single_grid_no_source"
+    ADIMSDI_SINGLE_GRID_SOURCE = "adimsdi_single_grid_source"
+    ADI_FULLFRAME_GRID = "adi_fullframe_grid"
+    ADI_FULLFRAME_STANDARD = "adi_fullframe_standard"
+    ADI_INCREMENTAL_BATCH = "adi_incremental_batch"
+    PCA_GRID_SN = "pca_grid_sn"
+    PCA_ROT_THRESH = "pca_rot_thresh"
 
 
 # TODO: document all metrics
-class Metric(LowEnum):
+class Metric(Enum):
     """Define all metrics possible for various post-processing functions."""
 
-    CITYBLOCK = auto()
-    COSINE = auto()
-    EUCLIDEAN = auto()
-    L1 = auto()
-    L2 = auto()
-    MANHATTAN = auto()
-    CORRELATION = auto()
+    CITYBLOCK = "cityblock"
+    COSINE = "cosine"
+    EUCLIDEAN = "euclidean"
+    L1 = "l1"
+    L2 = "l2"
+    MANHATTAN = "manhattan"
+    CORRELATION = "correlation"
 
 
 # TODO: document modes
-class LowRankMode(LowEnum):
+class LowRankMode(Enum):
     """Define the values for the low rank mode for LLSG."""
 
-    SVD = auto()
-    BRP = auto()
+    SVD = "svd"
+    BRP = "brp"
 
 
 # TODO: document modes
-class AutoRankMode(LowEnum):
+class AutoRankMode(Enum):
     """Define the values for the auto rank mode for LLSG."""
 
-    NOISE = auto()
-    CEVR = auto()
+    NOISE = "noise"
+    CEVR = "cevr"
 
 
 # TODO: document modes
-class ThreshMode(LowEnum):
+class ThreshMode(Enum):
     """Define the values for thresholding modes for LLSG."""
 
-    SOFT = auto()
-    HARD = auto()
+    SOFT = "soft"
+    HARD = "hard"
 
 
-class Solver(LowEnum):
+class Solver(Enum):
     """
     Define the solver for the least squares problem in LLSG.
 
@@ -239,11 +237,11 @@ class Solver(LowEnum):
     * ``NNLS`` : uses the scipy non-negative least-squares solver.
     """
 
-    LSTSQ = auto()
-    NNLS = auto()
+    LSTSQ = "lstsq"
+    NNLS = "nnls"
 
 
-class Runmode(LowEnum):
+class Runmode(Enum):
     """
     Define the mode for the PostProc PCA object.
 
@@ -259,13 +257,13 @@ class Runmode(LowEnum):
     * ``ANNULUS`` : annulus PCA function.
     """
 
-    CLASSIC = auto()
-    ANNULAR = auto()
-    GRID = auto()
-    ANNULUS = auto()
+    CLASSIC = "classic"
+    ANNULAR = "annular"
+    GRID = "grid"
+    ANNULUS = "annulus"
 
 
-class HandleNeg(LowEnum):
+class HandleNeg(Enum):
     """
     Define modes for handling negative values in NMF full-frame.
 
@@ -278,12 +276,12 @@ class HandleNeg(LowEnum):
     * ``NULL`` : set negative values to zero.
     """
 
-    SUBTR_MIN = auto()
-    MASK = auto()
-    NULL = auto()
+    SUBTR_MIN = "subtr_min"
+    MASK = "mask"
+    NULL = "null"
 
 
-class Initsvd(LowEnum):
+class Initsvd(Enum):
     """
     Define modes for initializing SVD for NMF full-frame.
 
@@ -297,13 +295,13 @@ class Initsvd(LowEnum):
     * ``RANDOM`` : random initial non-negative matrix.
     """
 
-    NNDSVD = auto()
-    NNDSVDA = auto()
-    RANDOM = auto()
+    NNDSVD = "nndsvd"
+    NNDSVDA = "nndsvda"
+    RANDOM = "random"
 
 
 # TODO: document modes
-class OptMethod(LowEnum):
+class OptMethod(Enum):
     """
     Defines the method of balancing for the flux difference for ANDROMEDA.
 
@@ -319,13 +317,13 @@ class OptMethod(LowEnum):
     * ``ROBUST``
     """
 
-    NO = auto()
-    TOTAL = auto()
-    LSQ = auto()
-    ROBUST = auto()
+    NO = "no"
+    TOTAL = "total"
+    LSQ = "lsq"
+    ROBUST = "robust"
 
 
-class VarEstim(LowEnum):
+class VarEstim(Enum):
     """
     Define modes to use for the residual noise variance estimation in FMMF.
 
@@ -345,6 +343,6 @@ class VarEstim(LowEnum):
     derotated cube of residuals except for the selected frame).
     """
 
-    FR = auto()
-    FM = auto()
-    TE = auto()
+    FR = "fr"
+    FM = "fm"
+    TE = "te"

--- a/vip_hci/var/paramenum.py
+++ b/vip_hci/var/paramenum.py
@@ -3,7 +3,7 @@ from enum import auto
 from enum import Enum
 
 
-class SvdMode(Enum):
+class SvdMode(str, Enum):
     """
     Define the various modes to use with SVD in PCA as constant strings.
 
@@ -54,7 +54,7 @@ class SvdMode(Enum):
     RANDPYTORCH = "randpytorch"
 
 
-class Scaling(Enum):
+class Scaling(str, Enum):
     """
     Define modes for the pixel-wise scaling.
 
@@ -77,7 +77,7 @@ class Scaling(Enum):
     SPATSTANDARD = "spat-standard"
 
 
-class Adimsdi(Enum):
+class Adimsdi(str, Enum):
     """
     Define modes for processing ADI+mSDI cubes through PCA.
 
@@ -101,7 +101,7 @@ class Adimsdi(Enum):
 
 
 # TODO: document all modes
-class Imlib(Enum):
+class Imlib(str, Enum):
     """
     Define modes for image transformations to be used.
 
@@ -123,7 +123,7 @@ class Imlib(Enum):
 
 
 # TODO: document all modes
-class Interpolation(Enum):
+class Interpolation(str, Enum):
     """
     Define modes for interpolation.
 
@@ -154,7 +154,7 @@ class Interpolation(Enum):
 
 
 # TODO: document all modes
-class Collapse(Enum):
+class Collapse(str, Enum):
     """
     Define modes for spectral/temporal residuals frames combining.
 
@@ -175,7 +175,7 @@ class Collapse(Enum):
     TRIMMEAN = "trimmean"
 
 
-class ReturnList(Enum):
+class ReturnList(str, Enum):
     """List of all possible modes of classic PCA."""
 
     ADIMSDI_DOUBLE = "adimsdi_double"
@@ -190,7 +190,7 @@ class ReturnList(Enum):
 
 
 # TODO: document all metrics
-class Metric(Enum):
+class Metric(str, Enum):
     """Define all metrics possible for various post-processing functions."""
 
     CITYBLOCK = "cityblock"
@@ -203,7 +203,7 @@ class Metric(Enum):
 
 
 # TODO: document modes
-class LowRankMode(Enum):
+class LowRankMode(str, Enum):
     """Define the values for the low rank mode for LLSG."""
 
     SVD = "svd"
@@ -211,7 +211,7 @@ class LowRankMode(Enum):
 
 
 # TODO: document modes
-class AutoRankMode(Enum):
+class AutoRankMode(str, Enum):
     """Define the values for the auto rank mode for LLSG."""
 
     NOISE = "noise"
@@ -219,14 +219,14 @@ class AutoRankMode(Enum):
 
 
 # TODO: document modes
-class ThreshMode(Enum):
+class ThreshMode(str, Enum):
     """Define the values for thresholding modes for LLSG."""
 
     SOFT = "soft"
     HARD = "hard"
 
 
-class Solver(Enum):
+class Solver(str, Enum):
     """
     Define the solver for the least squares problem in LLSG.
 
@@ -241,7 +241,7 @@ class Solver(Enum):
     NNLS = "nnls"
 
 
-class Runmode(Enum):
+class Runmode(str, Enum):
     """
     Define the mode for the PostProc PCA object.
 
@@ -263,7 +263,7 @@ class Runmode(Enum):
     ANNULUS = "annulus"
 
 
-class HandleNeg(Enum):
+class HandleNeg(str, Enum):
     """
     Define modes for handling negative values in NMF full-frame.
 
@@ -281,7 +281,7 @@ class HandleNeg(Enum):
     NULL = "null"
 
 
-class Initsvd(Enum):
+class Initsvd(str, Enum):
     """
     Define modes for initializing SVD for NMF full-frame.
 
@@ -301,7 +301,7 @@ class Initsvd(Enum):
 
 
 # TODO: document modes
-class OptMethod(Enum):
+class OptMethod(str, Enum):
     """
     Defines the method of balancing for the flux difference for ANDROMEDA.
 
@@ -323,7 +323,7 @@ class OptMethod(Enum):
     ROBUST = "robust"
 
 
-class VarEstim(Enum):
+class VarEstim(str, Enum):
     """
     Define modes to use for the residual noise variance estimation in FMMF.
 


### PR DESCRIPTION
Replaced strenum by generic, Python-included Enum support. Works just like before