### PR TITLE
Positionnal arguments retro compatibility

### DIFF
--- a/tests/pre_3_10/test_metrics_completeness.py
+++ b/tests/pre_3_10/test_metrics_completeness.py
@@ -14,7 +14,7 @@ from vip_hci.fm import cube_planet_free
 from vip_hci.metrics import completeness_curve
 from vip_hci.metrics import completeness_map
 from vip_hci.preproc import frame_crop
-from vip_hci.psfsub import pca
+from vip_hci.psfsub import pca, PCAParams
 
 
 @fixture(scope="module")
@@ -62,6 +62,7 @@ def test_completeness_curve(get_cube_empty):
         starphot=starphot,
         plot=True,
         algo_dict={"imlib": "opencv"},
+        algo_class=PCAParams,
     )
 
     if np.allclose(comp_curve / expected_res, [1], atol=0.5):
@@ -89,6 +90,7 @@ def test_completeness_map(get_cube_empty):
         ini_contrast=expected_res,
         starphot=starphot,
         algo_dict={"imlib": "opencv"},
+        algo_class=PCAParams,
     )
 
     if np.allclose(contrasts[:, -2] / expected_res, [1], atol=0.5):

--- a/tests/pre_3_10/test_metrics_contrcurve.py
+++ b/tests/pre_3_10/test_metrics_contrcurve.py
@@ -16,7 +16,7 @@ from vip_hci.fm.utils_negfc import cube_planet_free
 from vip_hci.fm.utils_negfc import find_nearest
 from vip_hci.metrics import contrast_curve
 from vip_hci.preproc import frame_crop
-from vip_hci.psfsub import pca
+from vip_hci.psfsub import pca, PCAParams
 
 
 @fixture(scope="module")
@@ -69,6 +69,7 @@ def test_contrast_curve(get_cube):
         transmission=trans,
         plot=True,
         debug=True,
+        algo_class=PCAParams,
     )
 
     rad = np.array(cc["distance"])

--- a/vip_hci/invprob/andromeda.py
+++ b/vip_hci/invprob/andromeda.py
@@ -265,15 +265,15 @@ def andromeda(*all_args: List, **all_kwargs: dict):
         diam_tel = 8.0   : Telescope diameter [m]
 
     """
-    class_params, rot_options = separate_kwargs_dict(
+    class_params, other_options = separate_kwargs_dict(
         initial_kwargs=all_kwargs, parent_class=AndroParams
     )
 
     # Extracting the object of parameters (if any)
     algo_params = None
-    if ALGO_KEY in rot_options.keys():
-        algo_params = rot_options[ALGO_KEY]
-        del rot_options[ALGO_KEY]
+    if ALGO_KEY in other_options.keys():
+        algo_params = other_options[ALGO_KEY]
+        del other_options[ALGO_KEY]
 
     if algo_params is None:
         algo_params = AndroParams(*all_args, **class_params)

--- a/vip_hci/invprob/fmmf.py
+++ b/vip_hci/invprob/fmmf.py
@@ -69,14 +69,50 @@ from ..config.utils_conf import pool_map, iterable
 from ..config import time_ini, timing
 from ..fm import cube_inject_companions
 from ..preproc.derotation import _find_indices_adi
-from ..var.object_utils import setup_parameters
-from ..var.paramenum import VarEstim, Imlib, Interpolation
+from ..var.object_utils import setup_parameters, separate_kwargs_dict
+from ..var.paramenum import VarEstim, Imlib, Interpolation, ALGO_KEY
 
 
 @dataclass
 class FMMFParams:
     """
     Set of parameters for the FMMF algorithm.
+
+    See function `fmmf` below for the documentation.
+    """
+
+    cube: np.ndarray = None
+    angle_list: np.ndarray = None
+    psf: np.ndarray = None
+    fwhm: float = None
+    min_r: int = None
+    max_r: int = None
+    model: str = "KLIP"
+    var: Enum = VarEstim.FR
+    param: dict = field(
+        default_factory=lambda: {"ncomp": 20, "tolerance": 5e-3, "delta_rot": 0.5}
+    )
+    crop: int = 5
+    imlib: Enum = Imlib.VIPFFT
+    interpolation: Enum = Interpolation.LANCZOS4
+    nproc: int = 1
+    verbose: bool = True
+
+
+def fmmf(*all_args, **all_kwargs: dict):
+    """
+    Forward model matched filter generating SNR map and contrast map, using
+    either KLIP or LOCI as PSF subtraction techniques, as implemented in
+    [RUF17]_ and [DAH21a]_.
+
+    Parameters
+    ----------
+    all_args: list, optional
+        Positionnal arguments for the FMMF algorithm. Full list of parameters
+        below.
+    all_kwargs: dictionary, optional
+        Mix of keyword arguments that can initialize a FMMFParams or a FMMFParams
+        itself.
 
     Parameters
     ----------
@@ -139,39 +175,6 @@ class FMMFParams:
     verbose: bool, optional
         If True provide a message each time an annulus has been treated.
         Default True.
-    """
-
-    cube: np.ndarray = None
-    angle_list: np.ndarray = None
-    psf: np.ndarray = None
-    fwhm: float = None
-    min_r: int = None
-    max_r: int = None
-    model: str = "KLIP"
-    var: Enum = VarEstim.FR
-    param: dict = field(
-        default_factory=lambda: {"ncomp": 20, "tolerance": 5e-3, "delta_rot": 0.5}
-    )
-    crop: int = 5
-    imlib: Enum = Imlib.VIPFFT
-    interpolation: Enum = Interpolation.LANCZOS4
-    nproc: int = 1
-    verbose: bool = True
-
-
-def fmmf(algo_params: FMMFParams = None, **class_params: dict):
-    """
-    Forward model matched filter generating SNR map and contrast map, using
-    either KLIP or LOCI as PSF subtraction techniques, as implemented in
-    [RUF17]_ and [DAH21a]_.
-
-    Parameters
-    ----------
-    algo_params: FMMFParams
-        Dataclass retaining all the needed parameters for FMMF.
-    class_params: dict, optionnal
-        Set of parameters needed for an initialization of algo_params if none
-        was provided.
 
     Returns
     -------
