### PR TITLE
Andromeda: fix numpy error due to dividing a boolean array

### DIFF
--- a/src/vip_hci/invprob/andromeda.py
+++ b/src/vip_hci/invprob/andromeda.py
@@ -844,7 +844,7 @@ def andromeda_core(
             msg += " {:.3f}".format(varmean)
             print(msg)
     else:
-        weights_diff_2d = variance_diff_2d > 0
+        weights_diff_2d = (variance_diff_2d > 0).astype(float)
         weights_diff_2d /= variance_diff_2d + (variance_diff_2d == 0)
         if verbose:
             msg = "    ANDROMEDA_CORE: Variance is taken equal to the "


### PR DESCRIPTION
I was getting a critical error when running Andromeda with `homogeneous_variance=False`, looks like it was just a problem with modern numpy being strict  