### PR TITLE
new fits.open_header function, typo fixes and better verbosity 

### DIFF
--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -5,14 +5,18 @@ Module with various fits handling functions.
 
 
 __author__ = "C. A. Gomez Gonzalez, T. Bédrine, V. Christiaens"
-__all__ = ["open_fits", "info_fits", "write_fits", "verify_fits", 
+__all__ = ["open_fits", "info_fits", "write_fits", "verify_fits",
            "byteswap_array"]
 
 
-import os
+from os.path import isfile, exists
+from os import remove
+
 import numpy as np
-from astropy.io import fits as ap_fits
-from astropy.io.fits import HDUList
+from astropy.io.fits.convenience import writeto
+from astropy.io.fits.hdu.hdulist import fitsopen, HDUList
+from astropy.io.fits.hdu.image import ImageHDU
+
 from ..config.paramenum import ALL_FITS
 
 
@@ -57,19 +61,19 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
         equals -2, returns a list of all arrays.
     header : dict or list of dict
         [memmap=False, header=True] Dictionary containing the fits header.
-        If n equals -2, returns a list of all dictionnaries.
+        If n equals -2, returns a list of all dictionaries.
 
     """
     fitsfilename = str(fitsfilename)
-    if not os.path.isfile(fitsfilename):
+    if not isfile(fitsfilename):
         fitsfilename += ".fits"
-    
+
     try:
-        hdulist = ap_fits.open(fitsfilename, 
+        hdulist = open(fitsfilename,
                                ignore_missing_end=ignore_missing_end,
                    	           	memmap=True, **kwargs)
     except: # If BZERO/BSCALE/BLANK header keywords are present, HDU can’t be loaded as memory map
-        hdulist = ap_fits.open(fitsfilename,
+        hdulist = open(fitsfilename,
                                ignore_missing_end=ignore_missing_end,
                    	           	memmap=False, **kwargs)
 
@@ -84,24 +88,28 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
             data, head = _return_data_fits(hdulist=hdulist, index=index,
                                            precision=precision,
                                            verbose=verbose)
+            data, head = _return_data_fits(hdulist=hdulist, index=index,
+                                           header=header, precision=precision,
+                                           verbose=verbose)
             data_list.append(data)
             header_list.append(head)
 
         hdulist.close()
         if header:
             if verbose:
-                print(f"All fits HDU data and headers succesfully loaded.")
+                print(f"All {len(hdulist)} FITS HDUs and headers successfully loaded. ")
             return data_list, header_list
         else:
             if verbose:
-                print(f"All fits HDU data succesfully loaded.")
+                print(f"All {len(hdulist)} FITS HDUs successfully loaded.")
             return data_list
+
     # Opening only a specified extension
     else:
         if return_memmap:
             return hdulist[n]
 
-        data, head = _return_data_fits(hdulist=hdulist, index=n, 
+        data, head = _return_data_fits(hdulist=hdulist, index=n,
                                        precision=precision, verbose=verbose)
         hdulist.close()
         if header:
@@ -112,6 +120,7 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
 
 def _return_data_fits(hdulist: HDUList,
                       index: int,
+                      header: bool = False,
                       precision=np.float32,
                       verbose: bool = True,
 ):
@@ -130,10 +139,13 @@ def _return_data_fits(hdulist: HDUList,
     head = hdulist[index].header
 
     if verbose:
-        print(
-            f"Fits HDU-{index} data successfully loaded, header available. "
-            f"Data shape: {data.shape}"
-        )
+        if header:
+            print(f"FITS HDU-{index} data and header successfully loaded. "
+                  f"Data shape: {data.shape}")
+        else:
+            print(f"FITS HDU-{index} data successfully loaded. "
+                  f"Data shape: {data.shape}")
+
     return data, head
 
 
@@ -183,7 +195,7 @@ def info_fits(fitsfilename, **kwargs):
         "output_verify" can be set to ignore, in case of non-standard header.
 
     """
-    with ap_fits.open(fitsfilename, memmap=True, **kwargs) as hdulist:
+    with fitsopen(fitsfilename, memmap=True, **kwargs) as hdulist:
         hdulist.info()
 
 
@@ -199,10 +211,10 @@ def verify_fits(fitsfilename):
     """
     if isinstance(fitsfilename, list):
         for ffile in fitsfilename:
-            with ap_fits.open(ffile) as f:
+            with fitsopen(ffile) as f:
                 f.verify()
     else:
-        with ap_fits.open(fitsfilename) as f:
+        with fitsopen(fitsfilename) as f:
             f.verify()
 
 
@@ -238,12 +250,12 @@ def write_fits(fitsfilename, array, header=None, output_verify="exception",
         fitsfilename += ".fits"
 
     res = "saved"
-    if os.path.exists(fitsfilename):
-        os.remove(fitsfilename)
+    if exists(fitsfilename):
+        remove(fitsfilename)
         res = "overwritten"
 
     if isinstance(array, tuple):
-        new_hdul = ap_fits.HDUList()
+        new_hdul = HDUList()
         if header is None:
             header = [None] * len(array)
         elif not isinstance(header, tuple):
@@ -255,12 +267,12 @@ def write_fits(fitsfilename, array, header=None, output_verify="exception",
 
         for i in range(len(array)):
             array_tmp = array[i].astype(precision, copy=False)
-            new_hdul.append(ap_fits.ImageHDU(array_tmp, header=header[i]))
+            new_hdul.append(ImageHDU(array_tmp, header=header[i]))
 
         new_hdul.writeto(fitsfilename, output_verify=output_verify)
     else:
         array = array.astype(precision, copy=False)
-        ap_fits.writeto(fitsfilename, array, header, output_verify)
+        writeto(fitsfilename, array, header, output_verify)
 
     if verbose:
-        print("Fits file successfully {}".format(res))
+        print(f"Fits file successfully {res}")

--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -69,13 +69,11 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
         fitsfilename += ".fits"
 
     try:
-        hdulist = open(fitsfilename,
-                               ignore_missing_end=ignore_missing_end,
-                   	           	memmap=True, **kwargs)
-    except: # If BZERO/BSCALE/BLANK header keywords are present, HDU can’t be loaded as memory map
-        hdulist = open(fitsfilename,
-                               ignore_missing_end=ignore_missing_end,
-                   	           	memmap=False, **kwargs)
+        hdulist = fitsopen(fitsfilename, ignore_missing_end=ignore_missing_end,
+                           memmap=True, **kwargs)
+    except ValueError:  # If BZERO/BSCALE/BLANK header keywords are present, HDU can’t be loaded as memory map
+        hdulist = fitsopen(fitsfilename, ignore_missing_end=ignore_missing_end,
+                           memmap=False, **kwargs)
 
     # Opening all extensions in a MEF
     if n == ALL_FITS:
@@ -86,9 +84,6 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
 
         for index, element in enumerate(hdulist):
             data, head = _return_data_fits(hdulist=hdulist, index=index,
-                                           precision=precision,
-                                           verbose=verbose)
-            data, head = _return_data_fits(hdulist=hdulist, index=index,
                                            header=header, precision=precision,
                                            verbose=verbose)
             data_list.append(data)
@@ -97,11 +92,11 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
         hdulist.close()
         if header:
             if verbose:
-                print(f"All {len(hdulist)} FITS HDUs and headers successfully loaded. ")
+                print(f"All {len(hdulist)} FITS HDU data and headers successfully loaded. ")
             return data_list, header_list
         else:
             if verbose:
-                print(f"All {len(hdulist)} FITS HDUs successfully loaded.")
+                print(f"All {len(hdulist)} FITS HDU data successfully loaded. ")
             return data_list
 
     # Opening only a specified extension
@@ -109,7 +104,7 @@ def open_fits(fitsfilename, n=0, header=False, ignore_missing_end=False,
         if return_memmap:
             return hdulist[n]
 
-        data, head = _return_data_fits(hdulist=hdulist, index=n,
+        data, head = _return_data_fits(hdulist=hdulist, index=n, header=header,
                                        precision=precision, verbose=verbose)
         hdulist.close()
         if header:
@@ -122,8 +117,7 @@ def _return_data_fits(hdulist: HDUList,
                       index: int,
                       header: bool = False,
                       precision=np.float32,
-                      verbose: bool = True,
-):
+                      verbose: bool = True):
     """
     Subfunction used to return data (and header) from a given index.
 
@@ -175,7 +169,7 @@ def byteswap_array(array):
     Note
     ----
     More info about byteswapping here:
-    http://docs.scipy.org/doc/numpy-1.10.1/user/basics.byteswapping.html
+    https://docs.scipy.org/doc/numpy-1.10.1/user/basics.byteswapping.html
 
     """
     array_out = array.byteswap().newbyteorder()

--- a/vip_hci/fits/fits.py
+++ b/vip_hci/fits/fits.py
@@ -4,7 +4,7 @@ Module with various fits handling functions.
 """
 
 
-__author__ = "C. A. Gomez Gonzalez, T. Bédrine, V. Christiaens"
+__author__ = "C. A. Gomez Gonzalez, T. Bédrine, V. Christiaens, I. Hammond"
 __all__ = ["open_fits", "info_fits", "write_fits", "verify_fits",
            "byteswap_array"]
 

--- a/vip_hci/fm/negfc_fmerit.py
+++ b/vip_hci/fm/negfc_fmerit.py
@@ -68,7 +68,7 @@ def chisquare(
     psfs_norm: numpy.array
         The scaled psf expressed as a numpy.array.
     fwhm : float
-        The FHWM in pixels.
+        The FWHM in pixels.
     annulus_width: int, optional
         The width in pixels of the annulus on which the PCA is done.
     aperture_radius: int, optional

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -137,7 +137,7 @@ def lnlike(param, cube, angs, psf_norm, fwhm, annulus_width, ncomp,
     ncomp: int or None
         The number of principal components for PCA-based algorithms.
     fwhm : float
-        The FHWM in pixels.
+        The FWHM in pixels.
     aperture_radius: float
         The radius of the circular aperture in terms of the FWHM.
     initial_state: numpy.array
@@ -335,7 +335,7 @@ def lnprob(param, bounds, cube, angs, psf_norm, fwhm, annulus_width, ncomp,
         If the input cube is 4D, psfn must be either 3D or 4D. In either cases,
         the first dimension(s) must match those of the input cube.
     fwhm : float
-        The FHWM in pixels.
+        The FWHM in pixels.
     annulus_width: float
         The width in pixel of the annulus on wich the PCA is performed.
     ncomp: int or None
@@ -525,7 +525,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     aperture_radius: float, optional
         The radius in FWHM of the circular aperture.
     fwhm : float
-        The FHWM in pixels.
+        The FWHM in pixels.
     mu_sigma: tuple of 2 floats or bool, opt
         If set to None: not used, and falls back to original version of the
         algorithm, using ``fmerit`` [WER17]_.

--- a/vip_hci/fm/negfc_nested.py
+++ b/vip_hci/fm/negfc_nested.py
@@ -88,7 +88,7 @@ def nested_negfc_sampling(init, cube, angs, psfn, fwhm, mu_sigma=True,
         If the input cube is 4D, psfn must be either 3D or 4D. In either cases,
         the first dimension(s) must match those of the input cube.
     fwhm : float
-        The FHWM in pixels.
+        The FWHM in pixels.
     mu_sigma: tuple of 2 floats or bool, opt
         If set to None: not used, and falls back to original version of the
         algorithm, using fmerit [WER17]_.

--- a/vip_hci/fm/negfc_simplex.py
+++ b/vip_hci/fm/negfc_simplex.py
@@ -54,7 +54,7 @@ def firstguess_from_coord(planet, center, cube, angs, psfn, fwhm, annulus_width,
         If the input cube is 4D, psfn must be either 3D or 4D. In either cases,
         the first dimension(s) must match those of the input cube.
     fwhm : float
-        The FHWM in pixels.
+        The FWHM in pixels.
     annulus_width: int, optional
         The width in pixels of the annulus on which the PCA is done.
     aperture_radius: int, optional
@@ -323,7 +323,7 @@ def firstguess_simplex(p, cube, angs, psfn, ncomp, fwhm, annulus_width,
     ncomp: int or None
         The number of principal components.
     fwhm : float
-        The FHWM in pixels.
+        The FWHM in pixels.
     annulus_width: int, optional
         The width in pixels of the annulus on which the PCA is done.
     aperture_radius: int, optional
@@ -479,7 +479,7 @@ def firstguess(cube, angs, psfn, ncomp, planets_xy_coord, fwhm=4,
     plsc: float, optional
         The platescale, in arcsec per pixel.
     fwhm : float, optional
-        The FHWM in pixels.
+        The FWHM in pixels.
     annulus_width: int, optional
         The width in pixels of the annulus on which the PCA is done.
     aperture_radius: int, optional

--- a/vip_hci/metrics/detection.py
+++ b/vip_hci/metrics/detection.py
@@ -13,7 +13,7 @@ __all__ = ['detection',
 import numpy as np
 import pandas as pn
 from hciplot import plot_frames
-from scipy.ndimage.filters import correlate
+from scipy.ndimage import correlate
 from skimage import feature
 from astropy.stats import sigma_clipped_stats
 from astropy.stats import gaussian_fwhm_to_sigma, gaussian_sigma_to_fwhm

--- a/vip_hci/objects/dataset.py
+++ b/vip_hci/objects/dataset.py
@@ -601,7 +601,7 @@ class Dataset(Saveable):
         self.fwhm = fwhm
         if self.fwhm is not None:
             if self.cube.ndim == 4:
-                check_array(self.fwhm, dim=1, msg="FHWM")
+                check_array(self.fwhm, dim=1, msg="FWHM")
             elif self.cube.ndim == 3:
                 print("FWHM: {}".format(self.fwhm))
         self.px_scale = px_scale

--- a/vip_hci/preproc/badpixremoval.py
+++ b/vip_hci/preproc/badpixremoval.py
@@ -15,7 +15,8 @@ Module with functions for correcting bad pixels in cubes.
 
 
 import warnings
-__author__ = 'V. Christiaens, Carlos Alberto Gomez Gonzalez'
+__author__ = ('V. Christiaens, Carlos Alberto Gomez Gonzalez, '
+              'Srikanth Kompella')
 __all__ = ['frame_fix_badpix_isolated',
            'cube_fix_badpix_isolated',
            'cube_fix_badpix_annuli',
@@ -334,7 +335,8 @@ def cube_fix_badpix_isolated(array, bpm_mask=None, correct_only=False,
                 array_out[i] = res[0]
                 final_bpm[i] = res[1]
         else:
-            print("Processing using ADACS' multiprocessing approach...")
+            if verbose:
+                print("Cleaning frames using ADACS' multiprocessing approach")
             # dummy calling the function to create cached version of the code prior to forking
             if bpm_mask is not None:
                 bpm_mask_dum = bpm_mask[0]
@@ -1110,8 +1112,8 @@ def cube_fix_badpix_clump(array, bpm_mask=None, correct_only=False, cy=None,
                                         verbose)
                     array_corr[i], bpix_map_cumul[i] = res
             else:
-                msg = "Cleaning frames using ADACS' multiprocessing approach"
-                print(msg)
+                if verbose:
+                    print("Cleaning frames using ADACS' multiprocessing approach")
                 # creating shared memory buffer space for the image cube.
                 shm_clump = shared_memory.SharedMemory(create=True,
                                                        size=array_corr.nbytes)
@@ -1182,8 +1184,8 @@ def cube_fix_badpix_clump(array, bpm_mask=None, correct_only=False, cy=None,
                                                  neighbor_box, nneig, half_res_y,
                                                  verbose)
             else:
-                msg = "Cleaning frames using ADACS' multiprocessing approach"
-                print(msg)
+                if verbose:
+                    print("Cleaning frames using ADACS' multiprocessing approach")
                 # dummy calling sigma_filter function to create a cached version of the numba function
                 if bpm_mask.ndim == 3:
                     dummy_bpm = bpm_mask[0]

--- a/vip_hci/psfsub/framediff.py
+++ b/vip_hci/psfsub/framediff.py
@@ -76,7 +76,7 @@ def frame_diff(*all_args: List, **all_kwargs: dict):
     angle_list : numpy ndarray, 1d
         Corresponding parallactic angle for each frame.
     fwhm : float, optional
-        Known size of the FHWM in pixels to be used. Default is 4.
+        Known size of the FWHM in pixels to be used. Default is 4.
     metric : str, optional
         Distance metric to be used ('cityblock', 'cosine', 'euclidean', 'l1',
         'l2', 'manhattan', 'correlation', etc). It uses the scikit-learn

--- a/vip_hci/psfsub/llsg.py
+++ b/vip_hci/psfsub/llsg.py
@@ -98,7 +98,7 @@ def llsg(*all_args: List, **all_kwargs: dict):
     angle_list : numpy ndarray, 1d
         Corresponding parallactic angle for each frame.
     fwhm : float
-        Known size of the FHWM in pixels to be used.
+        Known size of the FWHM in pixels to be used.
     rank : int, optional
         Expected rank of the L component.
     thresh : float, optional

--- a/vip_hci/psfsub/loci.py
+++ b/vip_hci/psfsub/loci.py
@@ -103,7 +103,7 @@ def xloci(*all_args: List, **all_kwargs: dict):
         cube (more thorough approaches can be used to get the scaling factors,
         e.g. with ``vip_hci.preproc.find_scal_vector``).
     fwhm : float, optional
-        Size of the FHWM in pixels. Default is 4.
+        Size of the FWHM in pixels. Default is 4.
     metric : Enum, see `vip_hci.config.paramenum.Metric`
         Distance metric to be used ('cityblock', 'cosine', 'euclidean', 'l1',
         'l2', 'manhattan', 'correlation', etc). It uses the scikit-learn
@@ -114,7 +114,7 @@ def xloci(*all_args: List, **all_kwargs: dict):
         initially discarded. 100 by default.
     delta_rot : float or tuple of floats, optional
         Factor for adjusting the parallactic angle threshold, expressed in
-        FWHM. Default is 1 (excludes 1 FHWM on each side of the considered
+        FWHM. Default is 1 (excludes 1 FWHM on each side of the considered
         frame). If a tuple of two floats is provided, they are used as the lower
         and upper intervals for the threshold (grows linearly as a function of
         the separation).

--- a/vip_hci/psfsub/medsub.py
+++ b/vip_hci/psfsub/medsub.py
@@ -119,7 +119,7 @@ def median_sub(*all_args: List, **all_kwargs: dict):
         provided, the algorithm will still work, but with a lower efficiency
         at subtracting the stellar halo.
     fwhm : float or 1d numpy array
-        Known size of the FHWM in pixels to be used. Default is 4.
+        Known size of the FWHM in pixels to be used. Default is 4.
     radius_int : int, optional
         The radius of the innermost annulus. By default is 0, if >0 then the
         central circular area is discarded.
@@ -127,7 +127,7 @@ def median_sub(*all_args: List, **all_kwargs: dict):
         The size of the annuli, in pixels.
     delta_rot : int, optional
         Factor for increasing the parallactic angle threshold, expressed in
-        FWHM. Default is 1 (excludes 1 FHWM on each side of the considered
+        FWHM. Default is 1 (excludes 1 FWHM on each side of the considered
         frame).
     delta_sep : float or tuple of floats, optional
         The threshold separation in terms of the mean FWHM (for ADI+mSDI data).

--- a/vip_hci/psfsub/nmf_fullfr.py
+++ b/vip_hci/psfsub/nmf_fullfr.py
@@ -109,9 +109,9 @@ def nmf(*all_args: List, **all_kwargs: dict):
         given (X,Y) coordinates are computed.
     delta_rot : float, optional
         Factor for tunning the parallactic angle threshold, expressed in FWHM.
-        Default is 1 (excludes 1xFHWM on each side of the considered frame).
+        Default is 1 (excludes 1xFWHM on each side of the considered frame).
     fwhm : float, optional
-        Known size of the FHWM in pixels to be used. Default value is 4.
+        Known size of the FWHM in pixels to be used. Default value is 4.
     init_svd: Enum, see `vip_hci.config.paramenum.Initsvd`
         Method used to initialize the iterative procedure to find H and W.
         'nndsvd': non-negative double SVD recommended for sparseness

--- a/vip_hci/psfsub/nmf_local.py
+++ b/vip_hci/psfsub/nmf_local.py
@@ -89,7 +89,7 @@ def nmf_annular(*all_args: List, **all_kwargs: dict):
         The radius of the innermost annulus. By default is 0, if >0 then the
         central circular region is discarded.
     fwhm : float, optional
-        Size of the FHWM in pixels. Default is 4.
+        Size of the FWHM in pixels. Default is 4.
     asize : float, optional
         The size of the annuli, in pixels.
     n_segments : int or list of ints or 'auto', optional
@@ -98,7 +98,7 @@ def nmf_annular(*all_args: List, **all_kwargs: dict):
         automatically determined for every annulus, based on the annulus width.
     delta_rot : float or tuple of floats, optional
         Factor for adjusting the parallactic angle threshold, expressed in
-        FWHM. Default is 1 (excludes 1 FHWM on each side of the considered
+        FWHM. Default is 1 (excludes 1 FWHM on each side of the considered
         frame). If a tuple of two floats is provided, they are used as the lower
         and upper intervals for the threshold (grows linearly as a function of
         the separation). !!! Important: this is used even if a reference cube
@@ -144,7 +144,7 @@ def nmf_annular(*all_args: List, **all_kwargs: dict):
         given (X,Y) coordinates are computed.
     delta_rot : int, optional
         Factor for tunning the parallactic angle threshold, expressed in FWHM.
-        Default is 1 (excludes 1xFHWM on each side of the considered frame).
+        Default is 1 (excludes 1xFWHM on each side of the considered frame).
     init_svd: str, optional {'nnsvd','nnsvda','random'}
         Method used to initialize the iterative procedure to find H and W.
         'nndsvd': non-negative double SVD recommended for sparseness

--- a/vip_hci/psfsub/pca_fullfr.py
+++ b/vip_hci/psfsub/pca_fullfr.py
@@ -222,9 +222,9 @@ def pca(*all_args: List, **all_kwargs: dict):
         given (X,Y) coordinates are computed.
     delta_rot : int, optional
         Factor for tuning the parallactic angle threshold, expressed in FWHM.
-        Default is 1 (excludes 1xFHWM on each side of the considered frame).
+        Default is 1 (excludes 1xFWHM on each side of the considered frame).
     fwhm : float, list or 1d numpy array, optional
-        Known size of the FHWM in pixels to be used. Default value is 4.
+        Known size of the FWHM in pixels to be used. Default value is 4.
         Can be a list or 1d numpy array for a 4d input cube with no scale_list.
     adimsdi : Enum, see `vip_hci.config.paramenum.Adimsdi`
         Changes the way the 4d cubes (ADI+mSDI) are processed. Basically it

--- a/vip_hci/psfsub/pca_local.py
+++ b/vip_hci/psfsub/pca_local.py
@@ -121,7 +121,7 @@ def pca_annular(*all_args: List, **all_kwargs: dict):
         The radius of the innermost annulus. By default is 0, if >0 then the
         central circular region is discarded.
     fwhm : float, optional
-        Size of the FHWM in pixels. Default is 4.
+        Size of the FWHM in pixels. Default is 4.
     asize : float, optional
         The size of the annuli, in pixels.
     n_segments : int or list of ints or 'auto', optional
@@ -130,7 +130,7 @@ def pca_annular(*all_args: List, **all_kwargs: dict):
         automatically determined for every annulus, based on the annulus width.
     delta_rot : float or tuple of floats, optional
         Factor for adjusting the parallactic angle threshold, expressed in
-        FWHM. Default is 1 (excludes 1 FHWM on each side of the considered
+        FWHM. Default is 1 (excludes 1 FWHM on each side of the considered
         frame). If a tuple of two floats is provided, they are used as the lower
         and upper intervals for the threshold (grows linearly as a function of
         the separation).

--- a/vip_hci/var/fit_2d.py
+++ b/vip_hci/var/fit_2d.py
@@ -190,8 +190,8 @@ def fit_2dgaussian(array, crop=False, cent=None, cropsize=15, fwhmx=4, fwhmy=4,
     following columns:
         'centroid_y': Y coordinate of the centroid.
         'centroid_x': X coordinate of the centroid.
-        'fwhm_y': Float value. FHWM in X [px].
-        'fwhm_x': Float value. FHWM in Y [px].
+        'fwhm_y': Float value. FWHM in X [px].
+        'fwhm_x': Float value. FWHM in Y [px].
         'amplitude': Amplitude of the Gaussian.
         'theta': Float value. Rotation angle.
         # and fit uncertainties on the above values:
@@ -359,7 +359,7 @@ def fit_2dmoffat(array, crop=False, cent=None, cropsize=15, fwhm=4,
     'amplitude' : Float value. Moffat Amplitude.
     'centroid_x' : Float value. X coordinate of the centroid.
     'centroid_y' : Float value. Y coordinate of the centroid.
-    'fwhm' : Float value. FHWM [px].
+    'fwhm' : Float value. FWHM [px].
     'gamma' : Float value. Gamma parameter.
 
     """
@@ -506,7 +506,7 @@ def fit_2dairydisk(array, crop=False, cent=None, cropsize=15, fwhm=4,
     'amplitude' : Float value. Moffat Amplitude.
     'centroid_x' : Float value. X coordinate of the centroid.
     'centroid_y' : Float value. Y coordinate of the centroid.
-    'fwhm' : Float value. FHWM [px].
+    'fwhm' : Float value. FWHM [px].
 
     """
     check_array(array, dim=2, msg='array')
@@ -669,15 +669,15 @@ def fit_2d2gaussian(array, crop=False, cent=None, cropsize=15, fwhm_neg=4,
     'amplitude' : Float value. Amplitude of the Gaussian.
     'centroid_x' : Float value. X coordinate of the centroid.
     'centroid_y' : Float value. Y coordinate of the centroid.
-    'fwhm_x' : Float value. FHWM in X [px].
-    'fwhm_y' : Float value. FHWM in Y [px].
+    'fwhm_x' : Float value. FWHM in X [px].
+    'fwhm_y' : Float value. FWHM in Y [px].
     'theta' : Float value. Rotation angle of x axis
     - for the negative gaussian:
     'amplitude_neg' : Float value. Amplitude of the Gaussian.
     'centroid_x_neg' : Float value. X coordinate of the centroid.
     'centroid_y_neg' : Float value. Y coordinate of the centroid.
-    'fwhm_x_neg' : Float value. FHWM in X [px].
-    'fwhm_y_neg' : Float value. FHWM in Y [px].
+    'fwhm_x_neg' : Float value. FWHM in X [px].
+    'fwhm_y_neg' : Float value. FWHM in Y [px].
     'theta_neg' : Float value. Rotation angle of x axis
     """
     if not array.ndim == 2:

--- a/vip_hci/var/shapes.py
+++ b/vip_hci/var/shapes.py
@@ -857,7 +857,7 @@ def mask_roi(array, source_xy, exc_radius=4, ann_width=4, inc_radius=8,
     source_xy: tuple of 2 int
         Pixel coordinates of the location of interest.
     exc_radius : float
-        Known size of the FHWM in pixels to be used. Default is 4.
+        Known size of the FWHM in pixels to be used. Default is 4.
     ann_width: int
         Width (in pxs) of the annulus (region 3 on description).
     inc_radius: int


### PR DESCRIPTION
hello there's a new function in `vip_hci.fits` for only opening FITS headers (`open_header`). This is designed to be super lightweight and is a wrapper around a core astropy function with a nice VIP interface. It behaves very similar to `open_fits` but is about 40 times faster to use on an average sized SPHERE data set, depending on your disk speed and file sizes. Good for pipeline use. It allows for opening HDU headers by number `n` or by HDU name `extname` too.

I adapted the new try/except in `open_fits` to better catch the specific astropy error it's meant to avoid, rather than potentially hiding something else. This came about because I noticed this try/except doesn't work on SPHERE data that has BZERO/BSCALE/BLANK header keywords as it still opens the file and raises the error later when accessing the hdulist.data containing those keywords. I don't know any way to avoid this and it's uncommon enough to probably not matter. I've also tidied the code and improved the verbosity.

Every typo of FWHM has been fixed and bad pixel correction no longer reminds you that ADACS made it lighting fast even if you ask for verbose=False, but we very much appreciate their work and I've added our developer to the authors of that function. 

Finally I fixed an upcoming `scipy.ndimage.filter` deprecation 