### PR TITLE
upgrades for cube_inject_fakedisk & pca_annular can now accept delta_sep as a list

### DIFF
--- a/vip_hci/fm/fakedisk.py
+++ b/vip_hci/fm/fakedisk.py
@@ -4,6 +4,8 @@
 __author__ = "Julien Milli, Valentin Christiaens, Iain Hammond"
 __all__ = ["cube_inject_fakedisk", "cube_inject_trace"]
 
+from typing import Union, Optional
+
 import numpy as np
 from scipy.signal import fftconvolve
 
@@ -13,9 +15,9 @@ from ..var import frame_center, dist_matrix
 
 def cube_inject_fakedisk(
     fakedisk: np.ndarray,
-    angle_list: list | np.ndarray,
-    transmission: np.ndarray | None = None,
-    psf: np.ndarray | float | int | None = None,
+    angle_list: Union[list, np.ndarray],
+    transmission: Optional[np.ndarray] = None,
+    psf: Union[np.ndarray, float, int, None] = None,
     normalize_psf: bool = True,
     **rot_options,
 ) -> np.ndarray:

--- a/vip_hci/fm/fakedisk.py
+++ b/vip_hci/fm/fakedisk.py
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 """Module with fake disk injection functions."""
 
-__author__ = "Julien Milli, Valentin Christiaens"
+__author__ = "Julien Milli, Valentin Christiaens, Iain Hammond"
 __all__ = ["cube_inject_fakedisk", "cube_inject_trace"]
 
 import numpy as np

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -933,7 +933,7 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
                                               mu_sigma, sigma, force_rPA]))
 
         if verbosity > 0:
-            print('emcee Ensemble sampler successful')
+            print('emcee Ensemble sampler successful', flush=True)
         start = datetime.datetime.now()
 
         # #########################################################################

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -920,142 +920,143 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     else:
         multiprocessing.set_start_method("spawn", force=True)  # slower, but available on all platforms
 
-    with multiprocessing.Pool(processes=nproc) as pool:
-        sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob,
-                                        pool=pool, moves=emcee.moves.StretchMove(a=a),
-                                        args=([bounds, cube, angs, psfn,
-                                              fwhm, annulus_width, ncomp,
-                                              aperture_radius, initial_state,
-                                              cube_ref, svd_mode, scaling, algo,
-                                              delta_rot, fmerit, imlib,
-                                              interpolation, collapse,
-                                              algo_options, weights, transmission,
-                                              mu_sigma, sigma, force_rPA]))
+    if __name__ == '__main__':  # extremely important to avoid multiprocessing issues in a python script
+        with multiprocessing.Pool(processes=nproc) as pool:
+            sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob,
+                                            pool=pool, moves=emcee.moves.StretchMove(a=a),
+                                            args=([bounds, cube, angs, psfn,
+                                                  fwhm, annulus_width, ncomp,
+                                                  aperture_radius, initial_state,
+                                                  cube_ref, svd_mode, scaling, algo,
+                                                  delta_rot, fmerit, imlib,
+                                                  interpolation, collapse,
+                                                  algo_options, weights, transmission,
+                                                  mu_sigma, sigma, force_rPA]))
 
-        if verbosity > 0:
-            print('emcee Ensemble sampler successful', flush=True)
-        start = datetime.datetime.now()
-
-        # #########################################################################
-        # Affine Invariant MCMC run
-        # #########################################################################
-        if verbosity > 1:
-            print('\nStart of the MCMC run ...')
-            print('Step  |  Duration/step (sec)  |  Remaining Estimated Time (sec)')
-
-        for k, res in enumerate(sampler.sample(pos, iterations=nIterations)):
-            elapsed = (datetime.datetime.now()-start).total_seconds()
-            if verbosity > 1:
-                if k == 0:
-                    q = 0.5
-                else:
-                    q = 1
-                print('{}\t\t{:.5f}\t\t\t{:.5f}'.format(k, elapsed * q,
-                                                        elapsed * (limit-k-1) * q),
-                      flush=True)
-
+            if verbosity > 0:
+                print('emcee Ensemble sampler successful', flush=True)
             start = datetime.datetime.now()
 
