### PR TITLE
Torch FFT Rotation & Juillard23 IPCA

### DIFF
--- a/vip_hci/greedy/ipca_fullfr.py
+++ b/vip_hci/greedy/ipca_fullfr.py
@@ -34,6 +34,13 @@ from ..preproc import cube_derotate, cube_collapse
 from ..metrics import stim_map, inverse_stim_map
 from ..var import prepare_matrix, mask_circle, frame_filter_lowpass
 
+try:
+    from GreeDS import GreeDS
+    no_greeds = False
+except ImportError:
+    msg = "GreeDS python bindings are missing."
+    warnings.warn(msg, ImportWarning)
+    no_greeds = True
 
 @dataclass
 class IPCA_Params(PCA_Params):
@@ -91,7 +98,7 @@ def ipca(*all_args: List, **all_kwargs: dict):
         shortest wavelength in the cube (more thorough approaches can be used
         to get the scaling factors). This scaling factors are used to re-scale
         the spectral channels and align the speckles.
-    mode: str or None, opt {'Pairet18', 'Pairet21'}
+    mode: str or None, opt {'Pairet18', 'Pairet21','Juillard23'}
         - If None: runs with provided value of 'n_comp' for 'nit' iterations,
         and considering threshold 'thr'.
         - If 'Pairet18': runs for n_comp iterations, with n_comp=1,...,n_comp,
@@ -101,6 +108,12 @@ def ipca(*all_args: List, **all_kwargs: dict):
         n_comp (i.e. outer loop on n_comp, inner loop on nit). thr set to 0
         (ignored if provided). 'thr' parameter discarded, always set to 0.
         - If 'Christiaens21': same as 'Pairet21', but with 'thr' parameter used.
+        - If 'Juillard23': Exact implementation from Juillard et al. 2023 using 
+        Torch. Parameter conventions are the same as in 'Christiaens21' and 
+        'Pairet21'. This method has no additional options for significant 
+        signal extraction and works exclusively with Torch, making it faster 
+        but also more prone to propagate noise and disk flux. Installation of 
+        the GreeDS package is required for this option.
     ncomp : int or tuple/list of int, optional
         How many PCs are used as a lower-dimensional subspace to project the
         target frames.
@@ -121,7 +134,7 @@ def ipca(*all_args: List, **all_kwargs: dict):
             total number of iterations
         - if mode is 'Pairet18':
             this parameter is ignored. Number of iterations will be ncomp.
