### PR TITLE
Made the contrast_curve function more robust to classes with inherited attributes

### DIFF
--- a/vip_hci/metrics/contrcurve.py
+++ b/vip_hci/metrics/contrcurve.py
@@ -730,7 +730,7 @@ def throughput(
         mod = algo.__module__[:idx]
         tmp = __import__(mod, fromlist=[algo_name.upper()+'_Params'])
         algo_params = getattr(tmp, algo_name.upper()+'_Params')
-        argl = [attr for attr in vars(algo_params)]
+        argl = [attr for attr in dir(algo_params)]
         if "cube" in argl and "angle_list" in argl and "verbose" in argl:
             # (ii) a VIP postproc algorithm [OK]
             pass
@@ -870,7 +870,7 @@ def throughput(
                     tmp = __import__(
                         mod, fromlist=[algo_name.upper()+'_Params'])
                     algo_params = getattr(tmp, algo_name.upper()+'_Params')
-                    arg = [attr for attr in vars(algo_params)]
+                    arg = [attr for attr in dir(algo_params)]
                     if "cube" in arg and "angle_list" in arg and "verbose" in arg:
                         # (ii) a VIP postproc algorithm [OK]
                         pass
@@ -996,7 +996,7 @@ def throughput(
                     tmp = __import__(
                         mod, fromlist=[algo_name.upper()+'_Params'])
                     algo_params = getattr(tmp, algo_name.upper()+'_Params')
-                    arg = [attr for attr in vars(algo_params)]
+                    arg = [attr for attr in dir(algo_params)]
                     if "cube" in arg and "angle_list" in arg and "verbose" in arg:
                         # (ii) a VIP postproc algorithm [OK]
                         pass


### PR DESCRIPTION
In the contrast curve function, an algorithm using a class with certain specific inherited attributes is not supported. This change makes it more robust to those kinds of algorithms if they need to be used.