-            # ---------------------------------------------------------------------
-            # Store the state manually in order to handle with dynamical sized chain
-            # ---------------------------------------------------------------------
-            # Check if the size of the chain is long enough.
-            s = chain.shape[1]
-            if k+1 > s:     # if not, one doubles the chain length
-                empty = np.zeros([nwalkers, 2*s, dim])
-                chain = np.concatenate((chain, empty), axis=1)
-            # Store the state of the chain
-            chain[:, k] = res[0]
+            # #########################################################################
+            # Affine Invariant MCMC run
+            # #########################################################################
+            if verbosity > 1:
+                print('\nStart of the MCMC run ...')
+                print('Step  |  Duration/step (sec)  |  Remaining Estimated Time (sec)')
 
-            # ---------------------------------------------------------------------
-            # If k meets the criterion, one tests the non-convergence.
-            # ---------------------------------------------------------------------
-            criterion = int(np.amin([np.ceil(itermin*(1+fraction)**geom),
-                                     lastcheck+np.floor(maxgap)]))
-            if k == criterion:
+            for k, res in enumerate(sampler.sample(pos, iterations=nIterations)):
+                elapsed = (datetime.datetime.now()-start).total_seconds()
                 if verbosity > 1:
-                    print('\n {} convergence test in progress...'.format(conv_test))
-
-                geom += 1
-                lastcheck = k
-                if display:
-                    show_walk_plot(chain, labels=labels)
-
-                if save and verbosity == 3:
-                    fname = '{d}/{f}_temp_k{k}'.format(d=output_dir,
-                                                       f=output_file_tmp, k=k)
-                    data = {'chain': sampler.chain,
-                            'lnprob': sampler.get_log_prob(),
-                            'AR': sampler.acceptance_fraction}
-                    with open(fname, 'wb') as fileSave:
-                        pickle.dump(data, fileSave)
-
-                # We only test the rhat if we have reached the min # of steps
-                if (k+1) >= itermin and konvergence == np.inf:
-                    if conv_test == 'gb':
-                        thr0 = int(np.floor(burnin*k))
-                        thr1 = int(np.floor((1-burnin)*k*0.25))
-
-                        # We calculate the rhat for each model parameter.
-                        for j in range(dim):
-                            part1 = chain[:, thr0:thr0 + thr1, j].reshape(-1)
-                            part2 = chain[:, thr0 + 3 * thr1:thr0 + 4 * thr1, j
-                                          ].reshape(-1)
-                            series = np.vstack((part1, part2))
-                            rhat[j] = gelman_rubin(series)
-                        if verbosity > 0:
-                            print('   r_hat = {}'.format(rhat))
-                            cond = rhat <= rhat_threshold
-                            print('   r_hat <= threshold = {} \n'.format(cond), flush=True)
-                        # We test the rhat.
-                        if (rhat <= rhat_threshold).all():
-                            rhat_count += 1
-                            if rhat_count < rhat_count_threshold:
-                                if verbosity > 0:
-                                    msg = "Gelman-Rubin test OK {}/{}"
-                                    print(msg.format(rhat_count,
-                                                     rhat_count_threshold))
-                            elif rhat_count >= rhat_count_threshold:
-                                if verbosity > 0:
-                                    print('... ==> convergence reached')
-                                konvergence = k
-                                stop = konvergence + supp
-                        else:
-                            rhat_count = 0
-                    elif conv_test == 'ac':
-                        # We calculate the auto-corr test for each model parameter.
-                        if save:
-                            chain_name = "TMP_test_chain{:.0f}.fits".format(k)
-                            write_fits(output_dir+'/'+chain_name, chain[:, :k])
-                        for j in range(dim):
-                            rhat[j] = autocorr_test(chain[:, :k, j])
-                        thr = 1./ac_c
-                        if verbosity > 0:
-                            print('Auto-corr tau/N = {}'.format(rhat))
-                            print('tau/N <= {} = {} \n'.format(thr, rhat < thr), flush=True)
-                        if (rhat <= thr).all():
-                            ac_count += 1
-                            if verbosity > 0:
-                                msg = "Auto-correlation test passed for all params!"
-                                msg += "{}/{}".format(ac_count, ac_count_thr)
-                                print(msg)
-                            if ac_count >= ac_count_thr:
-                                msg = '\n ... ==> convergence reached'
-                                print(msg)
-                                stop = k
-                        else:
-                            ac_count = 0
+                    if k == 0:
+                        q = 0.5
                     else:
