### PR TITLE
Modern multiprocessing for MCMC NEGFC, small fix to tutorial 05A

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ astropy
 photutils
 scikit-learn
 scikit-image
-emcee==2.2.1
+emcee
 nestle
 corner
 pandas

--- a/tests/pre_3_10/test_preproc_recentering.py
+++ b/tests/pre_3_10/test_preproc_recentering.py
@@ -32,7 +32,7 @@ from vip_hci.var import frame_center, fit_2dgaussian
 mpl.use("Agg")
 
 try:
-    from IPython.core.display import display, HTML
+    from IPython.display import display, HTML
 
     def html(s):
         display(HTML(s))

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -918,7 +918,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     if "forkserver" in avail_methods:
         multiprocessing.set_start_method("forkserver", force=True)  # faster, better
     else:
-        multiprocessing.set_start_method("spawn", force=True)  # slower, but on all platforms
+        multiprocessing.set_start_method("spawn", force=True)  # slower, but available on all platforms
 
     with multiprocessing.Pool() as pool:
         sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob,

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -926,130 +926,130 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
                                               algo_options, weights, transmission,
                                               mu_sigma, sigma, force_rPA]))
 
-    if verbosity > 0:
-        print('emcee Ensemble sampler successful')
-    start = datetime.datetime.now()
-
-    # #########################################################################
-    # Affine Invariant MCMC run
-    # #########################################################################
-    if verbosity > 1:
-        print('\nStart of the MCMC run ...')
-        print('Step  |  Duration/step (sec)  |  Remaining Estimated Time (sec)')
-
-    for k, res in enumerate(sampler.sample(pos, iterations=nIterations)):
-        elapsed = (datetime.datetime.now()-start).total_seconds()
-        if verbosity > 1:
-            if k == 0:
-                q = 0.5
-            else:
-                q = 1
-            print('{}\t\t{:.5f}\t\t\t{:.5f}'.format(k, elapsed * q,
-                                                    elapsed * (limit-k-1) * q),
-                  flush=True)
-
+        if verbosity > 0:
+            print('emcee Ensemble sampler successful')
         start = datetime.datetime.now()
 
-        # ---------------------------------------------------------------------
-        # Store the state manually in order to handle with dynamical sized chain
-        # ---------------------------------------------------------------------
-        # Check if the size of the chain is long enough.
-        s = chain.shape[1]
-        if k+1 > s:     # if not, one doubles the chain length
-            empty = np.zeros([nwalkers, 2*s, dim])
-            chain = np.concatenate((chain, empty), axis=1)
-        # Store the state of the chain
-        chain[:, k] = res[0]
+        # #########################################################################
+        # Affine Invariant MCMC run
+        # #########################################################################
+        if verbosity > 1:
+            print('\nStart of the MCMC run ...')
+            print('Step  |  Duration/step (sec)  |  Remaining Estimated Time (sec)')
 
-        # ---------------------------------------------------------------------
-        # If k meets the criterion, one tests the non-convergence.
-        # ---------------------------------------------------------------------
-        criterion = int(np.amin([np.ceil(itermin*(1+fraction)**geom),
-                                 lastcheck+np.floor(maxgap)]))
-        if k == criterion:
+        for k, res in enumerate(sampler.sample(pos, iterations=nIterations)):
+            elapsed = (datetime.datetime.now()-start).total_seconds()
             if verbosity > 1:
