### PR TITLE
Correction to how the reference dataset is built in do_pca_patch

### DIFF
--- a/vip_hci/psfsub/pca_local.py
+++ b/vip_hci/psfsub/pca_local.py
@@ -805,24 +805,14 @@ def do_pca_patch(
         if data_ref.shape[0] < min_frames_lib and matrix_ref is None:
             raise RuntimeError(msg.format(len(indices_left), min_frames_lib))
     else:
-        data_ref = None
-
-    if matrix_ref is not None:
-        # data_ref = None
-        # if matrix_ref is not None:
-        # Stacking the ref and the target ref (pa thresh) libraries
-        if data_ref is not None:
-            data_ref = np.vstack((matrix_ref, data_ref))
-        else:
-            data_ref = matrix_ref
-    elif pa_threshold == 0:
         if matrix_sig_segm is not None:
             data_ref = matrix - matrix_sig_segm
         else:
             data_ref = matrix
 
-    if matrix_ref is not None and matrix_sig_segm is None:
-        # Stacking the ref and the target (pa thresh) libraries
+
+    if matrix_ref is not None:
+        # Stacking the ref and the target ref (pa thresh) libraries
         if data_ref is not None:
             data_ref = np.vstack((matrix_ref, data_ref))
         else:


### PR DESCRIPTION
In the function "do_pca_patch" used in the PCA_annular algorithm, in some cases, the reference images (matrix_ref) were stacked twice in data_ref in the RDI+ADI case