### PR TITLE
Bug fix for PCA-RDI with 4D cubes + a few new features

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,16 +1,13 @@
 VIP - Vortex Image Processing package
 =====================================
 
-|VIP| |Versions| |travis| |License| |ArXiV| |docs| |codecov| |DOI| |Zenodo| |EMAC|
+|VIP| |Versions| |License| |ArXiV| |docs| |codecov| |DOI| |Zenodo| |EMAC|
 
 .. |VIP| image:: https://badge.fury.io/py/vip-hci.svg
         :target: https://pypi.python.org/pypi/vip-hci
 
 .. |Versions| image:: https://img.shields.io/badge/Python-3.7%2C%203.8%2C%203.9%2C%203.10%2C%203.11-brightgreen.svg
              :target: https://pypi.python.org/pypi/vip-hci
-
-.. |travis| image:: https://travis-ci.com/vortex-exoplanet/VIP.svg?branch=master
-           :target: https://travis-ci.com/vortex-exoplanet/VIP
 
 .. |License| image:: https://img.shields.io/badge/license-MIT-blue.svg?style=flat
             :target: https://github.com/vortex-exoplanet/VIP/blob/master/LICENSE

--- a/vip_hci/fm/negfc_fmerit.py
+++ b/vip_hci/fm/negfc_fmerit.py
@@ -493,6 +493,7 @@ def get_values_optimize(
             res_tmp = algo(
                 cube=crop_cube,
                 angle_list=angs,
+                cube_ref=cube_ref,
                 radius_int=radius_int,
                 fwhm=fwhm,
                 asize=annulus_width,
@@ -516,6 +517,7 @@ def get_values_optimize(
             res_tmp = algo(
                 cube=crop_cube,
                 angle_list=angs,
+                cube_ref=cube_ref,
                 radius_int=radius_int,
                 fwhm=fwhm,
                 asize=annulus_width,

--- a/vip_hci/fm/negfc_fmerit.py
+++ b/vip_hci/fm/negfc_fmerit.py
@@ -454,6 +454,8 @@ def get_values_optimize(
     collapse = algo_options.get("collapse", collapse)
     collapse_ifs = algo_options.get("collapse_ifs", "absmean")
     nproc = algo_options.get("nproc", 1)
+    if algo == pca:
+        mask_rdi = algo_options.get("mask_rdi", None)
 
     if algo == pca_annulus:
         res = pca_annulus(
@@ -555,6 +557,7 @@ def get_values_optimize(
             ifs_collapse_range=ifs_collapse_range,
             nproc=nproc,
             weights=weights,
+            mask_rdi=mask_rdi,
             verbose=False,
         )
     else:

--- a/vip_hci/greedy/ipca_fullfr.py
+++ b/vip_hci/greedy/ipca_fullfr.py
@@ -428,6 +428,7 @@ def ipca(*all_args: List, **all_kwargs: dict):
         cube_ref_tmp = None
 
     # 2. Get a first disc estimate, using PCA
+    pca_params['ncomp'] = final_ncomp[0]
     pca_params['cube_ref'] = ref_cube
     res = pca(**pca_params, **rot_options)
     frame = res[0]

--- a/vip_hci/psfsub/pca_fullfr.py
+++ b/vip_hci/psfsub/pca_fullfr.py
@@ -108,6 +108,8 @@ class PCA_Params:
     source_xy: Tuple[int] = None
     delta_rot: int = None
     fwhm: float = 4
+    # strategy: str = 'ADI' # TBD: add a strategy keyword: 'ADI', 'RDI', 'ARDI',
+    # 'ASDI', 'SDI', 'S+ADI', 'ARSDI', 'RSDI' => replace 'adimsdi'
     adimsdi: Enum = Adimsdi.SINGLE
     crop_ifs: bool = True
     imlib: Enum = Imlib.VIPFFT

--- a/vip_hci/psfsub/pca_fullfr.py
+++ b/vip_hci/psfsub/pca_fullfr.py
@@ -505,6 +505,9 @@ def pca(*all_args: List, **all_kwargs: dict):
         recon = []
         residuals_cube = []
         residuals_cube_ = []
+        final_residuals_cube = []
+        recon_cube = []
+        medians = []
 
         # (ADI+)RDI
         if algo_params.cube_ref is not None:
@@ -533,13 +536,8 @@ def pca(*all_args: List, **all_kwargs: dict):
                 ifs_adi_frames[ch] = res_pca[-1]
         # ADI
         else:
-            final_residuals_cube = []
             table = []
-            recon_cube = []
-            residuals_cube = []
-            residuals_cube_ = []
             pclist = []
-            medians = []
             for ch in range(nch):
                 add_params = {
                     "start_time": start_time,
@@ -590,9 +588,9 @@ def pca(*all_args: List, **all_kwargs: dict):
 
             if grid_case:
                 for i in range(len(ncomp[0])):
-                    frame = [cube_collapse(ifs_adi_frames[:, i],
-                                           mode=algo_params.collapse_ifs)]
-                    final_residuals_cube = frame
+                    frame = cube_collapse(ifs_adi_frames[:, i],
+                                          mode=algo_params.collapse_ifs)
+                    final_residuals_cube.append(frame)
             else:
                 frame = cube_collapse(ifs_adi_frames,
                                       mode=algo_params.collapse_ifs)

--- a/vip_hci/psfsub/pca_fullfr.py
+++ b/vip_hci/psfsub/pca_fullfr.py
@@ -508,92 +508,75 @@ def pca(*all_args: List, **all_kwargs: dict):
         final_residuals_cube = []
         recon_cube = []
         medians = []
+        table = []
+        pclist = []
+        grid_case = False
 
-        # (ADI+)RDI
-        if algo_params.cube_ref is not None:
-            for ch in range(nch):
+        # ADI or RDI
+        for ch in range(nch):
+            add_params = {
+                "start_time": start_time,
+                "cube": algo_params.cube[ch],
+                "ncomp": ncomp[ch],  # algo_params.ncomp[ch],
+                "fwhm": algo_params.fwhm[ch],
+                "full_output": True,
+            }
+
+            # RDI
+            if algo_params.cube_ref is not None:
                 if algo_params.cube_ref[ch].ndim != 3:
                     msg = "Ref cube has wrong format for 4d input cube"
                     raise TypeError(msg)
+                add_params["cube_ref"] = algo_params.cube_ref[ch]
 
-                add_params = {
-                    "start_time": start_time,
-                    "cube": algo_params.cube[ch],
-                    "cube_ref": algo_params.cube_ref[ch],
-                    "ncomp": ncomp[ch],
-                }
-                func_params = setup_parameters(
-                    params_obj=algo_params, fkt=_adi_rdi_pca, **add_params
-                )
-                res_pca = _adi_rdi_pca(
-                    **func_params,
-                    **rot_options,
-                )
-                pcs.append(res_pca[0])
-                recon.append(res_pca[1])
-                residuals_cube.append(res_pca[2])
-                residuals_cube_.append(res_pca[3])
-                ifs_adi_frames[ch] = res_pca[-1]
-        # ADI
-        else:
-            table = []
-            pclist = []
-            for ch in range(nch):
-                add_params = {
-                    "start_time": start_time,
-                    "cube": algo_params.cube[ch],
-                    "ncomp": ncomp[ch],  # algo_params.ncomp[ch],
-                    "fwhm": algo_params.fwhm[ch],
-                    "full_output": True,
-                }
-                func_params = setup_parameters(
-                    params_obj=algo_params, fkt=_adi_rdi_pca, **add_params
-                )
-                res_pca = _adi_rdi_pca(
-                    **func_params,
-                    **rot_options,
-                )
-                grid_case = False
-                if algo_params.batch is None:
-                    if algo_params.source_xy is not None:
-                        # PCA grid, computing S/Ns
-                        if isinstance(ncomp[ch], (tuple, list)):
-                            final_residuals_cube.append(res_pca[0])
-                            ifs_adi_frames[ch] = res_pca[1]
-                            table.append(res_pca[2])
-                        # full-frame PCA with rotation threshold
-                        else:
-                            recon_cube.append(res_pca[0])
-                            residuals_cube.append(res_pca[1])
-                            residuals_cube_.append(res_pca[2])
-                            ifs_adi_frames[ch] = res_pca[-1]
+            func_params = setup_parameters(
+                params_obj=algo_params, fkt=_adi_rdi_pca, **add_params
+            )
+            res_pca = _adi_rdi_pca(
+                **func_params,
+                **rot_options,
+            )
+
+            if algo_params.batch is None:
+                if algo_params.source_xy is not None:
+                    # PCA grid, computing S/Ns
+                    if isinstance(ncomp[ch], (tuple, list)):
+                        final_residuals_cube.append(res_pca[0])
+                        ifs_adi_frames[ch] = res_pca[1]
+                        table.append(res_pca[2])
+                    # full-frame PCA with rotation threshold
                     else:
-                        # PCA grid
-                        if isinstance(ncomp[ch], (tuple, list)):
-                            ifs_adi_frames[ch] = res_pca[0]
-                            pclist.append(res_pca[1])
-                            grid_case = True
-                        # full-frame standard PCA
-                        else:
-                            pcs.append(res_pca[0])
-                            recon.append(res_pca[1])
-                            residuals_cube.append(res_pca[2])
-                            residuals_cube_.append(res_pca[3])
-                            ifs_adi_frames[ch] = res_pca[-1]
-                # full-frame incremental PCA
+                        recon_cube.append(res_pca[0])
+                        residuals_cube.append(res_pca[1])
+                        residuals_cube_.append(res_pca[2])
+                        ifs_adi_frames[ch] = res_pca[-1]
                 else:
-                    ifs_adi_frames[ch] = res_pca[0]
-                    pcs.append(res_pca[2])
-                    medians.append(res_pca[3])
-
-            if grid_case:
-                for i in range(len(ncomp[0])):
-                    frame = cube_collapse(ifs_adi_frames[:, i],
-                                          mode=algo_params.collapse_ifs)
-                    final_residuals_cube.append(frame)
+                    # PCA grid
+                    if isinstance(ncomp[ch], (tuple, list)):
+                        ifs_adi_frames[ch] = res_pca[0]
+                        pclist.append(res_pca[1])
+                        grid_case = True
+                    # full-frame standard PCA
+                    else:
+                        pcs.append(res_pca[0])
+                        recon.append(res_pca[1])
+                        residuals_cube.append(res_pca[2])
+                        residuals_cube_.append(res_pca[3])
+                        ifs_adi_frames[ch] = res_pca[-1]
+            # full-frame incremental PCA
             else:
-                frame = cube_collapse(ifs_adi_frames,
+                ifs_adi_frames[ch] = res_pca[0]
+                pcs.append(res_pca[2])
+                medians.append(res_pca[3])
+
+        if grid_case:
+            for i in range(len(ncomp[0])):
+                frame = cube_collapse(ifs_adi_frames[:, i],
                                       mode=algo_params.collapse_ifs)
+                final_residuals_cube.append(frame)
+        else:
+            frame = cube_collapse(ifs_adi_frames,
+                                  mode=algo_params.collapse_ifs)
 
         # convert to numpy arrays when relevant
         if len(pcs) > 0:
@@ -611,22 +594,7 @@ def pca(*all_args: List, **all_kwargs: dict):
         if len(medians) > 0:
             medians = np.array(medians)
 
-    # ADI + RDI
-    # elif algo_params.cube_ref is not None:
-    #     add_params = {
-    #         "start_time": start_time,
-    #         "full_output": True,
-    #     }
-    #     func_params = setup_parameters(
-    #         params_obj=algo_params, fkt=_adi_rdi_pca, **add_params
-    #     )
-    #     res_pca = _adi_rdi_pca(
-    #         **func_params,
-    #         **rot_options,
-    #     )
-    #     pcs, recon, residuals_cube, residuals_cube_, frame = res_pca
-
-    # ADI+RDI OR ADI. Shape of cube: (n_adi_frames, y, x)
+    # 3D RDI or ADI. Shape of cube: (n_adi_frames, y, x)
     else:
         add_params = {
             "start_time": start_time,

--- a/vip_hci/psfsub/pca_local.py
+++ b/vip_hci/psfsub/pca_local.py
@@ -223,9 +223,9 @@ def pca_annular(*all_args: List, **all_kwargs: dict):
     frame : numpy ndarray, 2d
         [full_output=True] Median combination of the de-rotated cube.
     """
-    # Separating the parameters of the ParamsObject from the optionnal rot_options
-    class_params, rot_options = separate_kwargs_dict(initial_kwargs=all_kwargs,
-                                                     parent_class=PCA_ANNULAR_Params
+    # Separate parameters of the ParamsObject from the optionnal rot_options
+    class_params, rot_options = separate_kwargs_dict(all_kwargs,
+                                                     PCA_ANNULAR_Params
                                                      )
 
     # Extracting the object of parameters (if any)
@@ -244,7 +244,8 @@ def pca_annular(*all_args: List, **all_kwargs: dict):
         rot_options['interp_zeros'] = True
 
     global start_time
-    start_time = time_ini()
+    if algo_params.verbose:
+        start_time = time_ini()
 
     if algo_params.left_eigv:
         if (
@@ -259,7 +260,10 @@ def pca_annular(*all_args: List, **all_kwargs: dict):
 
     # ADI or ADI+RDI data
     if algo_params.cube.ndim == 3:
-        add_params = {"start_time": start_time, "full_output": True}
+        if algo_params.verbose:
+            add_params = {"start_time": start_time, "full_output": True}
+        else:
+            add_params = {"full_output": True}
 
         func_params = setup_parameters(
             params_obj=algo_params, fkt=_pca_adi_rdi, **add_params


### PR DESCRIPTION
- Bug fix for PCA-RDI with 4D cubes (issue https://github.com/vortex-exoplanet/VIP/issues/641)
- Added compatibility for either [PCA-ARDI](https://github.com/vortex-exoplanet/VIP/commit/866651443ec6594888d481b9682fcec47028b9ae) or [PCA RDI with data imputation for NEGFC](https://github.com/vortex-exoplanet/VIP/commit/b5af4fc5bebceaf4d3a7821293c6ba78174c8f34)
- [IPCA-ARDI now does PCA-ARDI with the initial number of principal components, instead of RDI with the last number of principal components](https://github.com/vortex-exoplanet/VIP/commit/a0bd13c827c230782f0e4036c9dfe0dc57d5725f)
- [Made frame_by_frame mode of cube_fix_badpix_isolated function compatible with input bad pixel map](https://github.com/vortex-exoplanet/VIP/commit/c656e9878d21360b834332d133463deec1bdd068)
- [Bug fix for mixed array types when creating bad pixel maps](https://github.com/vortex-exoplanet/VIP/commit/2ebe91bc89452e1a903145e2a56868e50e861ff0)