### PR TITLE
TST: measure and log individual test durations in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,6 @@ jobs:
 #        pre-commit run --files vip_hci/objects/*.py
     - name: Test with pytest
       run: |
-        pytest tests/post_3_10 --cov=vip_hci/objects/ --cov-report=xml
+        pytest tests/post_3_10 --cov=vip_hci/objects/ --cov-report=xml --durations
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,6 +7,7 @@ pandoc
 pytest
 pytest-cov ~=2.6.0
 pytest-split
+pytest-durations
 flake8
 flake8-bandit
 flake8-docstrings


### PR DESCRIPTION
This is a trial run, not intended for merging (at least not yet), as I'm curious to see exactly which test(s) is taking so long that CI requires about 2 hours.