-                        raise ValueError('conv_test value not recognized')
-                    # append the autocorrelation factor to file for easy reading
-                    if save:
-                        with open(output_dir + '/MCMC_results_tau.txt', 'a') as f:
-                            f.write(str(rhat) + '\n')
-            # We have reached the maximum number of steps for our Markov chain.
-            if k+1 >= stop:
-                if verbosity > 0:
-                    print('We break the loop because we have reached convergence')
-                break
+                        q = 1
+                    print('{}\t\t{:.5f}\t\t\t{:.5f}'.format(k, elapsed * q,
+                                                            elapsed * (limit-k-1) * q),
+                          flush=True)
+
+                start = datetime.datetime.now()
+
+                # ---------------------------------------------------------------------
+                # Store the state manually in order to handle with dynamical sized chain
+                # ---------------------------------------------------------------------
+                # Check if the size of the chain is long enough.
+                s = chain.shape[1]
+                if k+1 > s:     # if not, one doubles the chain length
+                    empty = np.zeros([nwalkers, 2*s, dim])
+                    chain = np.concatenate((chain, empty), axis=1)
+                # Store the state of the chain
+                chain[:, k] = res[0]
+
+                # ---------------------------------------------------------------------
+                # If k meets the criterion, one tests the non-convergence.
+                # ---------------------------------------------------------------------
+                criterion = int(np.amin([np.ceil(itermin*(1+fraction)**geom),
+                                         lastcheck+np.floor(maxgap)]))
+                if k == criterion:
+                    if verbosity > 1:
+                        print('\n {} convergence test in progress...'.format(conv_test))
+
+                    geom += 1
+                    lastcheck = k
+                    if display:
+                        show_walk_plot(chain, labels=labels)
+
+                    if save and verbosity == 3:
+                        fname = '{d}/{f}_temp_k{k}'.format(d=output_dir,
+                                                           f=output_file_tmp, k=k)
+                        data = {'chain': sampler.chain,
+                                'lnprob': sampler.get_log_prob(),
+                                'AR': sampler.acceptance_fraction}
+                        with open(fname, 'wb') as fileSave:
+                            pickle.dump(data, fileSave)
+
+                    # We only test the rhat if we have reached the min # of steps
+                    if (k+1) >= itermin and konvergence == np.inf:
+                        if conv_test == 'gb':
+                            thr0 = int(np.floor(burnin*k))
+                            thr1 = int(np.floor((1-burnin)*k*0.25))
+
+                            # We calculate the rhat for each model parameter.
+                            for j in range(dim):
+                                part1 = chain[:, thr0:thr0 + thr1, j].reshape(-1)
+                                part2 = chain[:, thr0 + 3 * thr1:thr0 + 4 * thr1, j
+                                              ].reshape(-1)
+                                series = np.vstack((part1, part2))
+                                rhat[j] = gelman_rubin(series)
+                            if verbosity > 0:
+                                print('   r_hat = {}'.format(rhat))
+                                cond = rhat <= rhat_threshold
+                                print('   r_hat <= threshold = {} \n'.format(cond), flush=True)
+                            # We test the rhat.
+                            if (rhat <= rhat_threshold).all():
+                                rhat_count += 1
+                                if rhat_count < rhat_count_threshold:
+                                    if verbosity > 0:
+                                        msg = "Gelman-Rubin test OK {}/{}"
+                                        print(msg.format(rhat_count,
+                                                         rhat_count_threshold))
+                                elif rhat_count >= rhat_count_threshold:
+                                    if verbosity > 0:
+                                        print('... ==> convergence reached')
+                                    konvergence = k
+                                    stop = konvergence + supp
+                            else:
+                                rhat_count = 0
+                        elif conv_test == 'ac':
+                            # We calculate the auto-corr test for each model parameter.
+                            if save:
+                                chain_name = "TMP_test_chain{:.0f}.fits".format(k)
+                                write_fits(output_dir+'/'+chain_name, chain[:, :k])
+                            for j in range(dim):
+                                rhat[j] = autocorr_test(chain[:, :k, j])
+                            thr = 1./ac_c
+                            if verbosity > 0:
+                                print('Auto-corr tau/N = {}'.format(rhat))
+                                print('tau/N <= {} = {} \n'.format(thr, rhat < thr), flush=True)
+                            if (rhat <= thr).all():
+                                ac_count += 1
+                                if verbosity > 0:
+                                    msg = "Auto-correlation test passed for all params!"
+                                    msg += "{}/{}".format(ac_count, ac_count_thr)
+                                    print(msg)
+                                if ac_count >= ac_count_thr:
+                                    msg = '\n ... ==> convergence reached'
+                                    print(msg)
+                                    stop = k
+                            else:
+                                ac_count = 0
+                        else:
+                            raise ValueError('conv_test value not recognized')
+                        # append the autocorrelation factor to file for easy reading
+                        if save:
+                            with open(output_dir + '/MCMC_results_tau.txt', 'a') as f:
+                                f.write(str(rhat) + '\n')
+                # We have reached the maximum number of steps for our Markov chain.
+                if k+1 >= stop:
+                    if verbosity > 0:
+                        print('We break the loop because we have reached convergence')
+                    break
 
     if k == nIterations-1:
         if verbosity > 0:

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -920,143 +920,142 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     else:
         multiprocessing.set_start_method("spawn", force=True)  # slower, but available on all platforms
 