-        - if mode is 'Pairet21' or 'Christiaens21':
+        - if mode is 'Pairet21', 'Christiaens21' or 'Juillard23':
             iterations per tested ncomp.
     strategy: str {'ADI, 'RDI', 'ARDI', 'RADI'}, opt
         Whether to do iterative ADI only ('ADI'), iterative RDI only ('RDI'),
@@ -351,269 +364,344 @@ def ipca(*all_args: List, **all_kwargs: dict):
     # force full_output
     pca_params['full_output'] = True
     pca_params['verbose'] = False  # too verbose otherwise
+    r = algo_params.ncomp
+    l = algo_params.nit
 
-    # 1. Prepare/format additional parameters depending on chosen options
-    mask_center_px = algo_params.mask_center_px  # None? what's better in pca?
-    mask_rdi_tmp = None
-    if algo_params.strategy == 'ADI' and algo_params.cube_ref is None:
-        ref_cube = None
-        mask_rdi_tmp = algo_params.mask_rdi
-    elif algo_params.cube_ref is not None:
-        if algo_params.strategy == 'ADI':
-            msg = "WARNING: requested strategy is 'ADI' but reference cube "
-            msg += "detected! Strategy automatically switched to 'ARDI'."
-            print(msg)
-            algo_params.strategy = 'ARDI'
-        if algo_params.mask_rdi is not None:
-            if isinstance(algo_params.mask_rdi, (list, tuple)):
-                mask_rdi_tmp = algo_params.mask_rdi
+    if algo_params.mode=="Juillard23":
+        if no_greeds:
+            msg = 'GreeDS Python bindings cannot be imported. Install GreeDS (pip install GreeDS) or use a different method.'
+            raise RuntimeError(msg)
+        if algo_params.strategy not in ['ADI',"ARDI"]:
+            msg = 'Juillard23 not compatible with this mode.'
+            raise RuntimeError(msg)
+
+        if algo_params.strategy == 'ARDI':
+                ref = algo_params.cube_ref.copy()
+        else : ref = None
+        
+        mask_center_px = algo_params.mask_center_px
+        pup = mask_center_px if mask_center_px is not None else 0
+        
+        if algo_params.full_output is True : 
+            it_cube, star_estim = GreeDS(algo_params.cube, algo_params.angle_list, refs=ref,r=r, l=l, r_start=1, pup=pup, full_output=1, returnL=True)
+        else : it_cube = GreeDS(algo_params.cube, algo_params.angle_list, refs=ref,r=r, l=l, r_start=1, pup=pup, full_output=1, returnL=False)
+        frame = it_cube[-1]
+        
+        # Set results matching full outputs
+        it=len(it_cube)-1
+        algo_params.thr = 0
+
+        stim_cube = it_cube_nd = sig_images = nstim = sig_mask = np.zeros(it_cube.shape)
+
+        if algo_params.full_output is True :       
+            print(algo_params.cube.shape)     
+            print(star_estim.shape)      
+            residuals_cube_ = cube_derotate(algo_params.cube - star_estim[-1],
+                            algo_params.angle_list,
+                            imlib="torch-fft",
+                            nproc=algo_params.nproc) - frame
+            
+            residuals_cube = cube_derotate(residuals_cube_,
+                                -algo_params.angle_list,
+                                imlib="torch-fft",
+                                nproc=algo_params.nproc)
+
+            if algo_params.thr_mode == 'STIM':
+                for it_i in range(len(it_cube)):
+                    residuals_cube__i = cube_derotate(algo_params.cube - star_estim[it_i],
+                            algo_params.angle_list,
+                            imlib="torch-fft",
+                            nproc=algo_params.nproc) - it_cube[it_i]
+            
+                    residuals_cube_i = cube_derotate(residuals_cube__i,
+                                -algo_params.angle_list,
+                                imlib="torch-fft",
+                                nproc=algo_params.nproc)
+                    
+                    sig_mask_i, nstim_i = _find_significant_signals(residuals_cube_i,
+                                                                residuals_cube__i,
+                                                                algo_params.angle_list,
+                                                                algo_params.thr,
+                                                                mask=mask_center_px,
+                                                                r_out=algo_params.r_out)
+                        
+                    sig_mask[it_i] = sig_mask_i.copy()
+                    nstim[it_i] = nstim_i.copy()
+
             else:
-                mask_rdi_tmp = algo_params.mask_rdi.copy()
-        if algo_params.cube_ref is None:
-            raise ValueError("cube_ref should be provided for RDI or RADI")
-        if algo_params.strategy == 'ARDI' and algo_params.mask_rdi is None:
-            ref_cube = np.concatenate((algo_params.cube,
-                                       algo_params.cube_ref), axis=0)
-        else:
-            ref_cube = algo_params.cube_ref.copy()
-    else:
-        msg = "strategy not recognized: must be ADI, RDI, ARDI or RADI"
-        raise ValueError(msg)
+                sig_mask = np.ones_like(it_cube)
+                sig_mask[np.where(it_cube < algo_params.thr)] = 0
+                nstim = sig_mask.copy()
 
-    if isinstance(algo_params.ncomp, (float, int)):
-        ncomp_list = [algo_params.ncomp]
-        if algo_params.strategy == 'RADI':
-            ncomp_list.append(algo_params.ncomp)
-    elif isinstance(algo_params.ncomp, (tuple, list)):
-        ncomp_list = algo_params.ncomp
-        if len(algo_params.ncomp) == 1:
+            sig_images = it_cube.copy()
+            sig_images[np.where(1-sig_mask)] = 0
+            sig_images[np.where(sig_images < 0)] = 0
+            stim_cube = nstim.copy()
+
+    else:
+            
+        # 1. Prepare/format additional parameters depending on chosen options
+        mask_center_px = algo_params.mask_center_px  # None? what's better in pca?
+        mask_rdi_tmp = None
+        if algo_params.strategy == 'ADI' and algo_params.cube_ref is None:
+            ref_cube = None
+            mask_rdi_tmp = algo_params.mask_rdi
+        elif algo_params.cube_ref is not None:
+            if algo_params.strategy == 'ADI':
+                msg = "WARNING: requested strategy is 'ADI' but reference cube "
+                msg += "detected! Strategy automatically switched to 'ARDI'."
+                print(msg)
+                algo_params.strategy = 'ARDI'
+            if algo_params.mask_rdi is not None:
+                if isinstance(algo_params.mask_rdi, (list, tuple)):
+                    mask_rdi_tmp = algo_params.mask_rdi
+                else:
+                    mask_rdi_tmp = algo_params.mask_rdi.copy()
+            if algo_params.cube_ref is None:
+                raise ValueError("cube_ref should be provided for RDI or RADI")
+            if algo_params.strategy == 'ARDI' and algo_params.mask_rdi is None:
+                ref_cube = np.concatenate((algo_params.cube,
+                                        algo_params.cube_ref), axis=0)
+            else:
+                ref_cube = algo_params.cube_ref.copy()
+        else:
+            msg = "strategy not recognized: must be ADI, RDI, ARDI or RADI"
+            raise ValueError(msg)
+
+        if isinstance(algo_params.ncomp, (float, int)):
+            ncomp_list = [algo_params.ncomp]
             if algo_params.strategy == 'RADI':
                 ncomp_list.append(algo_params.ncomp)
-        elif not len(algo_params.ncomp) == 2:
-            raise ValueError("Length of npc list cannot be larger than 2")
-    else:
-        raise TypeError("ncomp should be float, int, tuple or list")
-
-    ncomp_tmp = ncomp_list[0]
-    nframes = algo_params.cube.shape[0]
-    nit_ori = algo_params.nit
-
-    if algo_params.mode is not None:
-        final_ncomp = list(range(1, ncomp_tmp+1, algo_params.ncomp_step))
-        if algo_params.mode == 'Pairet18':
-            algo_params.nit = ncomp_tmp
-            final_ncomp = list(range(1, ncomp_tmp+1, algo_params.ncomp_step))
-            algo_params.thr = 0
-        elif algo_params.mode in ['Pairet21', 'Christiaens21']:
-            final_ncomp = []
-            for npc in range(1, ncomp_tmp+1, algo_params.ncomp_step):
-                for ii in range(algo_params.nit):
-                    final_ncomp.append(npc)
-            algo_params.nit = len(final_ncomp)
-            if algo_params.mode == 'Pairet21':
-                algo_params.thr = 0
-    else:
-        final_ncomp = [ncomp_tmp]*algo_params.nit
-
-    # Scale cube and cube_ref if necessary
-    cube_tmp = prepare_matrix(algo_params.cube, scaling=algo_params.scaling,
-                              mask_center_px=mask_center_px, mode='fullfr',
-                              verbose=False)
-    cube_tmp = np.reshape(cube_tmp, algo_params.cube.shape)
-    if ref_cube is not None:
-        cube_ref_tmp = prepare_matrix(ref_cube, scaling=algo_params.scaling,
-                                      mask_center_px=mask_center_px,
-                                      mode='fullfr', verbose=False)
-        cube_ref_tmp = np.reshape(cube_ref_tmp, ref_cube.shape)
-    else:
-        cube_ref_tmp = None
-
-    # 2. Get a first disc estimate, using PCA
-    pca_params['ncomp'] = final_ncomp[0]
-    pca_params['cube_ref'] = ref_cube
-    res = pca(**pca_params, **rot_options)
-    frame = res[0]
-    residuals_cube = res[-2]
-    residuals_cube_ = res[-1]
-    # smoothing and manual derotation if requested
-    smooth_ker = algo_params.smooth_ker
-    if smooth_ker is None or np.isscalar(smooth_ker):
-        smooth_ker = np.array([smooth_ker]*algo_params.nit, dtype=object)
-    else:
-        smooth_ker = np.array(smooth_ker, dtype=object)
-    # if smooth_ker[0] is not None:
-    #     residuals_cube = _blurring_3d(residuals_cube, None,
-    #                                   fwhm_sz=smooth_ker[0])
-    #     residuals_cube_ = cube_derotate(residuals_cube,
-    #                                     algo_params.angle_list,
-    #                                     imlib=algo_params.imlib,
-    #                                     nproc=algo_params.nproc)
-    #     frame = cube_collapse(residuals_cube_, algo_params.collapse)
-    if smooth_ker[0] is not None:
-        frame = frame_filter_lowpass(frame, fwhm_size=smooth_ker[0])
-
-    # 3. Identify significant signals with STIM map
-    it_cube = np.zeros([algo_params.nit, frame.shape[0], frame.shape[1]])
-    it_cube_nd = np.zeros_like(it_cube)
-    stim_cube = np.zeros_like(it_cube)
-    sig_images = np.zeros_like(it_cube)
-    it_cube[0] = frame.copy()
-    it_cube_nd[0] = frame.copy()
-    if algo_params.thr_mode == 'STIM':
-        sig_mask, nstim = _find_significant_signals(residuals_cube,
-                                                    residuals_cube_,
-                                                    algo_params.angle_list,
-                                                    algo_params.thr,
-                                                    mask=mask_center_px,
-                                                    r_out=algo_params.r_out)
-    else:
-        sig_mask = np.ones_like(frame)
-        sig_mask[np.where(frame < algo_params.thr)] = 0
-        nstim = sig_mask.copy()
-    sig_image = frame.copy()
-    sig_image[np.where(1-sig_mask)] = 0
-    sig_image[np.where(sig_image < 0)] = 0
-    sig_images[0] = sig_image.copy()
-    stim_cube[0] = nstim.copy()
-    mask_rdi_tmp = None  # after first iteration do not use it any more
-
-    # 4.Loop, updating the reference cube before projection by subtracting the
-    #   best disc estimate. This is done by providing sig_cube.
-    cond_skip = False  # whether to skip an iteration (e.g. in incremental mode)
-    for it in Progressbar(range(1, algo_params.nit), desc="Iterating..."):
-        if not cond_skip:
-            # Uncomment here (and comment below) to do like IROLL
-            # if smooth_ker[it] is not None:
-            #     frame = _blurring_2d(frame, None, fwhm_sz=smooth_ker[it])
-            # create and rotate sig cube
-            sig_cube = np.repeat(frame[np.newaxis, :, :], nframes, axis=0)
-            sig_cube = cube_derotate(sig_cube, -algo_params.angle_list,
-                                     imlib=algo_params.imlib,
-                                     nproc=algo_params.nproc)
-
-            if algo_params.thr_mode == 'STIM':
-                # create and rotate binary mask
-                mask_sig = np.zeros_like(sig_image)
-                mask_sig[np.where(sig_image > 0)] = 1
-                sig_mcube = np.repeat(mask_sig[np.newaxis, :, :], nframes,
-                                      axis=0)
-                sig_mcube = cube_derotate(sig_mcube, -algo_params.angle_list,
-                                          imlib='skimage',
-                                          interpolation='bilinear',
-                                          nproc=algo_params.nproc)
-                sig_cube[np.where(sig_mcube < 0.5)] = 0
-                sig_cube[np.where(sig_cube < 0)] = 0
-            else:
-                sig_cube[np.where(sig_cube < algo_params.thr)] = 0
-
-            if algo_params.strategy == 'ARDI':
-                ref_cube = np.concatenate((algo_params.cube-sig_cube,
-                                           algo_params.cube_ref), axis=0)
-                cube_ref_tmp = prepare_matrix(ref_cube,
-                                              scaling=algo_params.scaling,
-                                              mask_center_px=mask_center_px,
-                                              mode='fullfr', verbose=False)
-                cube_ref_tmp = np.reshape(cube_ref_tmp, ref_cube.shape)
-
-            # Run PCA on original cube
-            # Update PCA PARAMS
-            pca_params['cube'] = algo_params.cube
-            pca_params['cube_ref'] = ref_cube
-            pca_params['ncomp'] = final_ncomp[it]
-            pca_params['scaling'] = algo_params.scaling
-            pca_params['cube_sig'] = sig_cube
-            pca_params['mask_rdi'] = mask_rdi_tmp
-
-            res = pca(**pca_params, **rot_options)
-
-            frame = res[0]
-            residuals_cube = res[-2]
-            it_cube[it] = frame.copy()
-
-            # DON'T otherwise frame is smoothed twice!
-            # smoothing and manual derotation if requested
-            if smooth_ker[it] is not None:
-                residuals_cube = _blurring_3d(residuals_cube, None,
-                                              fwhm_sz=smooth_ker[it])
-                residuals_cube_ = cube_derotate(residuals_cube,
-                                                algo_params.angle_list,
-                                                imlib=algo_params.imlib,
-                                                nproc=algo_params.nproc)
-                frame = cube_collapse(residuals_cube_, algo_params.collapse)
-
-            # Run PCA on disk-empty cube
-            # Update PCA PARAMS
-            pca_params['cube'] = cube_tmp-sig_cube
-            pca_params['cube_ref'] = cube_ref_tmp
-            pca_params['cube_sig'] = None
-            pca_params['scaling'] = None
-
-            res_nd = pca(**pca_params, **rot_options)
-
-            residuals_cube_nd = res_nd[-2]
-            frame_nd = res_nd[0]
-
-            if algo_params.thr_mode == 'STIM':
-                sig_mask, nstim = _find_significant_signals(residuals_cube_nd,
-                                                            residuals_cube_,
-                                                            algo_params.angle_list,
-                                                            algo_params.thr,
-                                                            mask=mask_center_px,
-                                                            r_out=algo_params.r_out)
-            else:
-                sig_mask = np.ones_like(frame)
-                sig_mask[np.where(frame < algo_params.thr)] = 0
-                nstim = sig_mask.copy()
-            inv_sig_mask = np.ones_like(sig_mask)
-            inv_sig_mask[np.where(sig_mask)] = 0
-            if mask_center_px:
-                inv_sig_mask = mask_circle(inv_sig_mask, mask_center_px,
-                                           fillwith=1)
-            sig_image = frame.copy()
-            sig_image[np.where(inv_sig_mask)] = 0
-            sig_image[np.where(sig_image < 0)] = 0
-
-        # whether skipped or not:
-        it_cube[it] = frame.copy()
-        it_cube_nd[it] = frame_nd.copy()
-        sig_images[it] = sig_image.copy()
-        stim_cube[it] = nstim.copy()
-
-        # check if improvement compared to last iteration
-        if it > 1:
-            cond1 = np.allclose(sig_image, sig_images[it-1],
-                                rtol=algo_params.rtol, atol=algo_params.atol)
-            cond2 = np.allclose(sig_image, sig_images[it-2],
-                                rtol=algo_params.rtol, atol=algo_params.atol)
-            if cond1 or cond2:
-                # if convergence in incremental mode: skip iterations until the
-                # next increment in ncomp
-                cond_mode = algo_params.mode in ['Pairet21', 'Christiaens21']
-                cond_it = (it % nit_ori != nit_ori-1)
-                if cond_mode and cond_it:
-                    cond_skip = True
-                else:
-                    cond_skip = False
-                    if algo_params.strategy in ['ADI', 'RDI', 'ARDI']:
-                        msg = "Convergence criterion met after {} iterations"
-                        condB = algo_params.continue_without_smooth_after_conv
-                        if smooth_ker[it] is not None and condB:
-                            smooth_ker[it+1:] = None
-                            msg2 = "...Smoothing turned off and iterating more"
-                            if algo_params.verbose:
-                                print(msg.format(it)+msg2)
-                        else:
-                            if algo_params.verbose:
-                                print("Final " + msg.format(it))
-                            break
+        elif isinstance(algo_params.ncomp, (tuple, list)):
+            ncomp_list = algo_params.ncomp
+            if len(algo_params.ncomp) == 1:
                 if algo_params.strategy == 'RADI':
-                    # continue to iterate with ADI
-                    ncomp_tmp = ncomp_list[1]
-                    algo_params.strategy = 'ADI'
-                    ref_cube = None
-                    if algo_params.verbose:
-                        msg = "After {:.0f} iterations, PCA-RDI -> PCA-ADI."
-                        print(msg.format(it))
+                    ncomp_list.append(algo_params.ncomp)
+            elif not len(algo_params.ncomp) == 2:
+                raise ValueError("Length of npc list cannot be larger than 2")
+        else:
+            raise TypeError("ncomp should be float, int, tuple or list")
+
+        ncomp_tmp = ncomp_list[0]
+        nframes = algo_params.cube.shape[0]
+        nit_ori = algo_params.nit
+
+        if algo_params.mode is not None:
+            final_ncomp = list(range(1, ncomp_tmp+1, algo_params.ncomp_step))
+            if algo_params.mode == 'Pairet18':
+                algo_params.nit = ncomp_tmp
+                final_ncomp = list(range(1, ncomp_tmp+1, algo_params.ncomp_step))
+                algo_params.thr = 0
+            elif algo_params.mode in ['Pairet21', 'Christiaens21']:
+                final_ncomp = []
+                for npc in range(1, ncomp_tmp+1, algo_params.ncomp_step):
+                    for ii in range(algo_params.nit):
+                        final_ncomp.append(npc)
+                algo_params.nit = len(final_ncomp)
+                if algo_params.mode == 'Pairet21':
+                    algo_params.thr = 0
+        else:
+            final_ncomp = [ncomp_tmp]*algo_params.nit
+
+        # Scale cube and cube_ref if necessary
+        cube_tmp = prepare_matrix(algo_params.cube, scaling=algo_params.scaling,
+                                mask_center_px=mask_center_px, mode='fullfr',
+                                verbose=False)
+        cube_tmp = np.reshape(cube_tmp, algo_params.cube.shape)
+        if ref_cube is not None:
+            cube_ref_tmp = prepare_matrix(ref_cube, scaling=algo_params.scaling,
+                                        mask_center_px=mask_center_px,
+                                        mode='fullfr', verbose=False)
+            cube_ref_tmp = np.reshape(cube_ref_tmp, ref_cube.shape)
+        else:
+            cube_ref_tmp = None
+
+        # 2. Get a first disc estimate, using PCA
+        pca_params['ncomp'] = final_ncomp[0]
+        pca_params['cube_ref'] = ref_cube
+        res = pca(**pca_params, **rot_options)
+        frame = res[0]
+        residuals_cube = res[-2]
+        residuals_cube_ = res[-1]
+        # smoothing and manual derotation if requested
+        smooth_ker = algo_params.smooth_ker
+        if smooth_ker is None or np.isscalar(smooth_ker):
+            smooth_ker = np.array([smooth_ker]*algo_params.nit, dtype=object)
+        else:
+            smooth_ker = np.array(smooth_ker, dtype=object)
+        # if smooth_ker[0] is not None:
+        #     residuals_cube = _blurring_3d(residuals_cube, None,
+        #                                   fwhm_sz=smooth_ker[0])
+        #     residuals_cube_ = cube_derotate(residuals_cube,
+        #                                     algo_params.angle_list,
+        #                                     imlib=algo_params.imlib,
+        #                                     nproc=algo_params.nproc)
+        #     frame = cube_collapse(residuals_cube_, algo_params.collapse)
+        if smooth_ker[0] is not None:
+            frame = frame_filter_lowpass(frame, fwhm_size=smooth_ker[0])
+
+        # 3. Identify significant signals with STIM map
+        it_cube = np.zeros([algo_params.nit, frame.shape[0], frame.shape[1]])
+        it_cube_nd = np.zeros_like(it_cube)
+        stim_cube = np.zeros_like(it_cube)
+        sig_images = np.zeros_like(it_cube)
+        it_cube[0] = frame.copy()
+        it_cube_nd[0] = frame.copy()
+        if algo_params.thr_mode == 'STIM':
+            sig_mask, nstim = _find_significant_signals(residuals_cube,
+                                                        residuals_cube_,
+                                                        algo_params.angle_list,
+                                                        algo_params.thr,
+                                                        mask=mask_center_px,
+                                                        r_out=algo_params.r_out)
+        else:
+            sig_mask = np.ones_like(frame)
+            sig_mask[np.where(frame < algo_params.thr)] = 0
+            nstim = sig_mask.copy()
+        sig_image = frame.copy()
+        sig_image[np.where(1-sig_mask)] = 0
+        sig_image[np.where(sig_image < 0)] = 0
+        sig_images[0] = sig_image.copy()
+        stim_cube[0] = nstim.copy()
+        mask_rdi_tmp = None  # after first iteration do not use it any more
+
+        # 4.Loop, updating the reference cube before projection by subtracting the
+        #   best disc estimate. This is done by providing sig_cube.
+        cond_skip = False  # whether to skip an iteration (e.g. in incremental mode)
+        for it in Progressbar(range(1, algo_params.nit), desc="Iterating..."):
+            if not cond_skip:
+                # Uncomment here (and comment below) to do like IROLL
+                # if smooth_ker[it] is not None:
+                #     frame = _blurring_2d(frame, None, fwhm_sz=smooth_ker[it])
+                # create and rotate sig cube
+                sig_cube = np.repeat(frame[np.newaxis, :, :], nframes, axis=0)
+                sig_cube = cube_derotate(sig_cube, -algo_params.angle_list,
+                                        imlib=algo_params.imlib,
+                                        nproc=algo_params.nproc)
+
+                if algo_params.thr_mode == 'STIM':
+                    # create and rotate binary mask
+                    mask_sig = np.zeros_like(sig_image)
+                    mask_sig[np.where(sig_image > 0)] = 1
+                    sig_mcube = np.repeat(mask_sig[np.newaxis, :, :], nframes,
+                                        axis=0)
+                    sig_mcube = cube_derotate(sig_mcube, -algo_params.angle_list,
+                                            imlib='skimage',
+                                            interpolation='bilinear',
+                                            nproc=algo_params.nproc)
+                    sig_cube[np.where(sig_mcube < 0.5)] = 0
+                    sig_cube[np.where(sig_cube < 0)] = 0
+                else:
+                    sig_cube[np.where(sig_cube < algo_params.thr)] = 0
+
+                if algo_params.strategy == 'ARDI':
+                    ref_cube = np.concatenate((algo_params.cube-sig_cube,
+                                            algo_params.cube_ref), axis=0)
+                    cube_ref_tmp = prepare_matrix(ref_cube,
+                                                scaling=algo_params.scaling,
+                                                mask_center_px=mask_center_px,
+                                                mode='fullfr', verbose=False)
+                    cube_ref_tmp = np.reshape(cube_ref_tmp, ref_cube.shape)
+
+                # Run PCA on original cube
+                # Update PCA PARAMS
+                pca_params['cube'] = algo_params.cube
+                pca_params['cube_ref'] = ref_cube
+                pca_params['ncomp'] = final_ncomp[it]
+                pca_params['scaling'] = algo_params.scaling
+                pca_params['cube_sig'] = sig_cube
+                pca_params['mask_rdi'] = mask_rdi_tmp
+
+                res = pca(**pca_params, **rot_options)
+
+                frame = res[0]
+                residuals_cube = res[-2]
+                it_cube[it] = frame.copy()
+
+                # DON'T otherwise frame is smoothed twice!
+                # smoothing and manual derotation if requested
+                if smooth_ker[it] is not None:
+                    residuals_cube = _blurring_3d(residuals_cube, None,
+                                                fwhm_sz=smooth_ker[it])
+                    residuals_cube_ = cube_derotate(residuals_cube,
+                                                    algo_params.angle_list,
+                                                    imlib=algo_params.imlib,
+                                                    nproc=algo_params.nproc)
+                    frame = cube_collapse(residuals_cube_, algo_params.collapse)
+
+                # Run PCA on disk-empty cube
+                # Update PCA PARAMS
+                pca_params['cube'] = cube_tmp-sig_cube
+                pca_params['cube_ref'] = cube_ref_tmp
+                pca_params['cube_sig'] = None
+                pca_params['scaling'] = None
+
+                res_nd = pca(**pca_params, **rot_options)
+
+                residuals_cube_nd = res_nd[-2]
+                frame_nd = res_nd[0]
+
+                if algo_params.thr_mode == 'STIM':
+                    sig_mask, nstim = _find_significant_signals(residuals_cube_nd,
+                                                                residuals_cube_,
+                                                                algo_params.angle_list,
+                                                                algo_params.thr,
+                                                                mask=mask_center_px,
+                                                                r_out=algo_params.r_out)
+                else:
+                    sig_mask = np.ones_like(frame)
+                    sig_mask[np.where(frame < algo_params.thr)] = 0
+                    nstim = sig_mask.copy()
+                inv_sig_mask = np.ones_like(sig_mask)
+                inv_sig_mask[np.where(sig_mask)] = 0
+                if mask_center_px:
+                    inv_sig_mask = mask_circle(inv_sig_mask, mask_center_px,
+                                            fillwith=1)
+                sig_image = frame.copy()
+                sig_image[np.where(inv_sig_mask)] = 0
+                sig_image[np.where(sig_image < 0)] = 0
+
+            # whether skipped or not:
+            it_cube[it] = frame.copy()
+            it_cube_nd[it] = frame_nd.copy()
+            sig_images[it] = sig_image.copy()
+            stim_cube[it] = nstim.copy()
+
+            # check if improvement compared to last iteration
+            if it > 1:
+                cond1 = np.allclose(sig_image, sig_images[it-1],
+                                    rtol=algo_params.rtol, atol=algo_params.atol)
+                cond2 = np.allclose(sig_image, sig_images[it-2],
+                                    rtol=algo_params.rtol, atol=algo_params.atol)
+                if cond1 or cond2:
+                    # if convergence in incremental mode: skip iterations until the
+                    # next increment in ncomp
+                    cond_mode = algo_params.mode in ['Pairet21', 'Christiaens21']
+                    cond_it = (it % nit_ori != nit_ori-1)
+                    if cond_mode and cond_it:
+                        cond_skip = True
+                    else:
+                        cond_skip = False
+                        if algo_params.strategy in ['ADI', 'RDI', 'ARDI']:
+                            msg = "Convergence criterion met after {} iterations"
+                            condB = algo_params.continue_without_smooth_after_conv
+                            if smooth_ker[it] is not None and condB:
+                                smooth_ker[it+1:] = None
+                                msg2 = "...Smoothing turned off and iterating more"
+                                if algo_params.verbose:
+                                    print(msg.format(it)+msg2)
+                            else:
+                                if algo_params.verbose:
+                                    print("Final " + msg.format(it))
+                                break
+                    if algo_params.strategy == 'RADI':
+                        # continue to iterate with ADI
+                        ncomp_tmp = ncomp_list[1]
+                        algo_params.strategy = 'ADI'
+                        ref_cube = None
+                        if algo_params.verbose:
+                            msg = "After {:.0f} iterations, PCA-RDI -> PCA-ADI."
+                            print(msg.format(it))
 
     # mask everything last
     if mask_center_px is not None:

--- a/vip_hci/preproc/derotation.py
+++ b/vip_hci/preproc/derotation.py
@@ -639,7 +639,7 @@ def _fft_shear(arr, arr_ori, c, ax, pad=0, shift_ini=True):
 
 
 
-def tensor_rotate_fft(tensor: torch.Tensor, angle: float) -> torch.Tensor:
+def tensor_rotate_fft(tensor, angle):
     """ Rotates Tensor using Fourier transform phases:
         Rotation = 3 consecutive lin. shears = 3 consecutive FFT phase shifts
         See details in Larkin et al. (1997) and Hagelberg et al. (2016).


### PR DESCRIPTION
**1-Adding Torch for Faster FFT Rotation Mode**
Fft rotation using `vip-fft` mode use `Numpy` library. The use of `Torch` instead of `Numpy` consistently improves speed. New `imlib='torch-fft'`.Having Torch remains an optional dependency, and a check to determine whether or not Torch is installed has been implemented.


Here are the differences between the Torch FFT and VIP FFT methods for 50 rotations of a cube. The time is measured in seconds. The third image shows the difference between both rotation methods. The use of `Torch` instead of `Numpy` consistently improves speed.
![torch fft 2 780](https://github.com/user-attachments/assets/0a88e109-1c88-4dd1-b6fe-b1d5d4ed68d2)



**FYI (NOT IN THIS COMMIT)- Torch with Built-in Rotation Method (Bilinear/Nearest) not faster than Open CV**
Here are the differences between the Torch and OpenCV methods for 50 rotations of a cube, with time measured in seconds. The third image shows the difference between the two rotation methods. In this case, the use of OpenCV is better, hence, I did not included  the option of using Torch Built-in Rotation Method in the commit.
![Pytorch 0 269](https://github.com/user-attachments/assets/6ffca62b-1310-4350-9f0a-aa2bfc128ec0)




**2-Adding “Juillard23” Mode to IPCA**
The `“Juillard23”` mode has been added to the IPCA mode, enabling users to utilize the implementation from Juillard et al. (2023/2024). This method has no additional options for significant signal extraction and works exclusively with Torch, making it faster but also more prone to propagating noise and disk flux. The mode can return a stim map and residual map if full-output is set to true. This option is only compatible with `'ADI' `and `'ARDI'`; an error is raised if the options do not match. Other parameters, such as imbil and interpolation, are ignored. This option only uses `nit`, `ncomp`, `pup_mask_center_px`, `cube_ref`, `cube`, and `angle_list`. In particular, the threshold is always set to 0, and STIM is only computed at the end and is not part of the iterative process. Installation of the GreeDS package (via `pip install GreeDS`) is required for this option. GreeDS is now a new optional dependency of VIP.
<img width="584" alt="vip_fft 15 219753 Greeds Sand 0 496539" src="https://github.com/user-attachments/assets/5e961389-51de-44e7-a34e-d59b8604bf58">