-                print('\n {} convergence test in progress...'.format(conv_test))
-
-            geom += 1
-            lastcheck = k
-            if display:
-                show_walk_plot(chain, labels=labels)
-
-            if save and verbosity == 3:
-                fname = '{d}/{f}_temp_k{k}'.format(d=output_dir,
-                                                   f=output_file_tmp, k=k)
-                data = {'chain': sampler.chain,
-                        'lnprob': sampler.lnprobability,
-                        'AR': sampler.acceptance_fraction}
-                with open(fname, 'wb') as fileSave:
-                    pickle.dump(data, fileSave)
-
-            # We only test the rhat if we have reached the min # of steps
-            if (k+1) >= itermin and konvergence == np.inf:
-                if conv_test == 'gb':
-                    thr0 = int(np.floor(burnin*k))
-                    thr1 = int(np.floor((1-burnin)*k*0.25))
-
-                    # We calculate the rhat for each model parameter.
-                    for j in range(dim):
-                        part1 = chain[:, thr0:thr0 + thr1, j].reshape(-1)
-                        part2 = chain[:, thr0 + 3 * thr1:thr0 + 4 * thr1, j
-                                      ].reshape(-1)
-                        series = np.vstack((part1, part2))
-                        rhat[j] = gelman_rubin(series)
-                    if verbosity > 0:
-                        print('   r_hat = {}'.format(rhat))
-                        cond = rhat <= rhat_threshold
-                        print('   r_hat <= threshold = {} \n'.format(cond), flush=True)
-                    # We test the rhat.
-                    if (rhat <= rhat_threshold).all():
-                        rhat_count += 1
-                        if rhat_count < rhat_count_threshold:
-                            if verbosity > 0:
-                                msg = "Gelman-Rubin test OK {}/{}"
-                                print(msg.format(rhat_count,
-                                                 rhat_count_threshold))
-                        elif rhat_count >= rhat_count_threshold:
-                            if verbosity > 0:
-                                print('... ==> convergence reached')
-                            konvergence = k
-                            stop = konvergence + supp
-                    else:
-                        rhat_count = 0
-                elif conv_test == 'ac':
-                    # We calculate the auto-corr test for each model parameter.
-                    if save:
-                        chain_name = "TMP_test_chain{:.0f}.fits".format(k)
-                        write_fits(output_dir+'/'+chain_name, chain[:, :k])
-                    for j in range(dim):
-                        rhat[j] = autocorr_test(chain[:, :k, j])
-                    thr = 1./ac_c
-                    if verbosity > 0:
-                        print('Auto-corr tau/N = {}'.format(rhat))
-                        print('tau/N <= {} = {} \n'.format(thr, rhat < thr), flush=True)
-                    if (rhat <= thr).all():
-                        ac_count += 1
-                        if verbosity > 0:
-                            msg = "Auto-correlation test passed for all params!"
-                            msg += "{}/{}".format(ac_count, ac_count_thr)
-                            print(msg)
-                        if ac_count >= ac_count_thr:
-                            msg = '\n ... ==> convergence reached'
-                            print(msg)
-                            stop = k
-                    else:
-                        ac_count = 0
+                if k == 0:
+                    q = 0.5
                 else:
-                    raise ValueError('conv_test value not recognized')
-                # append the autocorrelation factor to file for easy reading
-                if save:
-                    with open(output_dir + '/MCMC_results_tau.txt', 'a') as f:
-                        f.write(str(rhat) + '\n')
-        # We have reached the maximum number of steps for our Markov chain.
-        if k+1 >= stop:
-            if verbosity > 0:
-                print('We break the loop because we have reached convergence')
-            break
+                    q = 1
+                print('{}\t\t{:.5f}\t\t\t{:.5f}'.format(k, elapsed * q,
+                                                        elapsed * (limit-k-1) * q),
+                      flush=True)
+
+            start = datetime.datetime.now()
+
+            # ---------------------------------------------------------------------
+            # Store the state manually in order to handle with dynamical sized chain
+            # ---------------------------------------------------------------------
+            # Check if the size of the chain is long enough.
+            s = chain.shape[1]
+            if k+1 > s:     # if not, one doubles the chain length
+                empty = np.zeros([nwalkers, 2*s, dim])
+                chain = np.concatenate((chain, empty), axis=1)
+            # Store the state of the chain
+            chain[:, k] = res[0]
+
+            # ---------------------------------------------------------------------
+            # If k meets the criterion, one tests the non-convergence.
+            # ---------------------------------------------------------------------
+            criterion = int(np.amin([np.ceil(itermin*(1+fraction)**geom),
+                                     lastcheck+np.floor(maxgap)]))
+            if k == criterion:
+                if verbosity > 1:
+                    print('\n {} convergence test in progress...'.format(conv_test))
+
+                geom += 1
+                lastcheck = k
+                if display:
+                    show_walk_plot(chain, labels=labels)
+
+                if save and verbosity == 3:
+                    fname = '{d}/{f}_temp_k{k}'.format(d=output_dir,
+                                                       f=output_file_tmp, k=k)
+                    data = {'chain': sampler.chain,
+                            'lnprob': sampler.lnprobability,
+                            'AR': sampler.acceptance_fraction}
+                    with open(fname, 'wb') as fileSave:
+                        pickle.dump(data, fileSave)
+
+                # We only test the rhat if we have reached the min # of steps
+                if (k+1) >= itermin and konvergence == np.inf:
+                    if conv_test == 'gb':
+                        thr0 = int(np.floor(burnin*k))
+                        thr1 = int(np.floor((1-burnin)*k*0.25))
+
+                        # We calculate the rhat for each model parameter.
+                        for j in range(dim):
+                            part1 = chain[:, thr0:thr0 + thr1, j].reshape(-1)
+                            part2 = chain[:, thr0 + 3 * thr1:thr0 + 4 * thr1, j
+                                          ].reshape(-1)
+                            series = np.vstack((part1, part2))
+                            rhat[j] = gelman_rubin(series)
+                        if verbosity > 0:
+                            print('   r_hat = {}'.format(rhat))
+                            cond = rhat <= rhat_threshold
+                            print('   r_hat <= threshold = {} \n'.format(cond), flush=True)
+                        # We test the rhat.
+                        if (rhat <= rhat_threshold).all():
+                            rhat_count += 1
+                            if rhat_count < rhat_count_threshold:
+                                if verbosity > 0:
+                                    msg = "Gelman-Rubin test OK {}/{}"
+                                    print(msg.format(rhat_count,
+                                                     rhat_count_threshold))
+                            elif rhat_count >= rhat_count_threshold:
+                                if verbosity > 0:
+                                    print('... ==> convergence reached')
+                                konvergence = k
+                                stop = konvergence + supp
+                        else:
+                            rhat_count = 0
+                    elif conv_test == 'ac':
+                        # We calculate the auto-corr test for each model parameter.
+                        if save:
+                            chain_name = "TMP_test_chain{:.0f}.fits".format(k)
+                            write_fits(output_dir+'/'+chain_name, chain[:, :k])
+                        for j in range(dim):
+                            rhat[j] = autocorr_test(chain[:, :k, j])
+                        thr = 1./ac_c
+                        if verbosity > 0:
+                            print('Auto-corr tau/N = {}'.format(rhat))
+                            print('tau/N <= {} = {} \n'.format(thr, rhat < thr), flush=True)
+                        if (rhat <= thr).all():
+                            ac_count += 1
+                            if verbosity > 0:
+                                msg = "Auto-correlation test passed for all params!"
+                                msg += "{}/{}".format(ac_count, ac_count_thr)
+                                print(msg)
+                            if ac_count >= ac_count_thr:
+                                msg = '\n ... ==> convergence reached'
+                                print(msg)
+                                stop = k
+                        else:
+                            ac_count = 0
+                    else:
+                        raise ValueError('conv_test value not recognized')
+                    # append the autocorrelation factor to file for easy reading
+                    if save:
+                        with open(output_dir + '/MCMC_results_tau.txt', 'a') as f:
+                            f.write(str(rhat) + '\n')
+            # We have reached the maximum number of steps for our Markov chain.
+            if k+1 >= stop:
+                if verbosity > 0:
+                    print('We break the loop because we have reached convergence')
+                break
 
     if k == nIterations-1:
         if verbosity > 0:

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -699,7 +699,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     conv_test: str, optional {'gb','ac'}
         Method to check for convergence:
             - 'gb' for gelman-rubin test