-    if __name__ == '__main__':  # extremely important to avoid multiprocessing issues in a python script
-        with multiprocessing.Pool(processes=nproc) as pool:
-            sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob,
-                                            pool=pool, moves=emcee.moves.StretchMove(a=a),
-                                            args=([bounds, cube, angs, psfn,
-                                                  fwhm, annulus_width, ncomp,
-                                                  aperture_radius, initial_state,
-                                                  cube_ref, svd_mode, scaling, algo,
-                                                  delta_rot, fmerit, imlib,
-                                                  interpolation, collapse,
-                                                  algo_options, weights, transmission,
-                                                  mu_sigma, sigma, force_rPA]))
+    with multiprocessing.Pool(processes=nproc) as pool:
+        sampler = emcee.EnsembleSampler(nwalkers, dim, lnprob,
+                                        pool=pool, moves=emcee.moves.StretchMove(a=a),
+                                        args=([bounds, cube, angs, psfn,
+                                              fwhm, annulus_width, ncomp,
+                                              aperture_radius, initial_state,
+                                              cube_ref, svd_mode, scaling, algo,
+                                              delta_rot, fmerit, imlib,
+                                              interpolation, collapse,
+                                              algo_options, weights, transmission,
+                                              mu_sigma, sigma, force_rPA]))
 
-            if verbosity > 0:
-                print('emcee Ensemble sampler successful', flush=True)
+        if verbosity > 0:
+            print('emcee Ensemble sampler successful', flush=True)
+        start = datetime.datetime.now()
+
+        # #########################################################################
+        # Affine Invariant MCMC run
+        # #########################################################################
+        if verbosity > 1:
+            print('\nStart of the MCMC run ...')
+            print('Step  |  Duration/step (sec)  |  Remaining Estimated Time (sec)')
+
+        for k, res in enumerate(sampler.sample(pos, iterations=nIterations)):
+            elapsed = (datetime.datetime.now()-start).total_seconds()
+            if verbosity > 1:
+                if k == 0:
+                    q = 0.5
+                else:
+                    q = 1
+                print('{}\t\t{:.5f}\t\t\t{:.5f}'.format(k, elapsed * q,
+                                                        elapsed * (limit-k-1) * q),
+                      flush=True)
+
             start = datetime.datetime.now()
 
-            # #########################################################################
-            # Affine Invariant MCMC run
-            # #########################################################################
-            if verbosity > 1:
-                print('\nStart of the MCMC run ...')
-                print('Step  |  Duration/step (sec)  |  Remaining Estimated Time (sec)')
+            # ---------------------------------------------------------------------
+            # Store the state manually in order to handle with dynamical sized chain
+            # ---------------------------------------------------------------------
+            # Check if the size of the chain is long enough.
+            s = chain.shape[1]
+            if k+1 > s:     # if not, one doubles the chain length
+                empty = np.zeros([nwalkers, 2*s, dim])
+                chain = np.concatenate((chain, empty), axis=1)
+            # Store the state of the chain
+            chain[:, k] = res[0]
 