@@ -183,8 +186,18 @@ def fmmf(algo_params: FMMFParams = None, **class_params: dict):
         the estimated standard deviation of the contrast).
 
     """
+    class_params, other_options = separate_kwargs_dict(
+        initial_kwargs=all_kwargs, parent_class=FMMFParams
+    )
+
+    # Extracting the object of parameters (if any)
+    algo_params = None
+    if ALGO_KEY in other_options.keys():
+        algo_params = other_options[ALGO_KEY]
+        del other_options[ALGO_KEY]
+
     if algo_params is None:
-        algo_params = FMMFParams(**class_params)
+        algo_params = FMMFParams(*all_args, **class_params)
     start_time = time_ini(algo_params.verbose)
 
     if algo_params.crop >= 2 * round(algo_params.fwhm) + 1:

--- a/vip_hci/metrics/completeness.py
+++ b/vip_hci/metrics/completeness.py
@@ -187,6 +187,7 @@ def _estimate_snr_fc(
     return max_target - max_map, b
 
 
+# TODO: Include algo_class modifications in any tutorial using this function
 def completeness_curve(
     cube,
     angle_list,
@@ -210,6 +211,7 @@ def completeness_curve(
     object_name=None,
     fix_y_lim=(),
     figsize=vip_figsize,
+    algo_class=None,
 ):
     """
     Function allowing the computation of completeness-based contrast curves with