-                (http://digitalassets.lib.berkeley.edu/sdtr/ucb/text/305.pdf)
+                (https://digitalassets.lib.berkeley.edu/sdtr/ucb/text/305.pdf)
             - 'ac' for autocorrelation analysis
                 (https://emcee.readthedocs.io/en/stable/tutorials/autocorr/)
     ac_c: float, optional
@@ -725,7 +725,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
         Maximum number of steps per walker between two Gelman-Rubin test.
     nproc: int or None, optional
         The number of processes to use for parallelization. If None, will be set
-        automatically to half the number of CPUs available.
+        automatically to the number of CPUs available.
     output_dir: str, optional
         The name of the output directory which contains the output files in the
         case  ``save`` is True.
@@ -814,7 +814,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     else:
         raise TypeError("Interpolation not recognized.")
 
-    if nproc is None:  # actually not used anymore, now that Pool has been implemented for EnsembleSampler
+    if nproc is None:  # if the user has not provided nproc, determine the number of processes for Pool to use
         nproc = multiprocessing.cpu_count()
 
     # #########################################################################
@@ -920,9 +920,9 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     else:
         multiprocessing.set_start_method("spawn", force=True)  # slower, but available on all platforms
 
-    with multiprocessing.Pool() as pool:
+    with multiprocessing.Pool(processes=nproc) as pool:
         sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob,
-                                        pool=pool, moves=emcee.moves.StretchMove(a=2),
+                                        pool=pool, moves=emcee.moves.StretchMove(a=a),
                                         args=([bounds, cube, angs, psfn,
                                               fwhm, annulus_width, ncomp,
                                               aperture_radius, initial_state,

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -50,7 +50,7 @@ __all__ = ['mcmc_negfc_sampling',
 import numpy as np
 import os
 import emcee
-from multiprocessing import cpu_count
+from multiprocessing import cpu_count, Pool
 import inspect
 import datetime
 import corner
@@ -914,16 +914,17 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     os.environ["NUMEXPR_NUM_THREADS"] = "1"
     os.environ["OMP_NUM_THREADS"] = "1"
 
-    sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob, a=a,
-                                    args=([bounds, cube, angs, psfn,
-                                           fwhm, annulus_width, ncomp,
-                                           aperture_radius, initial_state,
-                                           cube_ref, svd_mode, scaling, algo,
-                                           delta_rot, fmerit, imlib,
-                                           interpolation, collapse,
-                                           algo_options, weights, transmission,
-                                           mu_sigma, sigma, force_rPA]),
-                                    threads=nproc)
+    with Pool() as pool:
+        sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob, a=a,
+                                        args=([bounds, cube, angs, psfn,
+                                               fwhm, annulus_width, ncomp,
+                                               aperture_radius, initial_state,
+                                               cube_ref, svd_mode, scaling, algo,
+                                               delta_rot, fmerit, imlib,
+                                               interpolation, collapse,
+                                               algo_options, weights, transmission,
+                                               mu_sigma, sigma, force_rPA]),
+                                        pool=pool)
 
     if verbosity > 0:
         print('emcee Ensemble sampler successful')

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -50,7 +50,7 @@ __all__ = ['mcmc_negfc_sampling',
 import numpy as np
 import os
 import emcee
-from multiprocessing import cpu_count, Pool
+from multiprocessing import cpu_count, Pool, set_start_method
 import inspect
 import datetime
 import corner
@@ -914,6 +914,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     os.environ["NUMEXPR_NUM_THREADS"] = "1"
     os.environ["OMP_NUM_THREADS"] = "1"
 
+    set_start_method("forkserver", force=True)
     with Pool() as pool:
         sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob,
                                         pool=pool, moves=emcee.moves.StretchMove(a=2),

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -915,16 +915,16 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     os.environ["OMP_NUM_THREADS"] = "1"
 
     with Pool() as pool:
-        sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob, a=a,
+        sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob,
+                                        pool=pool, moves=emcee.moves.StretchMove(a=2),
                                         args=([bounds, cube, angs, psfn,
-                                               fwhm, annulus_width, ncomp,
-                                               aperture_radius, initial_state,
-                                               cube_ref, svd_mode, scaling, algo,
-                                               delta_rot, fmerit, imlib,
-                                               interpolation, collapse,
-                                               algo_options, weights, transmission,
-                                               mu_sigma, sigma, force_rPA]),
-                                        pool=pool)
+                                              fwhm, annulus_width, ncomp,
+                                              aperture_radius, initial_state,
+                                              cube_ref, svd_mode, scaling, algo,
+                                              delta_rot, fmerit, imlib,
+                                              interpolation, collapse,
+                                              algo_options, weights, transmission,
+                                              mu_sigma, sigma, force_rPA]))
 
     if verbosity > 0:
         print('emcee Ensemble sampler successful')

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -979,7 +979,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
                     fname = '{d}/{f}_temp_k{k}'.format(d=output_dir,
                                                        f=output_file_tmp, k=k)
                     data = {'chain': sampler.chain,
-                            'lnprob': sampler.lnprobability,
+                            'lnprob': sampler.get_log_prob(),
                             'AR': sampler.acceptance_fraction}
                     with open(fname, 'wb') as fileSave:
                         pickle.dump(data, fileSave)
@@ -1063,7 +1063,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
         output = {'chain': chain_zero_truncated(chain),
                   'input_parameters': input_parameters,
                   'AR': sampler.acceptance_fraction,
-                  'lnprobability': sampler.lnprobability}
+                  'lnprobability': sampler.get_log_prob()}
 
         if output_file is None:
             output_file = 'MCMC_results'


