### PR TITLE
BLD: switch build backend to flit-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-build-backend = "setuptools.build_meta"
-requires = ["setuptools>=77.0.0"]
+requires = ["flit_core >=3.11,<4"]
+build-backend = "flit_core.buildapi"
 
 [project]
 name = "vip_hci"
@@ -66,7 +66,3 @@ dev = [
     "sphinx_rtd_theme",
     "jupyter_sphinx",
 ]
-
-[tool.setuptools]
-zip-safe = false
-packages.find = { where = ["src"], namespaces = false }


### PR DESCRIPTION
This is a very small quality-of-life improvement.
`setuptools` is the historical default build-backend (the definition of which was actually proposed to start and standardize what it does), and it's a very messy one-size-fits-all option that does much more than this package needs.
In contrast, `flit-core` is the modern, bare-bones-minimal implementation of PEP 517. Its wheels are ~50kB (compare with >1Mb for setuptools), and it tends to build packages much faster, while still being implemented in pure Python (allowing it to be as portable as setuptools). Its default configuration happen to exactly match what setuptools is configured to do here.
Anyway, happy to discuss this small benefit in more details if needed, and no hard feelings if you guys aren't interested.