-            for k, res in enumerate(sampler.sample(pos, iterations=nIterations)):
-                elapsed = (datetime.datetime.now()-start).total_seconds()
+            # ---------------------------------------------------------------------
+            # If k meets the criterion, one tests the non-convergence.
+            # ---------------------------------------------------------------------
+            criterion = int(np.amin([np.ceil(itermin*(1+fraction)**geom),
+                                     lastcheck+np.floor(maxgap)]))
+            if k == criterion:
                 if verbosity > 1:
-                    if k == 0:
-                        q = 0.5
-                    else:
-                        q = 1
-                    print('{}\t\t{:.5f}\t\t\t{:.5f}'.format(k, elapsed * q,
-                                                            elapsed * (limit-k-1) * q),
-                          flush=True)
+                    print('\n {} convergence test in progress...'.format(conv_test))
 
-                start = datetime.datetime.now()
+                geom += 1
+                lastcheck = k
+                if display:
+                    show_walk_plot(chain, labels=labels)
 
-                # ---------------------------------------------------------------------
-                # Store the state manually in order to handle with dynamical sized chain
-                # ---------------------------------------------------------------------
-                # Check if the size of the chain is long enough.
-                s = chain.shape[1]
-                if k+1 > s:     # if not, one doubles the chain length
-                    empty = np.zeros([nwalkers, 2*s, dim])
-                    chain = np.concatenate((chain, empty), axis=1)
-                # Store the state of the chain
-                chain[:, k] = res[0]
+                if save and verbosity == 3:
+                    fname = '{d}/{f}_temp_k{k}'.format(d=output_dir,
+                                                       f=output_file_tmp, k=k)
+                    data = {'chain': sampler.chain,
+                            'lnprob': sampler.get_log_prob(),
+                            'AR': sampler.acceptance_fraction}
+                    with open(fname, 'wb') as fileSave:
+                        pickle.dump(data, fileSave)
 
-                # ---------------------------------------------------------------------
-                # If k meets the criterion, one tests the non-convergence.
-                # ---------------------------------------------------------------------
-                criterion = int(np.amin([np.ceil(itermin*(1+fraction)**geom),
-                                         lastcheck+np.floor(maxgap)]))
-                if k == criterion:
-                    if verbosity > 1:
-                        print('\n {} convergence test in progress...'.format(conv_test))
+                # We only test the rhat if we have reached the min # of steps
+                if (k+1) >= itermin and konvergence == np.inf:
+                    if conv_test == 'gb':
+                        thr0 = int(np.floor(burnin*k))
+                        thr1 = int(np.floor((1-burnin)*k*0.25))
 