### PR DESCRIPTION
So emcee has been locked into version 2.2.1 for some time, which was release on 15 July 2016. The reason was likely to be due to the change in multiprocessing behaviour in version 3.0 -> with the removal of the `threads` argument in favour of `pool` in `multiprocessing`.

From https://emcee.readthedocs.io/en/stable/user/upgrade/
"_The `threads` keyword argument has been removed in favor of the `pool` interface (see the Parallelization tutorial for more information). The old interface had issues with memory consumption and hanging processes when the sampler object wasn’t explicitly deleted. The `pool` interface has been supported since the first release of emcee and existing code should be easy to update following the Parallelization tutorial._"

This older version was indeed causing some occasional problems (at least for me) such as memory accumulating or the code seemingly stopping. To overcome this I've jumped us up to emcee 3.1.6 and made all of the recommended changes to the call for `emcee.EnsembleSampler` provided in the docs. It works, and it produces the same results. Is it faster? A bit. The user doesn't need to manually assign the number of processors anymore either as python automatically determines what is available. The `multiprocessing` start method is forkserver by default as it was running about 10% faster than fork. If it's unavailable, spawn is used instead so that Windows is supported (albeit spawn is about 20% slower than forkserver). Finally, a new `moves` keyword replaces the `a` keyword, and `sampler.lnprobability` is now `sampler.get_log_prob()`.

The implication of this is that VIP technically needs emcee 3.0 -> from now on and requirements.txt has been updated to remove the version lock. In the long term this is much better, but will cause an error if a user doesnt update emcee following this pull request.

Random things:
- fixed a wrong keyword argument in tutorial 05A
- fixed a deprecated ipython import