@@ -368,11 +370,8 @@ def completeness_curve(
 
     if verbose:
         print("Calculating initial SNR map with no injected companion...")
-    algo_params = signature(algo).parameters
-    param_name = next(iter(algo_params))
-    class_name = algo_params[param_name].annotation
 
-    argl = [attr for attr in vars(class_name)]
+    argl = [attr for attr in vars(algo_class)]
     if "cube" in argl and "angle_list" in argl:
         if "fwhm" in argl:
             frame_fin = algo(
@@ -699,6 +698,7 @@ def completeness_curve(
     return an_dist, cont_curve
 
 
+# TODO: Include the algo_class in the metrics tutorial !!
 def completeness_map(
     cube,
     angle_list,
@@ -713,6 +713,7 @@ def completeness_map(
     nproc=1,
     algo_dict={},
     verbose=True,
+    algo_class=None,
 ):
     """
     Function allowing the computation of two dimensional (radius and
@@ -846,15 +847,11 @@ def completeness_map(
 
     # argl = getfullargspec(algo).args # does not work with recent object support
 
-    """Because all psfsub algorithms now take a single object as parameter, looking for
-    specific named arguments can be a puzzle. We have to first identify the object,
-    and look inside its attributes to find the arguments we need."""
+    """Because all psfsub algorithms now take more vague parameters, looking for
+    specific named arguments can be a puzzle. We have to first identify the parameters
+    tied to the algorithm by looking at its object of parameters."""
 
-    algo_params = signature(algo).parameters
-    param_name = next(iter(algo_params))
-    class_name = algo_params[param_name].annotation
-
-    argl = [attr for attr in vars(class_name)]
+    argl = [attr for attr in vars(algo_class)]
 
     if "cube" in argl and "angle_list" in argl and "verbose" in argl:
         if "fwhm" in argl:

--- a/vip_hci/metrics/completeness.py
+++ b/vip_hci/metrics/completeness.py
@@ -352,6 +352,7 @@ def completeness_curve(
             wedge=(0, 360),
             fc_snr=100,
             plot=False,
+            algo_class=algo_class,
             **algo_dict,
         )
         ini_rads = np.array(ini_cc["distance"])

--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -26,6 +26,7 @@ from ..config.utils_conf import vip_figsize, vip_figdpi
 from ..var import frame_center, dist
 
 
+# TODO: Include algo_class modifications in any tutorial using this function
 def contrast_curve(
     cube,
     angle_list,
@@ -56,6 +57,7 @@ def contrast_curve(
     frame_size=None,
     fix_y_lim=(),
     figsize=vip_figsize,
+    algo_class=None,
     **algo_dict,
 ):
     """Computes the contrast curve at a given confidence (``sigma``) level for
@@ -234,6 +236,7 @@ def contrast_curve(
         fc_snr=fc_snr,
         full_output=True,
         verbose=verbose_thru,
+        algo_class=algo_class,
         **algo_dict,
     )
     vector_radd = res_throug[3]
@@ -556,6 +559,7 @@ def contrast_curve(
         return datafr
 
 
+# TODO: Include algo_class modifications in any tutorial using this function
 def throughput(
     cube,
     angle_list,
@@ -570,6 +574,7 @@ def throughput(
     fc_snr=100,
     full_output=False,
     verbose=True,
+    algo_class=None,
     **algo_dict,
 ):
     """Measures the throughput for chosen algorithm and input dataset (ADI or
@@ -708,11 +713,8 @@ def throughput(
         start_time = time_ini()
     # ***************************************************************************
     # Compute noise in concentric annuli on the "empty frame"
-    algo_params = signature(algo).parameters
-    param_name = next(iter(algo_params))
-    class_name = algo_params[param_name].annotation
 
-    argl = [attr for attr in vars(class_name)]
+    argl = [attr for attr in vars(algo_class)]
     if "cube" in argl and "angle_list" in argl and "verbose" in argl:
         if "fwhm" in argl:
             frame_nofc = algo(
@@ -832,11 +834,8 @@ def throughput(
                     timing(start_time)
 
                 # ***************************************************************
-                algo_params = signature(algo).parameters
-                param_name = next(iter(algo_params))
-                class_name = algo_params[param_name].annotation
 
-                arg = [attr for attr in vars(class_name)]
+                arg = [attr for attr in vars(algo_class)]
                 if "cube" in arg and "angle_list" in arg and "verbose" in arg:
                     if "fwhm" in arg:
                         frame_fc = algo(
@@ -937,11 +936,8 @@ def throughput(
                     timing(start_time)
 
                 # **************************************************************
-                algo_params = signature(algo).parameters
-                param_name = next(iter(algo_params))
-                class_name = algo_params[param_name].annotation
 
-                arg = [attr for attr in vars(class_name)]
+                arg = [attr for attr in vars(algo_class)]
                 if "cube" in arg and "angle_list" in arg and "verbose" in arg:
                     if "fwhm" in arg:
                         frame_fc = algo(

--- a/vip_hci/objects/ppandromeda.py
+++ b/vip_hci/objects/ppandromeda.py
@@ -2,9 +2,7 @@
 """Module for the post-processing ANDROMEDA algorithm."""
 
 __author__ = "Thomas Bédrine, Carlos Alberto Gomez Gonzalez, Ralf Farkas"
-__all__ = [
-    "AndroBuilder",
-]
+__all__ = ["AndroBuilder", "PPAndromeda"]
 
 from typing import Optional
 from dataclasses import dataclass

--- a/vip_hci/objects/ppandromeda.py
+++ b/vip_hci/objects/ppandromeda.py
@@ -73,7 +73,8 @@ class PPAndromeda(PostProc, AndroParams):
             self.nproc = nproc
 
         params_dict = self._create_parameters_dict(AndroParams)
-        res = andromeda(algo_params=self)
+        all_params = {"algo_params": self}
+        res = andromeda(**all_params)
 
         self.contrast_map = res[0]
         self.likelihood_map = res[5]

--- a/vip_hci/objects/ppfmmf.py
+++ b/vip_hci/objects/ppfmmf.py
@@ -60,7 +60,8 @@ class PPFMMF(PostProc, FMMFParams):
             self.nproc = nproc
 
         params_dict = self._create_parameters_dict(FMMFParams)
-        res = fmmf(algo_params=self)
+        all_params = {"algo_params": self}
+        res = fmmf(**all_params)
 
         self.frame_final, self.snr_map = res
 

--- a/vip_hci/objects/ppfmmf.py
+++ b/vip_hci/objects/ppfmmf.py
@@ -2,9 +2,7 @@
 """Module for the post-processing FMMF algorithm."""
 
 __author__ = "Thomas Bédrine"
-__all__ = [
-    "FMMFBuilder",
-]
+__all__ = ["FMMFBuilder", "PPFMMF"]
 
 from typing import Optional
 from dataclasses import dataclass

--- a/vip_hci/objects/ppframediff.py
+++ b/vip_hci/objects/ppframediff.py
@@ -74,7 +74,9 @@ class PPFrameDiff(PostProc, FrameDiffParams):
         self._explicit_dataset()
         params_dict = self._create_parameters_dict(FrameDiffParams)
 
-        res = frame_diff(algo_params=self, **rot_options)
+        all_params = {"algo_params": self, **rot_options}
+
+        res = frame_diff(**all_params)
 
         self.frame_final = res
 

--- a/vip_hci/objects/ppframediff.py
+++ b/vip_hci/objects/ppframediff.py
@@ -2,9 +2,7 @@
 """Module for the post-processing frame differencing algorithm."""
 
 __author__ = "Thomas Bédrine"
-__all__ = [
-    "FrameDiffBuilder",
-]
+__all__ = ["FrameDiffBuilder", "PPFrameDiff"]
 
 from dataclasses import dataclass
 from typing import Optional

--- a/vip_hci/objects/ppllsg.py
+++ b/vip_hci/objects/ppllsg.py
@@ -80,7 +80,9 @@ class PPLLSG(PostProc, LLSGParams):
 
         params_dict = self._create_parameters_dict(LLSGParams)
 
-        res = llsg(algo_params=self, **rot_options)
+        all_params = {"algo_params": self, **rot_options}
+
+        res = llsg(**all_params)
         self.frame_l = res[3]
         self.frame_s = res[4]
         self.frame_g = res[5]

--- a/vip_hci/objects/ppllsg.py
+++ b/vip_hci/objects/ppllsg.py
@@ -2,9 +2,7 @@
 """Module for the post-processing LLSG algorithm."""
 
 __author__ = "Thomas Bédrine"
-__all__ = [
-    "LLSGBuilder",
-]
+__all__ = ["LLSGBuilder", "PPLLSG"]
 
 from typing import Optional
 from dataclasses import dataclass

--- a/vip_hci/objects/pploci.py
+++ b/vip_hci/objects/pploci.py
@@ -2,7 +2,7 @@
 """Module for the post-processing LOCI algorithm."""
 
 __author__ = "Thomas Bédrine"
-__all__ = ["LOCIBuilder"]
+__all__ = ["LOCIBuilder", "PPLOCI"]
 
 
 from typing import Optional

--- a/vip_hci/objects/pploci.py
+++ b/vip_hci/objects/pploci.py
@@ -77,7 +77,8 @@ class PPLOCI(PostProc, LOCIParams):
 
         params_dict = self._create_parameters_dict(LOCIParams)
 
-        res = xloci(algo_params=self, **rot_options)
+        all_params = {"algo_params": self, **rot_options}
+        res = xloci(**all_params)
 
         self.cube_res, self.cube_der, self.frame_final = res
 

--- a/vip_hci/objects/ppmediansub.py
+++ b/vip_hci/objects/ppmediansub.py
@@ -2,7 +2,7 @@
 """Module for the post-processing median subtraction algorithm."""
 
 __author__ = "Thomas Bédrine"
-__all__ = ["MedianBuilder"]
+__all__ = ["MedianBuilder", "PPMedianSub"]
 
 from typing import Optional
 from dataclasses import dataclass

--- a/vip_hci/objects/ppmediansub.py
+++ b/vip_hci/objects/ppmediansub.py
@@ -87,7 +87,9 @@ class PPMedianSub(PostProc, MedsubParams):
 
         params_dict = self._create_parameters_dict(MedsubParams)
 
-        res = median_sub(algo_params=self, **rot_options)
+        all_params = {"algo_params": self, **rot_options}
+
+        res = median_sub(**all_params)
 
         self.cube_residuals, self.cube_residuals_der, self.frame_final = res
 

--- a/vip_hci/objects/ppnmf.py
+++ b/vip_hci/objects/ppnmf.py
@@ -2,9 +2,7 @@
 """Module for the post-processing non-negative matrix factorization algorithm."""
 
 __author__ = "Thomas Bédrine"
-__all__ = [
-    "NMFBuilder",
-]
+__all__ = ["NMFBuilder", "PPNMF"]
 
 from typing import Optional, List, Tuple, Union
 from dataclasses import dataclass, field

--- a/vip_hci/objects/ppnmf.py
+++ b/vip_hci/objects/ppnmf.py
@@ -100,13 +100,15 @@ class PPNMF(PostProc, NMFAnnParams, NMFParams):
         if verbose is not None:
             self.verbose = verbose
 
+        all_params = {"algo_params": self, **rot_options}
+
         if runmode == "fullframe":
             # Annular NMF gives the default delta_rot, fullframe delta_rot must be int
             if not isinstance(self.delta_rot, float):
                 self.delta_rot = DELTA_FF_DEFAULT
 
             params_dict = self._create_parameters_dict(NMFParams)
-            res = nmf(algo_params=self, **rot_options)
+            res = nmf(**all_params)
 
             (
                 self.nmf_reshaped,
@@ -128,7 +130,7 @@ class PPNMF(PostProc, NMFAnnParams, NMFParams):
 
         else:
             params_dict = self._create_parameters_dict(NMFAnnParams)
-            res = nmf_annular(algo_params=self, **rot_options)
+            res = nmf_annular(**all_params)
 
             (
                 self.cube_residuals,

--- a/vip_hci/objects/pppca.py
+++ b/vip_hci/objects/pppca.py
@@ -2,9 +2,7 @@
 """Module for the post-processing PCA algorithm."""
 
 __author__ = "Thomas Bédrine"
-__all__ = [
-    "PCABuilder",
-]
+__all__ = ["PCABuilder", "PPPCA"]
 
 from typing import Tuple, Optional, List
 from dataclasses import dataclass, field

--- a/vip_hci/objects/pppca.py
+++ b/vip_hci/objects/pppca.py
@@ -188,7 +188,9 @@ class PPPCA(PostProc, PCAParams, PCAAnnParams):
 
                 params_dict = self._create_parameters_dict(PCAParams)
 
-                res = pca(algo_params=self, **rot_options)
+                all_params = {"algo_params": self, **rot_options}
+
+                res = pca(**all_params)
 
                 self._find_pca_mode(res=res)
 
@@ -205,7 +207,9 @@ class PPPCA(PostProc, PCAParams, PCAAnnParams):
 
                 params_dict = self._create_parameters_dict(PCAAnnParams)
 
-                res = pca_annular(algo_params=self, **rot_options)
+                all_params = {"algo_params": self, **rot_options}
+
+                res = pca_annular(**all_params)
 
                 self.cube_residuals, self.cube_residuals_der, self.frame_final = res
 

--- a/vip_hci/psfsub/framediff.py
+++ b/vip_hci/psfsub/framediff.py
@@ -65,7 +65,7 @@ def frame_diff(
         Positionnal arguments for the frame diff algorithm. Full list of parameters
         below.
     all_kwargs: dictionary, optional
-        Mix of keyword arguments that can initialize a MedsubParams and the optional
+        Mix of keyword arguments that can initialize a FrameDiffParams and the optional
         'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
         "edge_blend", "interp_zeros", "ker" (see documentation of
         ``vip_hci.preproc.frame_rotate``). Can also contain a FrameDiffParams if

--- a/vip_hci/psfsub/framediff.py
+++ b/vip_hci/psfsub/framediff.py
@@ -9,6 +9,7 @@ import pandas as pn
 from hciplot import plot_frames
 from multiprocessing import cpu_count
 from dataclasses import dataclass
+from typing import List
 from enum import Enum
 from sklearn.metrics import pairwise_distances
 from ..var import get_annulus_segments
@@ -48,10 +49,7 @@ class FrameDiffParams:
     full_output: bool = False
 
 
-def frame_diff(
-    *all_args,
-    **all_kwargs,
-):
+def frame_diff(*all_args: List, **all_kwargs: dict):
     """Run the frame differencing algorithm.
 
     It uses vector distance (depending on
@@ -68,8 +66,8 @@ def frame_diff(
         Mix of keyword arguments that can initialize a FrameDiffParams and the optional
         'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
         "edge_blend", "interp_zeros", "ker" (see documentation of
-        ``vip_hci.preproc.frame_rotate``). Can also contain a FrameDiffParams if
-        provided.
+        ``vip_hci.preproc.frame_rotate``). Can also contain a FrameDiffParams named as
+        `algo_params`.
 
     Frame differencing parameters
     ----------

--- a/vip_hci/psfsub/llsg.py
+++ b/vip_hci/psfsub/llsg.py
@@ -22,6 +22,7 @@ from scipy.linalg import qr
 from multiprocessing import cpu_count
 from astropy.stats import median_absolute_deviation
 from dataclasses import dataclass
+from typing import List
 from enum import Enum
 from ..config import time_ini, timing
 from ..preproc import cube_derotate, cube_collapse
@@ -65,10 +66,7 @@ class LLSGParams:
     debug: bool = False
 
 
-def llsg(
-    *all_args,
-    **all_kwargs,
-):
+def llsg(*all_args: List, **all_kwargs: dict):
     """Local Low-rank plus Sparse plus Gaussian-noise decomposition (LLSG) as
     described in [GOM16]_. This first version of our algorithm aims at
     decomposing ADI cubes into three terms L+S+G (low-rank, sparse and Gaussian
@@ -90,8 +88,8 @@ def llsg(
         Mix of keyword arguments that can initialize a LLSGParams and the optional
         'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
         "edge_blend", "interp_zeros", "ker" (see documentation of
-        ``vip_hci.preproc.frame_rotate``). Can also contain a LLSGParams if
-        provided.
+        ``vip_hci.preproc.frame_rotate``). Can also contain a LLSGParams named as
+        `algo_params`.
 
     LLSG parameters
     ----------

--- a/vip_hci/psfsub/loci.py
+++ b/vip_hci/psfsub/loci.py
@@ -23,7 +23,7 @@ from multiprocessing import cpu_count
 from sklearn.metrics import pairwise_distances
 from dataclasses import dataclass
 from enum import Enum
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 from ..var import get_annulus_segments
 from ..var.object_utils import setup_parameters, separate_kwargs_dict
 from ..var.paramenum import (
@@ -74,7 +74,7 @@ class LOCIParams:
     full_output: bool = False
 
 
-def xloci(*all_args, **all_kwargs):
+def xloci(*all_args: List, **all_kwargs: dict):
     """Locally Optimized Combination of Images (LOCI) algorithm as in [LAF07]_.
     The PSF is modeled (for ADI and ADI+mSDI) with a least-square combination
     of neighbouring frames (solving the equation a x = b by computing a vector
@@ -92,8 +92,8 @@ def xloci(*all_args, **all_kwargs):
         Mix of keyword arguments that can initialize a LOCIParams and the optional
         'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
         "edge_blend", "interp_zeros", "ker" (see documentation of
-        ``vip_hci.preproc.frame_rotate``). Can also contain a LOCIParams if
-        provided.
+        ``vip_hci.preproc.frame_rotate``). Can also contain a LOCIParams named as
+        `algo_params`.
 
     LOCI parameters
     ----------

--- a/vip_hci/psfsub/medsub.py
+++ b/vip_hci/psfsub/medsub.py
@@ -48,14 +48,59 @@ from ..config.utils_conf import pool_map, iterable, print_precision
 from ..preproc.derotation import _find_indices_adi, _define_annuli
 from ..preproc.rescaling import _find_indices_sdi
 
+ALGO_KEY = "algo_params"
+
 
 @dataclass
 class MedsubParams:
     """
     Set of parameters for the median subtraction module.
 
+    See function `median_sub` below for documentation.
+    """
+
+    cube: np.ndarray = None
+    angle_list: np.ndarray = None
+    scale_list: np.ndarray = None
+    flux_sc_list: np.ndarray = None
+    fwhm: float = 4
+    radius_int: int = 0
+    asize: int = 4
+    delta_rot: int = 1
+    delta_sep: Union[float, Tuple[float]] = (0.1, 1)
+    mode: str = "fullfr"
+    nframes: int = 4
+    sdi_only: bool = False
+    imlib: Enum = Imlib.VIPFFT
+    interpolation: Enum = Interpolation.LANCZOS4
+    collapse: Enum = Collapse.MEDIAN
+    nproc: int = 1
+    full_output: bool = False
+    verbose: bool = True
+
+
+def median_sub(*all_args, **all_kwargs):
+    """Implementation of a median subtraction algorithm for model PSF
+    subtraction in high-contrast imaging sequences. In the case of ADI, the
+    algorithm is based on [MAR06]_. The ADI+IFS method is an extension of this
+    basic idea to multi-spectral cubes.
+
+    References: [MAR06]_ for median-ADI; [SPA02]_ and [THA07]_ for SDI.
+
     Parameters
     ----------
+    all_args: list, optional
+        Positionnal arguments for the median_sub function. Full list of parameters
+        below.
+    all_kwargs: dictionary, optional
+        Mix of keyword arguments that can initialize a MedsubParams and the optional
+        'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
+        "edge_blend", "interp_zeros", "ker" (see documentation of
+        ``vip_hci.preproc.frame_rotate``). Can also contain a MedsubParams if
+        provided.
+
+    Median subtraction parameters
+    -----------------------------
     cube : numpy ndarray, 3d
         Input cube.
     angle_list : numpy ndarray, 1d
@@ -118,46 +163,6 @@ class MedsubParams:
         intermediate arrays.
     verbose : bool, optional
         If True prints to stdout intermediate info.
-    """
-
-    cube: np.ndarray = None
-    angle_list: np.ndarray = None
-    scale_list: np.ndarray = None
-    flux_sc_list: np.ndarray = None
-    fwhm: float = 4
-    radius_int: int = 0
-    asize: int = 4
-    delta_rot: int = 1
-    delta_sep: Union[float, Tuple[float]] = (0.1, 1)
-    mode: str = "fullfr"
-    nframes: int = 4
-    sdi_only: bool = False
-    imlib: Enum = Imlib.VIPFFT
-    interpolation: Enum = Interpolation.LANCZOS4
-    collapse: Enum = Collapse.MEDIAN
-    nproc: int = 1
-    full_output: bool = False
-    verbose: bool = True
-
-
-def median_sub(algo_params: MedsubParams = None, **all_kwargs):
-    """Implementation of a median subtraction algorithm for model PSF
-    subtraction in high-contrast imaging sequences. In the case of ADI, the
-    algorithm is based on [MAR06]_. The ADI+IFS method is an extension of this
-    basic idea to multi-spectral cubes.
-
-    References: [MAR06]_ for median-ADI; [SPA02]_ and [THA07]_ for SDI.
-
-    Parameters
-    ----------
-    algo_params: MedsubParams or PostProc
-        Dataclass retaining all the needed parameters for median subtraction.
-    all_kwargs: dictionary, optional
-        Mix of the parameters that can initialize an algo_params and the optional
-        'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
-        "edge_blend", "interp_zeros", "ker" (see documentation of
-        ``vip_hci.preproc.frame_rotate``)
-
     Returns
     -------
     cube_out : numpy ndarray, 3d
@@ -168,13 +173,19 @@ def median_sub(algo_params: MedsubParams = None, **all_kwargs):
         Median combination of the de-rotated cube.
 
     """
-
     # Separating the parameters of the ParamsObject from the optionnal rot_options
     class_params, rot_options = separate_kwargs_dict(
         initial_kwargs=all_kwargs, parent_class=MedsubParams
     )
+
+    # Extracting the object of parameters (if any)
+    algo_params = None
+    if ALGO_KEY in rot_options.keys():
+        algo_params = rot_options[ALGO_KEY]
+        del rot_options[ALGO_KEY]
+
     if algo_params is None:
-        algo_params = MedsubParams(**class_params)
+        algo_params = MedsubParams(*all_args, **class_params)
 
     global ARRAY
     ARRAY = algo_params.cube.copy()

--- a/vip_hci/psfsub/medsub.py
+++ b/vip_hci/psfsub/medsub.py
@@ -37,7 +37,7 @@ import numpy as np
 from multiprocessing import cpu_count
 from dataclasses import dataclass
 from enum import Enum
-from typing import Tuple, Union
+from typing import Tuple, Union, List
 from ..config import time_ini, timing
 from ..var import get_annulus_segments, mask_circle
 from ..var.paramenum import Imlib, Interpolation, Collapse, ALGO_KEY
@@ -77,7 +77,7 @@ class MedsubParams:
     verbose: bool = True
 
 
-def median_sub(*all_args, **all_kwargs):
+def median_sub(*all_args: List, **all_kwargs: dict):
     """Implementation of a median subtraction algorithm for model PSF
     subtraction in high-contrast imaging sequences. In the case of ADI, the
     algorithm is based on [MAR06]_. The ADI+IFS method is an extension of this
@@ -94,8 +94,8 @@ def median_sub(*all_args, **all_kwargs):
         Mix of keyword arguments that can initialize a MedsubParams and the optional
         'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
         "edge_blend", "interp_zeros", "ker" (see documentation of
-        ``vip_hci.preproc.frame_rotate``). Can also contain a MedsubParams if
-        provided.
+        ``vip_hci.preproc.frame_rotate``). Can also contain a MedsubParams named as
+        `algo_params`.
 
     Median subtraction parameters
     -----------------------------

--- a/vip_hci/psfsub/medsub.py
+++ b/vip_hci/psfsub/medsub.py
@@ -40,15 +40,13 @@ from enum import Enum
 from typing import Tuple, Union
 from ..config import time_ini, timing
 from ..var import get_annulus_segments, mask_circle
-from ..var.paramenum import Imlib, Interpolation, Collapse
+from ..var.paramenum import Imlib, Interpolation, Collapse, ALGO_KEY
 from ..var.object_utils import setup_parameters, separate_kwargs_dict
 from ..preproc import cube_derotate, cube_collapse, check_pa_vector, check_scal_vector
 from ..preproc import cube_rescaling_wavelengths as scwave
 from ..config.utils_conf import pool_map, iterable, print_precision
 from ..preproc.derotation import _find_indices_adi, _define_annuli
 from ..preproc.rescaling import _find_indices_sdi
-
-ALGO_KEY = "algo_params"
 
 
 @dataclass
@@ -90,7 +88,7 @@ def median_sub(*all_args, **all_kwargs):
     Parameters
     ----------
     all_args: list, optional
-        Positionnal arguments for the median_sub function. Full list of parameters
+        Positionnal arguments for the medsub algorithm. Full list of parameters
         below.
     all_kwargs: dictionary, optional
         Mix of keyword arguments that can initialize a MedsubParams and the optional

--- a/vip_hci/psfsub/nmf_fullfr.py
+++ b/vip_hci/psfsub/nmf_fullfr.py
@@ -19,7 +19,7 @@ import numpy as np
 from sklearn.decomposition import NMF
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Tuple
+from typing import Tuple, List
 from ..preproc import cube_derotate, cube_collapse
 from ..preproc.derotation import _compute_pa_thresh, _find_indices_adi
 from ..var import (
@@ -63,7 +63,7 @@ class NMFParams:
     nmf_args: dict = field(default_factory=lambda: {})
 
 
-def nmf(*all_args, **all_kwargs):
+def nmf(*all_args: List, **all_kwargs: dict):
     """Non Negative Matrix Factorization [LEE99]_ for ADI sequences [GOM17]_.
     Alternative to the full-frame ADI-PCA processing that does not rely on SVD
     or ED for obtaining a low-rank approximation of the datacube. This function
@@ -79,8 +79,8 @@ def nmf(*all_args, **all_kwargs):
         Mix of keyword arguments that can initialize a NMFParams and the optional
         'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
         "edge_blend", "interp_zeros", "ker" (see documentation of
-        ``vip_hci.preproc.frame_rotate``). Can also contain a NMFParams if
-        provided.
+        ``vip_hci.preproc.frame_rotate``). Can also contain a NMFParams named as
+        `algo_params`.
 
     NMF parameters
     ----------

--- a/vip_hci/psfsub/nmf_fullfr.py
+++ b/vip_hci/psfsub/nmf_fullfr.py
@@ -31,7 +31,7 @@ from ..var import (
     mask_circle,
 )
 from ..var.object_utils import setup_parameters, separate_kwargs_dict
-from ..var.paramenum import Collapse, HandleNeg, Initsvd
+from ..var.paramenum import Collapse, HandleNeg, Initsvd, ALGO_KEY
 from ..config import timing, time_ini
 
 
@@ -40,7 +40,49 @@ class NMFParams:
     """
     Set of parameters for the NMF full-frame algorithm.
 
+    See function `nmf` below for the documentation.
+    """
+
+    cube: np.ndarray = None
+    angle_list: np.ndarray = None
+    cube_ref: np.ndarray = None
+    ncomp: int = 1
+    scaling: Enum = None
+    max_iter: int = 10000
+    random_state: int = None
+    mask_center_px: int = None
+    source_xy: Tuple[int] = None
+    delta_rot: float = 1
+    fwhm: float = 4
+    init_svd: Enum = Initsvd.NNDSVD
+    collapse: Enum = Collapse.MEDIAN
+    full_output: bool = False
+    verbose: bool = True
+    cube_sig: np.ndarray = None
+    handle_neg: Enum = HandleNeg.MASK
+    nmf_args: dict = field(default_factory=lambda: {})
+
+
+def nmf(*all_args, **all_kwargs):
+    """Non Negative Matrix Factorization [LEE99]_ for ADI sequences [GOM17]_.
+    Alternative to the full-frame ADI-PCA processing that does not rely on SVD
+    or ED for obtaining a low-rank approximation of the datacube. This function
+    embeds the scikit-learn NMF algorithm solved through either the coordinate
+    descent or the multiplicative update method.
+
     Parameters
+    ----------
+    all_args: list, optional
+        Positionnal arguments for the NMF algorithm. Full list of parameters
+        below.
+    all_kwargs: dictionary, optional
+        Mix of keyword arguments that can initialize a NMFParams and the optional
+        'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
+        "edge_blend", "interp_zeros", "ker" (see documentation of
+        ``vip_hci.preproc.frame_rotate``). Can also contain a NMFParams if
+        provided.
+
+    NMF parameters
     ----------
     cube : numpy ndarray, 3d
         Input cube.
@@ -98,44 +140,6 @@ class NMFParams:
     nmf_args : dictionary, optional
         Additional arguments for scikit-learn NMF algorithm. See:
         https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.NMF.html
-    """
-
-    cube: np.ndarray = None
-    angle_list: np.ndarray = None
-    cube_ref: np.ndarray = None
-    ncomp: int = 1
-    scaling: Enum = None
-    max_iter: int = 10000
-    random_state: int = None
-    mask_center_px: int = None
-    source_xy: Tuple[int] = None
-    delta_rot: float = 1
-    fwhm: float = 4
-    init_svd: Enum = Initsvd.NNDSVD
-    collapse: Enum = Collapse.MEDIAN
-    full_output: bool = False
-    verbose: bool = True
-    cube_sig: np.ndarray = None
-    handle_neg: Enum = HandleNeg.MASK
-    nmf_args: dict = field(default_factory=lambda: {})
-
-
-def nmf(algo_params: NMFParams = None, **all_kwargs):
-    """Non Negative Matrix Factorization [LEE99]_ for ADI sequences [GOM17]_.
-    Alternative to the full-frame ADI-PCA processing that does not rely on SVD
-    or ED for obtaining a low-rank approximation of the datacube. This function
-    embeds the scikit-learn NMF algorithm solved through either the coordinate
-    descent or the multiplicative update method.
-
-    Parameters
-    ----------
-    algo_params: NMFParams
-        Dataclass retaining all the needed parameters for NMF full-frame.
-    rot_options: dictionary, optional
-        Dictionary with optional keyword values for "nproc", "imlib",
-        "interpolation, "border_mode", "mask_val",  "edge_blend",
-        "interp_zeros", "ker" (see documentation of
-        ``vip_hci.preproc.frame_rotate``)
 
     Returns
     -------
@@ -148,8 +152,15 @@ def nmf(algo_params: NMFParams = None, **all_kwargs):
     class_params, rot_options = separate_kwargs_dict(
         initial_kwargs=all_kwargs, parent_class=NMFParams
     )
+
+    # Extracting the object of parameters (if any)
+    algo_params = None
+    if ALGO_KEY in rot_options.keys():
+        algo_params = rot_options[ALGO_KEY]
+        del rot_options[ALGO_KEY]
+
     if algo_params is None:
-        algo_params = NMFParams(**class_params)
+        algo_params = NMFParams(*all_args, **class_params)
 
     array = algo_params.cube.copy()
     if algo_params.verbose:

--- a/vip_hci/psfsub/nmf_local.py
+++ b/vip_hci/psfsub/nmf_local.py
@@ -17,18 +17,68 @@ from ..preproc import cube_derotate, cube_collapse, check_pa_vector
 from ..preproc.derotation import _find_indices_adi, _define_annuli
 from ..var import get_annulus_segments, matrix_scaling
 from ..var.object_utils import setup_parameters, separate_kwargs_dict
-from ..var.paramenum import Initsvd, Imlib, Interpolation, HandleNeg, Collapse
+from ..var.paramenum import Initsvd, Imlib, Interpolation, HandleNeg, Collapse, ALGO_KEY
 from ..config import timing, time_ini
 from ..config.utils_conf import pool_map, iterable
 
 
-# TODO: update the doc of the params (some are missing)
 @dataclass
 class NMFAnnParams:
     """
     Set of parameters for the NMF annular algorithm.
 
+    See function `nmf_annular` below for the documentation.
+    """
+
+    cube: np.ndarray = None
+    angle_list: np.ndarray = None
+    cube_ref: np.ndarray = None
+    radius_int: int = 0
+    fwhm: float = 4
+    asize: int = 4
+    n_segments: int = 1
+    delta_rot: Union[float, Tuple[float]] = (0.1, 1)
+    ncomp: int = 1
+    init_svd: Enum = Initsvd.NNDSVD
+    nproc: int = 1
+    min_frames_lib: int = 2
+    max_frames_lib: int = 200
+    scaling: Enum = None
+    imlib: Enum = Imlib.VIPFFT
+    interpolation: Enum = Interpolation.LANCZOS4
+    collapse: Enum = Collapse.MEDIAN
+    full_output: bool = False
+    verbose: bool = True
+    theta_init: float = 0
+    weights: List = None
+    cube_sig: np.ndarray = None
+    handle_neg: Enum = HandleNeg.MASK
+    max_iter: int = 1000
+    random_state: int = None
+    nmf_args: dict = field(default_factory=lambda: {})
+
+
+# TODO: update the doc of the params (some are missing)
+def nmf_annular(*all_args, **all_kwargs):
+    """Non Negative Matrix Factorization in concentric annuli, for ADI/RDI
+    sequences. Alternative to the annular ADI-PCA processing that does not rely
+    on SVD or ED for obtaining a low-rank approximation of the datacube.
+    This function embeds the scikit-learn NMF algorithm solved through either
+    the coordinate descent or the multiplicative update method.
+
     Parameters
+    ----------
+    all_args: list, optional
+        Positionnal arguments for the NMF annular algorithm. Full list of parameters
+        below.
+    all_kwargs: dictionary, optional
+        Mix of keyword arguments that can initialize a NMFAnnParams and the optional
+        'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
+        "edge_blend", "interp_zeros", "ker" (see documentation of
+        ``vip_hci.preproc.frame_rotate``). Can also contain a NMFAnnParams if
+        provided.
+
+    NMF annular parameters
     ----------
     cube : numpy ndarray, 3d
         Input cube.
@@ -112,52 +162,6 @@ class NMFAnnParams:
     nmf_args: dictionary, optional
         Additional arguments for scikit-learn NMF algorithm. See:
         https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.NMF.html
-    """
-
-    cube: np.ndarray = None
-    angle_list: np.ndarray = None
-    cube_ref: np.ndarray = None
-    radius_int: int = 0
-    fwhm: float = 4
-    asize: int = 4
-    n_segments: int = 1
-    delta_rot: Union[float, Tuple[float]] = (0.1, 1)
-    ncomp: int = 1
-    init_svd: Enum = Initsvd.NNDSVD
-    nproc: int = 1
-    min_frames_lib: int = 2
-    max_frames_lib: int = 200
-    scaling: Enum = None
-    imlib: Enum = Imlib.VIPFFT
-    interpolation: Enum = Interpolation.LANCZOS4
-    collapse: Enum = Collapse.MEDIAN
-    full_output: bool = False
-    verbose: bool = True
-    theta_init: float = 0
-    weights: List = None
-    cube_sig: np.ndarray = None
-    handle_neg: Enum = HandleNeg.MASK
-    max_iter: int = 1000
-    random_state: int = None
-    nmf_args: dict = field(default_factory=lambda: {})
-
-
-def nmf_annular(algo_params: NMFAnnParams = None, **all_kwargs):
-    """Non Negative Matrix Factorization in concentric annuli, for ADI/RDI
-    sequences. Alternative to the annular ADI-PCA processing that does not rely
-    on SVD or ED for obtaining a low-rank approximation of the datacube.
-    This function embeds the scikit-learn NMF algorithm solved through either
-    the coordinate descent or the multiplicative update method.
-
-    Parameters
-    ----------
-    algo_params: NMFAnnParams
-        Dataclass retaining all the needed parameters for NMF annular.
-    all_kwargs: dictionary, optional
-        Mix of the parameters that can initialize an algo_params and the optional
-        'rot_options' dictionnary, with keyword values for "imlib", "interpolation,
-        "border_mode", "mask_val",  "edge_blend", "interp_zeros", "ker" (see
-        documentation of ``vip_hci.preproc.frame_rotate``)
 
     Returns
     -------
@@ -170,8 +174,15 @@ def nmf_annular(algo_params: NMFAnnParams = None, **all_kwargs):
     class_params, rot_options = separate_kwargs_dict(
         initial_kwargs=all_kwargs, parent_class=NMFAnnParams
     )
+
+    # Extracting the object of parameters (if any)
+    algo_params = None
+    if ALGO_KEY in rot_options.keys():
+        algo_params = rot_options[ALGO_KEY]
+        del rot_options[ALGO_KEY]
+
     if algo_params is None:
-        algo_params = NMFAnnParams(**class_params)
+        algo_params = NMFAnnParams(*all_args, **class_params)
 
     if algo_params.verbose:
         global start_time

--- a/vip_hci/psfsub/nmf_local.py
+++ b/vip_hci/psfsub/nmf_local.py
@@ -59,7 +59,7 @@ class NMFAnnParams:
 
 
 # TODO: update the doc of the params (some are missing)
-def nmf_annular(*all_args, **all_kwargs):
+def nmf_annular(*all_args: List, **all_kwargs: dict):
     """Non Negative Matrix Factorization in concentric annuli, for ADI/RDI
     sequences. Alternative to the annular ADI-PCA processing that does not rely
     on SVD or ED for obtaining a low-rank approximation of the datacube.
@@ -75,8 +75,8 @@ def nmf_annular(*all_args, **all_kwargs):
         Mix of keyword arguments that can initialize a NMFAnnParams and the optional
         'rot_options' dictionnary, with keyword values for "border_mode", "mask_val",
         "edge_blend", "interp_zeros", "ker" (see documentation of
-        ``vip_hci.preproc.frame_rotate``). Can also contain a NMFAnnParams if
-        provided.
+        ``vip_hci.preproc.frame_rotate``). Can also contain a NMFAnnParams named as
+        `algo_params`..
 
     NMF annular parameters
     ----------

--- a/vip_hci/psfsub/pca_fullfr.py
+++ b/vip_hci/psfsub/pca_fullfr.py
@@ -332,6 +332,8 @@ def pca(*all_args: List, **all_kwargs: dict):
 
     """
     # Separating the parameters of the ParamsObject from the optionnal rot_options
+    print(f"kwargs : {all_kwargs}")
+
     class_params, rot_options = separate_kwargs_dict(
         initial_kwargs=all_kwargs, parent_class=PCAParams
     )

--- a/vip_hci/var/object_utils.py
+++ b/vip_hci/var/object_utils.py
@@ -56,7 +56,7 @@ def setup_parameters(
     params_obj: object,
     fkt: Callable,
     as_list: bool = False,
-    show_params: bool = True,
+    show_params: bool = False,
     **add_params: dict,
 ) -> any:
     """

--- a/vip_hci/var/object_utils.py
+++ b/vip_hci/var/object_utils.py
@@ -5,6 +5,8 @@ from typing import Callable
 
 import numpy as np
 
+KWARGS_EXCEPTIONS = ["param"]
+
 
 def filter_duplicate_keys(filter_item: any, ref_item: any, filter_in: bool = True):
     """
@@ -148,7 +150,7 @@ def separate_kwargs_dict(initial_kwargs: dict, parent_class: any) -> None:
     more_params = {}
 
     for key, value in initial_kwargs.items():
-        if hasattr(parent_class, key):
+        if hasattr(parent_class, key) or key in KWARGS_EXCEPTIONS:
             class_params[key] = value
         else:
             more_params[key] = value

--- a/vip_hci/var/paramenum.py
+++ b/vip_hci/var/paramenum.py
@@ -2,6 +2,8 @@
 from enum import auto
 from enum import Enum
 
+ALGO_KEY = "algo_params"
+
 
 class SvdMode(str, Enum):
     """


### PR DESCRIPTION
Reintroduced the possibility to give positionnal arguments in algorithms (such as : `pca(cube, angs, fwhm=fwhm,...)`)
Also exported PP objects on top of their builders, so they can appear in the documentation.