-                    geom += 1
-                    lastcheck = k
-                    if display:
-                        show_walk_plot(chain, labels=labels)
-
-                    if save and verbosity == 3:
-                        fname = '{d}/{f}_temp_k{k}'.format(d=output_dir,
-                                                           f=output_file_tmp, k=k)
-                        data = {'chain': sampler.chain,
-                                'lnprob': sampler.get_log_prob(),
-                                'AR': sampler.acceptance_fraction}
-                        with open(fname, 'wb') as fileSave:
-                            pickle.dump(data, fileSave)
-
-                    # We only test the rhat if we have reached the min # of steps
-                    if (k+1) >= itermin and konvergence == np.inf:
-                        if conv_test == 'gb':
-                            thr0 = int(np.floor(burnin*k))
-                            thr1 = int(np.floor((1-burnin)*k*0.25))
-
-                            # We calculate the rhat for each model parameter.
-                            for j in range(dim):
-                                part1 = chain[:, thr0:thr0 + thr1, j].reshape(-1)
-                                part2 = chain[:, thr0 + 3 * thr1:thr0 + 4 * thr1, j
-                                              ].reshape(-1)
-                                series = np.vstack((part1, part2))
-                                rhat[j] = gelman_rubin(series)
-                            if verbosity > 0:
-                                print('   r_hat = {}'.format(rhat))
-                                cond = rhat <= rhat_threshold
-                                print('   r_hat <= threshold = {} \n'.format(cond), flush=True)
-                            # We test the rhat.
-                            if (rhat <= rhat_threshold).all():
-                                rhat_count += 1
-                                if rhat_count < rhat_count_threshold:
-                                    if verbosity > 0:
-                                        msg = "Gelman-Rubin test OK {}/{}"
-                                        print(msg.format(rhat_count,
-                                                         rhat_count_threshold))
-                                elif rhat_count >= rhat_count_threshold:
-                                    if verbosity > 0:
-                                        print('... ==> convergence reached')
-                                    konvergence = k
-                                    stop = konvergence + supp
-                            else:
-                                rhat_count = 0
-                        elif conv_test == 'ac':
-                            # We calculate the auto-corr test for each model parameter.
-                            if save:
-                                chain_name = "TMP_test_chain{:.0f}.fits".format(k)
-                                write_fits(output_dir+'/'+chain_name, chain[:, :k])
-                            for j in range(dim):
-                                rhat[j] = autocorr_test(chain[:, :k, j])
-                            thr = 1./ac_c
-                            if verbosity > 0:
-                                print('Auto-corr tau/N = {}'.format(rhat))
-                                print('tau/N <= {} = {} \n'.format(thr, rhat < thr), flush=True)
-                            if (rhat <= thr).all():
-                                ac_count += 1
+                        # We calculate the rhat for each model parameter.
+                        for j in range(dim):
+                            part1 = chain[:, thr0:thr0 + thr1, j].reshape(-1)
+                            part2 = chain[:, thr0 + 3 * thr1:thr0 + 4 * thr1, j
+                                          ].reshape(-1)
+                            series = np.vstack((part1, part2))
+                            rhat[j] = gelman_rubin(series)
+                        if verbosity > 0:
+                            print('   r_hat = {}'.format(rhat))
+                            cond = rhat <= rhat_threshold
+                            print('   r_hat <= threshold = {} \n'.format(cond), flush=True)
+                        # We test the rhat.
+                        if (rhat <= rhat_threshold).all():
+                            rhat_count += 1
+                            if rhat_count < rhat_count_threshold:
                                 if verbosity > 0:
-                                    msg = "Auto-correlation test passed for all params!"
-                                    msg += "{}/{}".format(ac_count, ac_count_thr)
-                                    print(msg)
-                                if ac_count >= ac_count_thr:
-                                    msg = '\n ... ==> convergence reached'
-                                    print(msg)
-                                    stop = k
-                            else:
-                                ac_count = 0
+                                    msg = "Gelman-Rubin test OK {}/{}"
+                                    print(msg.format(rhat_count,
+                                                     rhat_count_threshold))
+                            elif rhat_count >= rhat_count_threshold:
+                                if verbosity > 0:
+                                    print('... ==> convergence reached')
+                                konvergence = k
+                                stop = konvergence + supp
                         else:
-                            raise ValueError('conv_test value not recognized')
-                        # append the autocorrelation factor to file for easy reading
+                            rhat_count = 0
+                    elif conv_test == 'ac':
+                        # We calculate the auto-corr test for each model parameter.
                         if save:
-                            with open(output_dir + '/MCMC_results_tau.txt', 'a') as f:
-                                f.write(str(rhat) + '\n')
-                # We have reached the maximum number of steps for our Markov chain.
-                if k+1 >= stop:
-                    if verbosity > 0:
-                        print('We break the loop because we have reached convergence')
-                    break
+                            chain_name = "TMP_test_chain{:.0f}.fits".format(k)
+                            write_fits(output_dir+'/'+chain_name, chain[:, :k])
+                        for j in range(dim):
+                            rhat[j] = autocorr_test(chain[:, :k, j])
+                        thr = 1./ac_c
+                        if verbosity > 0:
+                            print('Auto-corr tau/N = {}'.format(rhat))
+                            print('tau/N <= {} = {} \n'.format(thr, rhat < thr), flush=True)
+                        if (rhat <= thr).all():
+                            ac_count += 1
+                            if verbosity > 0:
+                                msg = "Auto-correlation test passed for all params!"
+                                msg += "{}/{}".format(ac_count, ac_count_thr)
+                                print(msg)
+                            if ac_count >= ac_count_thr:
+                                msg = '\n ... ==> convergence reached'
+                                print(msg)
+                                stop = k
+                        else:
+                            ac_count = 0
+                    else:
+                        raise ValueError('conv_test value not recognized')
+                    # append the autocorrelation factor to file for easy reading
+                    if save:
+                        with open(output_dir + '/MCMC_results_tau.txt', 'a') as f:
+                            f.write(str(rhat) + '\n')
+            # We have reached the maximum number of steps for our Markov chain.
+            if k+1 >= stop:
+                if verbosity > 0:
+                    print('We break the loop because we have reached convergence')
+                break
 
     if k == nIterations-1:
         if verbosity > 0:

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -915,8 +915,8 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     os.environ["OMP_NUM_THREADS"] = "1"
 
     avail_methods = multiprocessing.get_all_start_methods()
-    if "fork" in avail_methods:
-        multiprocessing.set_start_method("fork", force=True)  # faster, better
+    if "forkserver" in avail_methods:
+        multiprocessing.set_start_method("forkserver", force=True)  # faster, better
     else:
         multiprocessing.set_start_method("spawn", force=True)  # slower, but available on all platforms
 

--- a/vip_hci/fm/negfc_mcmc.py
+++ b/vip_hci/fm/negfc_mcmc.py
@@ -915,8 +915,8 @@ def mcmc_negfc_sampling(cube, angs, psfn, initial_state, algo=pca_annulus,
     os.environ["OMP_NUM_THREADS"] = "1"
 
     avail_methods = multiprocessing.get_all_start_methods()
-    if "forkserver" in avail_methods:
-        multiprocessing.set_start_method("forkserver", force=True)  # faster, better
+    if "fork" in avail_methods:
+        multiprocessing.set_start_method("fork", force=True)  # faster, better
     else:
         multiprocessing.set_start_method("spawn", force=True)  # slower, but available on all platforms
 

--- a/vip_hci/preproc/derotation.py
+++ b/vip_hci/preproc/derotation.py
@@ -339,9 +339,9 @@ def cube_derotate(array, angle_list, imlib='vip-fft', interpolation='lanczos4',
 
     Parameters
     ----------
-    array : numpy ndarray
+    array : numpy.ndarray
         Input 3d array, cube.
-    angle_list : list
+    angle_list : list or 1D numpy.ndarray
         Vector containing the parallactic angles.
     imlib : str, optional
         See the documentation of the ``vip_hci.preproc.frame_rotate`` function.

--- a/vip_hci/psfsub/pca_local.py
+++ b/vip_hci/psfsub/pca_local.py
@@ -477,7 +477,7 @@ def _pca_sdi_fr(
 
     cube_res = np.zeros_like(multispec_fr)  # shape (z, resc_y, resc_x)
 
-    if isinstance(delta_sep, tuple):
+    if isinstance(delta_sep, (tuple, list)):
         delta_sep_vec = np.linspace(delta_sep[0], delta_sep[1], n_annuli)
     elif np.isscalar(delta_sep):
         delta_sep_vec = [delta_sep] * n_annuli

--- a/vip_hci/psfsub/utils_pca.py
+++ b/vip_hci/psfsub/utils_pca.py
@@ -189,7 +189,7 @@ def pca_grid(cube, angle_list, fwhm=None, range_pcs=None, source_xy=None,
     """
     from ..metrics import snr, frame_report
 
-    def truncate_svd_get_finframe(matrix, angle_list, ncomp, V):
+    def truncate_svd_get_finframe(matrix, angle_list, ncomp, V, **rot_options):
         """ Projection, subtraction, derotation plus combination in one frame.
         Only for full-frame"""
         transformed = np.dot(V[:ncomp], matrix.T)
@@ -226,7 +226,7 @@ def pca_grid(cube, angle_list, fwhm=None, range_pcs=None, source_xy=None,
         res_frame = cube_collapse(residuals_res_der, mode=collapse, w=weights)
         return res_frame
 
-    def truncate_svd_get_finframe_ann(matrix, indices, angle_list, ncomp, V):
+    def truncate_svd_get_finframe_ann(matrix, indices, angle_list, ncomp, V, **rot_options):
         """ Projection, subtraction, derotation plus combination in one frame.
         Only for annular mode"""
         transformed = np.dot(V[:ncomp], matrix.T)
@@ -349,10 +349,10 @@ def pca_grid(cube, angle_list, fwhm=None, range_pcs=None, source_xy=None,
     frlist = []
     for pc in pclist:
         if mode == 'fullfr':
-            frame = truncate_svd_get_finframe(matrix, angle_list, pc, V)
+            frame = truncate_svd_get_finframe(matrix, angle_list, pc, V, **rot_options)
         elif mode == 'annular':
             frame = truncate_svd_get_finframe_ann(matrix, annind,
-                                                  angle_list, pc, V)
+                                                  angle_list, pc, V, **rot_options)
         else:
             raise RuntimeError('Wrong mode. Choose either full or annular')
 

--- a/vip_hci/psfsub/utils_pca.py
+++ b/vip_hci/psfsub/utils_pca.py
@@ -189,7 +189,7 @@ def pca_grid(cube, angle_list, fwhm=None, range_pcs=None, source_xy=None,
     """
     from ..metrics import snr, frame_report
 
-    def truncate_svd_get_finframe(matrix, angle_list, ncomp, V, **rot_options):
+    def truncate_svd_get_finframe(matrix, angle_list, ncomp, V):
         """ Projection, subtraction, derotation plus combination in one frame.
         Only for full-frame"""
         transformed = np.dot(V[:ncomp], matrix.T)
@@ -226,7 +226,7 @@ def pca_grid(cube, angle_list, fwhm=None, range_pcs=None, source_xy=None,
         res_frame = cube_collapse(residuals_res_der, mode=collapse, w=weights)
         return res_frame
 
-    def truncate_svd_get_finframe_ann(matrix, indices, angle_list, ncomp, V, **rot_options):
+    def truncate_svd_get_finframe_ann(matrix, indices, angle_list, ncomp, V):
         """ Projection, subtraction, derotation plus combination in one frame.
         Only for annular mode"""
         transformed = np.dot(V[:ncomp], matrix.T)
@@ -349,10 +349,10 @@ def pca_grid(cube, angle_list, fwhm=None, range_pcs=None, source_xy=None,
     frlist = []
     for pc in pclist:
         if mode == 'fullfr':
-            frame = truncate_svd_get_finframe(matrix, angle_list, pc, V, **rot_options)
+            frame = truncate_svd_get_finframe(matrix, angle_list, pc, V)
         elif mode == 'annular':
             frame = truncate_svd_get_finframe_ann(matrix, annind,
-                                                  angle_list, pc, V, **rot_options)
+                                                  angle_list, pc, V)
         else:
             raise RuntimeError('Wrong mode. Choose either full or annular')
 

--- a/vip_hci/var/coords.py
+++ b/vip_hci/var/coords.py
@@ -66,9 +66,9 @@ def frame_center(array, verbose=False):
 
     Parameters
     ----------
-    array : 2d/3d/4d numpy ndarray
-        Frame or cube.
-    verbose : bool optional
+    array : numpy.ndarray
+        2D frame or 3D/4D frame or cube.
+    verbose : bool, optional
         If True the center coordinates are printed out.
 
     Returns


### PR DESCRIPTION
`cube_inject_fakedisk `
- creation of the cube, transmission and convolution are now done in a more "accurate" order. We instead first account for transmission, then convolve with the PSF, before making the cube as recommended by the ELT experts!
- the function is significantly faster because it only convolves once
- including the transmission profile of the coronagraph is now faster and only a few lines of code, simply using np.interp as scipy's `interp1d` function is now legacy and not supported
- the transmission profile doesn't need to be the same size as the frame - instead, fluxes beyond the radius of the transmission curve are left untouched by multiplying by 1
- added more checks for correct inputs and updated the docstring
- added the option to not normalize the provided PSF, which in some cases might be what the user wants

`pca_annular `
- pretty simple one: the docstring says `delta_sep` can be a list, but if a list were provided there was no support for it. so now it works